### PR TITLE
Fix build with clang-18 toolchain.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ AlignArrayOfStructures: Left
 PointerAlignment: Left
 
 BreakAfterAttributes: Leave
-BreakAfterReturnType: Automatic
+# BreakAfterReturnType: Automatic
 PenaltyReturnTypeOnItsOwnLine: 100
 BreakBeforeConceptDeclarations: Always
 BreakBeforeInlineASMColon: OnlyMultiline
@@ -62,7 +62,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 RequiresClausePosition: OwnLine
 BinPackArguments: false
-BinPackParameters: OnePerLine
+# BinPackParameters: OnePerLine
 
 # Space
 SeparateDefinitionBlocks: Always

--- a/include/Server/Logger.h
+++ b/include/Server/Logger.h
@@ -7,6 +7,7 @@
 #include <Support/FileSystem.h>
 #include <llvm/ADT/SmallString.h>
 
+#include <iomanip>
 namespace clice::logger {
 
 inline auto init(std::string_view type, std::string_view filepath) {

--- a/scripts/build-dev-test.sh
+++ b/scripts/build-dev-test.sh
@@ -1,1 +1,3 @@
+#! /usr/bin/bash
+
 cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCLICE_ENABLE_TEST=ON -DCMAKE_CXX_FLAGS="-fno-rtti -g -O0"

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -1,1 +1,3 @@
-cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug
+#! /usr/bin/bash
+
+cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fno-rtti -g -O0"

--- a/scripts/build-llvm-dev.py
+++ b/scripts/build-llvm-dev.py
@@ -1,26 +1,28 @@
+#! /usr/bin/python3
+
 import os
 import shutil
 import subprocess
 
-os.chdir('deps/llvm')
+os.chdir("deps/llvm")
 
 args = [
-    '-B=build',
-    '-S=./llvm',
-    '-G=Ninja',
-    '-DLLVM_USE_LINKER=lld',
-    '-DCMAKE_C_COMPILER=clang',
-    '-DCMAKE_CXX_COMPILER=clang++',
-    '-DBUILD_SHARED_LIBS=ON',
-    '-DCMAKE_BUILD_TYPE=Debug',
-    '-DLLVM_TARGETS_TO_BUILD=X86',
-    '-DLLVM_ENABLE_PROJECTS=clang',
-    '-DCMAKE_INSTALL_PREFIX=./build-install',
+    "-B=build",
+    "-S=./llvm",
+    "-G=Ninja",
+    "-DLLVM_USE_LINKER=lld",
+    "-DCMAKE_C_COMPILER=clang",
+    "-DCMAKE_CXX_COMPILER=clang++",
+    # "-DBUILD_SHARED_LIBS=ON",
+    "-DCMAKE_BUILD_TYPE=Debug",
+    "-DLLVM_TARGETS_TO_BUILD=X86",
+    "-DLLVM_ENABLE_PROJECTS=clang",
+    "-DCMAKE_INSTALL_PREFIX=./build-install",
 ]
 
-subprocess.run(['cmake'] + args)
-subprocess.run(['cmake', '--build', 'build', '--target', 'clang'])
-subprocess.run(['cmake', '--build', 'build', '--target', 'install'])
+subprocess.run(["cmake"] + args)
+subprocess.run(["cmake", "--build", "build", "--target", "clang"])
+subprocess.run(["cmake", "--build", "build", "--target", "install"])
 
 src = "./clang/lib/Sema/"
 dst = "./build-install/include/clang/Sema/"
@@ -28,6 +30,3 @@ dst = "./build-install/include/clang/Sema/"
 for file in ["CoroutineStmtBuilder.h", "TypeLocBuilder.h", "TreeTransform.h"]:
     shutil.copyfile(src + file, dst + file)
     print(f"Copying {src + file} to {dst + file}")
-
-
-

--- a/scripts/build-llvm-release.sh
+++ b/scripts/build-llvm-release.sh
@@ -1,10 +1,15 @@
+#! /usr/bin/bash
+
 cd deps/llvm
 cmake -B build-release -S ./llvm -G Ninja \
 -DCMAKE_BUILD_TYPE=Release \
--DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb" \
+-DLLVM_ENABLE_PROJECTS="clang" \
 -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -w" \
 -DCMAKE_C_COMPILER=clang \
 -DCMAKE_CXX_COMPILER=clang++ \
--DLLVM_USE_LINKER=lld
+-DLLVM_USE_LINKER=lld \
+-DLLVM_ENABLE_PROJECTS=clang \
+-DCMAKE_INSTALL_PREFIX=./build-install
+
 cmake --build build-release
 cmake --build build-release --target install

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 cmake -B build-runtime -S ./runtimes -G Ninja \
 -DCMAKE_BUILD_TYPE=Release \
 -DLLVM_ENABLE_PROJECTS="clang" \


### PR DESCRIPTION
## Fix Build with Clang-18 toolchain 
So sorry to start such a direct PR without any issue or email communication before.  I'm interested in this project to build a new LSP for C++. Tried to build it in my machine, I got some CE and has fixed it in this PR. 

1. My develop environment: WSL Ubuntu 22.04.5 LTS
```sh 
shiyu@DESKTOP-FNGPFEO ~/g/clice (main)> clang++ --version                                                                                                   10-14 [16:07:36]
Ubuntu clang version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
shiyu@DESKTOP-FNGPFEO ~/g/clice (main)> clang-format --version                                                                                              10-14 [16:07:40]
Ubuntu clang-format version 18.1.8 (++20240731024944+3b5b5c1ec4a3-1~exp1~20240731145000.144)
```

2. What I did (as the changes):
+ Fix a build error caused by missing include headers
``` json 
[{
	"resource": "/home/shiyu/github/clice/include/Server/Logger.h",
	"owner": "_generated_diagnostic_collection_name_#7",
	"code": "template_instantiate_undefined",
	"severity": 8,
	"message": "Implicit instantiation of undefined template 'std::basic_ostringstream<char>'",
	"source": "clang",
	"startLineNumber": 23,
	"startColumn": 28,
	"endLineNumber": 23,
	"endColumn": 38,
	"relatedInformation": [
		{
			"startLineNumber": 104,
			"startColumn": 11,
			"endLineNumber": 104,
			"endColumn": 30,
			"message": "Template is declared here",
			"resource": "/usr/include/c++/11/iosfwd"
		}
	]
},{
	"resource": "/home/shiyu/github/clice/include/Server/Logger.h",
	"owner": "_generated_diagnostic_collection_name_#7",
	"code": "no_member",
	"severity": 8,
	"message": "No member named 'put_time' in namespace 'std' (fix available)",
	"source": "clang",
	"startLineNumber": 24,
	"startColumn": 28,
	"endLineNumber": 24,
	"endColumn": 36
}]
```

+ Fix a link error (with build script `scripts/build-dev.sh`) caused by missing argument `-fno-rtti` 
```
CMakeFiles/clice.dir/src/Compiler/Diagnostic.cpp.o:Diagnostic.cpp:typeinfo for clice::Diagnostic: error: undefined reference to 'typeinfo for clang::DiagnosticConsumer'
CMakeFiles/clice.dir/src/Compiler/Directive.cpp.o:Directive.cpp:typeinfo for clice::CommentHandler: error: undefined reference to 'typeinfo for clang::CommentHandler'
CMakeFiles/clice.dir/src/Compiler/Directive.cpp.o:Directive.cpp:typeinfo for clice::PPCallback: error: undefined reference to 'typeinfo for clang::PPCallbacks'
CMakeFiles/clice.dir/src/Compiler/Resolver.cpp.o:Resolver.cpp:typeinfo for clang::sema::CapturingScopeInfo: error: undefined reference to 'typeinfo for clang::sema::FunctionScopeInfo'
CMakeFiles/clice.dir/src/Support/URI.cpp.o:URI.cpp:typeinfo for llvm::support::detail::provider_format_adapter<llvm::StringRef&>: error: undefined reference to 'typeinfo for llvm::support::detail::format_adapter'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

+ Fix bad `.clang-format` file.
I noticed that the `alt + shift + f` can not work properly and there are some error logs in clangd (whth clang-format-18). 
```
/home/shiyu/github/clice/.clang-format:65:20: error: invalid boolean
BinPackParameters: OnePerLine
                   ^~~~~~~~~~
I[00:13:50.550] getStyle() failed for file /home/shiyu/github/clice/include/Server/Logger.h: Error reading /home/shiyu/github/clice/.clang-format: Invalid argument. Fallback is LLVM style.

/home/shiyu/github/clice/.clang-format:35:1: error: unknown key 'BreakAfterReturnType'
BreakAfterReturnType: Automatic
^~~~~~~~~~~~~~~~~~~~
I[00:16:45.539] getStyle() failed for file /home/shiyu/github/clice/include/Server/Logger.h: Error reading /home/shiyu/github/clice/.clang-format: Invalid argument. Fallback is LLVM style.
```

+ Fix other scirpts in `scripts` dir and format `.py` file  with black.

## MISC
This is a simple trail to contribute to clice project, if master branch is not ready to merge it u can close this directly.   

I also noticed something may could be improved (IMO), such as use `xmake` instead of `cmake` to manage depdencies because this project may needs to be tested under various version of compiler in the future (in my guess). And [libhv](https://github.com/ithewei/libhv?tab=readme-ov-file#tcp) maybe more suitable than `libuv` to build a LSP server, based on my experience (I have deploied some production app with libhv). 

If u need some help about it (or other things), I will be happy to do something for clice.
