### PR TITLE
Specify shallow copy for submodule and fix a few issues while compiling in Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,16 +2,20 @@
 	path = deps/llvm
 	url = https://github.com/llvm/llvm-project.git
 	branch = main
+	shallow = true
 
 [submodule "deps/libuv"]
 	path = deps/libuv
 	url = https://github.com/libuv/libuv.git
 	branch = v1.x
+	shallow = true
 
 [submodule "deps/toml"]
 	path = deps/toml
 	url = https://github.com/marzer/tomlplusplus.git
+	shallow = true
 	
 [submodule "deps/googletest"]
 	path = deps/googletest
 	url = https://github.com/google/googletest.git
+	shallow = true

--- a/include/Server/Async.h
+++ b/include/Server/Async.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#if defined(_WIN32)
+// libuv uses windows.h
+// Stops windows.h from spamming min and max macros
+#define NOMINMAX
+#endif
 #include "uv.h"
 
 #include "llvm/ADT/SmallVector.h"
@@ -202,7 +207,8 @@ struct fs_awaiter {
             uv_timespec_t& mtime = req->statbuf.st_mtim;
             using namespace std::chrono;
             awaiter.modified =
-                system_clock::time_point(seconds(mtime.tv_sec) + nanoseconds(mtime.tv_nsec));
+                system_clock::time_point(duration_cast<system_clock::duration>(
+                    seconds(mtime.tv_sec) + nanoseconds(mtime.tv_nsec)));
             awaiter.caller.resume();
             delete req;
         };

--- a/src/Index/Memory.cpp
+++ b/src/Index/Memory.cpp
@@ -1,4 +1,5 @@
 #include "Index/Memory.h"
+#include <numeric>
 #include <ranges>
 
 namespace clice::index {


### PR DESCRIPTION
I'm experiencing a few issue while building this project in a Windows environment:
1. libuv is spamming min/max macro defined in <Windows.h> to other headers
2. `std::ranges::iota` is defined in numeric
3. `system_clock::duration` may not match the type of `seconds(mtime.tv_sec) + nanoseconds(mtime.tv_nsec)`