### PR TITLE
Add setup document.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,7 +32,7 @@ AlignArrayOfStructures: Left
 PointerAlignment: Left
 
 BreakAfterAttributes: Leave
-BreakAfterReturnType: Automatic
+# BreakAfterReturnType: Automatic
 PenaltyReturnTypeOnItsOwnLine: 100
 BreakBeforeConceptDeclarations: Always
 BreakBeforeInlineASMColon: OnlyMultiline
@@ -62,7 +62,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 RequiresClausePosition: OwnLine
 BinPackArguments: false
-BinPackParameters: OnePerLine
+# BinPackParameters: OnePerLine
 
 # Space
 SeparateDefinitionBlocks: Always

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -5,7 +5,7 @@ clice is a language server, which is also a kind of server. It uses [libuv](http
 
 - communicate with the client
 - initialize the server
-- distrubute tasks to the thread pool
+- distribute tasks to the thread pool
 - manage all opened files
 
 ## Protocol

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,94 @@
+# Prepare Development Environment
+
+This document indicates how to build clice in  Linux / WSL environment.
+
+## Prepare Requirements
+
+The following tools need to be installed: 
+
++ clang & clang++   
+Which is required to support the `C++23` standard to build clice itself and submodule LLVM. 
+
++ libstdc++-14-dev   
+Supply C++ standard library headers like `<format>`, by `sudo apt install libstdc++-14-dev`.       
+You can also install gcc-14 to prepare this by `sudo apt install gcc-14` (e.g Ubuntu 24.04.1)
+
++ cmake    
+Minimum required version is `3.22` .
+
++ lld    
+Clice use lld as the linker to build llvm. 
+
++ ninja 
+
+
+
+## Download Source Code 
+
+Use the following commands to get source code of clice quickly:
+
+``` sh
+git clone https://github.com/clice-project/clice.git 
+cd clice 
+git submodule init 
+git submodule update --recursive -depth 1 
+```
+
+## Build Dependency 
+
+Clice relies on a specific version of Clang (and it's inner headers), which be updated manually by developer. So LLVM is one of the submodules of clice.     
+
+Use the following commands to compile LLVM and extract clang inner headers to build artifacts directory. 
+
+``` sh 
+cd clice 
+python3 scripts/build-llvm-dev.py
+```
+
+If you are not the first time to build LLVM that clice relied on (e.g recently synced the fork from upstream), make sure that the cache of compilation was cleared successfully before another build. Use `rm -r deps/llvm/build-install` to remove it.
+
+## Build Clice 
+
+Build clice with following commands:
+
+``` sh
+cd clice 
+
+# build clice without test 
+./scripts/build-dev.sh
+
+# or build with test 
+# ./scripts/build-dev-test.sh
+
+cmake --build build -j
+```
+
+## Run Test  
+
+Run test with commands: 
+
+``` sh
+./build/bin/clice-tests --test-dir tests     
+```
+
+And get outputs like 
+
+```
+[==========] Running 50 tests from 8 test suites.
+[----------] Global test environment set-up.
+[----------] 4 tests from URITest
+[ RUN      ] URITest.ConstructorAndAccessors
+[       OK ] URITest.ConstructorAndAccessors (0 ms)
+[ RUN      ] URITest.CopyConstructor
+[       OK ] URITest.CopyConstructor (0 ms)
+[ RUN      ] URITest.EqualityOperator
+[       OK ] URITest.EqualityOperator (0 ms)
+[ RUN      ] URITest.ParseFunction
+[       OK ] URITest.ParseFunction (0 ms)
+[----------] 4 tests from URITest (0 ms total)
+...
+[----------] Global test environment tear-down
+[==========] 47 tests from 8 test suites ran. (2021 ms total)
+[  PASSED  ] 47 tests.
+```
+

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -1,1 +1,8 @@
-cmake -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Debug
+cmake -B build -G Ninja \
+-DCMAKE_CXX_COMPILER=clang++ \
+-DCMAKE_C_COMPILER=clang \
+-DCMAKE_BUILD_TYPE=Debug \
+-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -g -O0 -fsanitize=address -Wno-deprecated-declarations" \
+-DCMAKE_LINKER_FLAGS="${CMAKE_LINKER_FLAGS} -fsanitize=address" \
+-DLLVM_INSTALL_PATH="./deps/llvm/build-install" \
+-DCLICE_LIB_TYPE=SHARED

--- a/scripts/build-llvm-dev.py
+++ b/scripts/build-llvm-dev.py
@@ -2,26 +2,26 @@ import os
 import shutil
 import subprocess
 
-os.chdir('deps/llvm')
+os.chdir("deps/llvm")
 
 args = [
-    '-B=build',
-    '-S=./llvm',
-    '-G=Ninja',
-    '-DLLVM_USE_LINKER=lld',
-    '-DCMAKE_C_COMPILER=clang',
-    '-DCMAKE_CXX_COMPILER=clang++',
-    '-DBUILD_SHARED_LIBS=ON',
-    '-DCMAKE_BUILD_TYPE=Debug',
-    '-DLLVM_TARGETS_TO_BUILD=X86',
-    '-DLLVM_ENABLE_PROJECTS=clang',
-    '-DCMAKE_INSTALL_PREFIX=./build-install',
-    '-DLLVM_USE_SANITIZER=Address',
+    "-B=build",
+    "-S=./llvm",
+    "-G=Ninja",
+    "-DLLVM_USE_LINKER=lld",
+    "-DCMAKE_C_COMPILER=clang",
+    "-DCMAKE_CXX_COMPILER=clang++",
+    "-DBUILD_SHARED_LIBS=ON",
+    "-DCMAKE_BUILD_TYPE=Debug",
+    "-DLLVM_TARGETS_TO_BUILD=X86",
+    "-DLLVM_ENABLE_PROJECTS=clang",
+    "-DCMAKE_INSTALL_PREFIX=./build-install",
+    "-DLLVM_USE_SANITIZER=Address",
 ]
 
-subprocess.run(['cmake'] + args)
-subprocess.run(['cmake', '--build', 'build', '--target', 'clang'])
-subprocess.run(['cmake', '--build', 'build', '--target', 'install'])
+subprocess.run(["cmake"] + args)
+subprocess.run(["cmake", "--build", "build", "--target", "clang"])
+subprocess.run(["cmake", "--build", "build", "--target", "install"])
 
 src = "./clang/lib/Sema/"
 dst = "./build-install/include/clang/Sema/"
@@ -30,5 +30,8 @@ for file in ["CoroutineStmtBuilder.h", "TypeLocBuilder.h", "TreeTransform.h"]:
     shutil.copyfile(src + file, dst + file)
     print(f"Copying {src + file} to {dst + file}")
 
+src = "./build-install/lib/clang/20"
+dst = "../../build/lib/clang/20"
 
-
+shutil.copytree(src, dst)
+print(f"Copying {src} to {dst}")

--- a/scripts/build-llvm-release.py
+++ b/scripts/build-llvm-release.py
@@ -2,24 +2,24 @@ import os
 import shutil
 import subprocess
 
-os.chdir('deps/llvm')
+os.chdir("deps/llvm")
 
 args = [
-    '-B=./build-release',
-    '-S=./llvm',
-    '-G=Ninja',
-    '-DLLVM_USE_LINKER=lld',
-    '-DCMAKE_C_COMPILER=clang',
-    '-DCMAKE_CXX_COMPILER=clang++',
-    '-DCMAKE_BUILD_TYPE=Release',
-    '-DLLVM_TARGETS_TO_BUILD=X86',
-    '-DLLVM_ENABLE_PROJECTS=clang',
-    '-DCMAKE_INSTALL_PREFIX=./build-release-install',
+    "-B=./build-release",
+    "-S=./llvm",
+    "-G=Ninja",
+    "-DLLVM_USE_LINKER=lld",
+    "-DCMAKE_C_COMPILER=clang",
+    "-DCMAKE_CXX_COMPILER=clang++",
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DLLVM_TARGETS_TO_BUILD=X86",
+    "-DLLVM_ENABLE_PROJECTS=clang",
+    "-DCMAKE_INSTALL_PREFIX=./build-release-install",
 ]
 
-subprocess.run(['cmake'] + args)
-subprocess.run(['cmake', '--build', 'build-release', '--target', 'clang'])
-subprocess.run(['cmake', '--build', 'build-release', '--target', 'install'])
+subprocess.run(["cmake"] + args)
+subprocess.run(["cmake", "--build", "build-release", "--target", "clang"])
+subprocess.run(["cmake", "--build", "build-release", "--target", "install"])
 
 src = "./clang/lib/Sema/"
 dst = "./build-release-install/include/clang/Sema/"
@@ -28,5 +28,8 @@ for file in ["CoroutineStmtBuilder.h", "TypeLocBuilder.h", "TreeTransform.h"]:
     shutil.copyfile(src + file, dst + file)
     print(f"Copying {src + file} to {dst + file}")
 
+src = "./build-install/lib/clang/20"
+dst = "../../build/lib/clang/20"
 
-
+shutil.copytree(src, dst)
+print(f"Copying {src} to {dst}")

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -4,5 +4,5 @@ cmake -B build-release -G Ninja \
 -DCLICE_ENABLE_TEST=ON \
 -DCMAKE_BUILD_TYPE=Release \
 -DCMAKE_CXX_FLAGS="-fno-rtti -fno-exceptions -O3 -g" \
--DLLVM_INSTALL_PATH="./deps/llvm/build-release-install" \
+-DLLVM_INSTALL_PATH="./deps/llvm/build-install" \
 -DCLICE_LIB_TYPE=STATIC


### PR DESCRIPTION
## Document Update 
1. Add documentation on how to prepare development environment.
2. Fix and lint Bash/Python scripts.
3. Remove two configurations from `.clang-format` that are not supported by clang-format-18.