### PR TITLE
Improve xmake ci build speed

### DIFF
--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build clice
         run: |
-          xmake --verbose --diagnosis
+          xmake build --verbose --diagnosis --all
 
       - name: Run tests
         run: xmake test --verbose


### PR DESCRIPTION
Due to dependencies, building pch blocks the clice code from compiling, and the test code does not participate in the `Build clice` step, wasting a lot of build time.

before:

- `Build clice` step
  - Build clice code.
- `Run tests` step
  - Build test code.
  - Run test.

now:

- `Build clice` step
  - Build clice code.
  - Build test code.
- `Run tests` step
  - Run test.
