### PR TITLE
Add nix flake config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738961098,
+        "narHash": "sha256-yWNBf6VDW38tl179FEuJ0qukthVfB02kv+mRsfUsWC0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a3eaf5e8eca7cab680b964138fb79073704aca75",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "Flake for Clice";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        tomlplusplus = pkgs.tomlplusplus.overrideAttrs (
+          oldAttrs: {
+            mesonFlags = oldAttrs.mesonFlags or [] ++ [
+              "-Dbuild_examples=false"
+              "-Dbuild_tests=false"
+              "-Dcompile_library=false"
+            ];
+
+            postInstall = oldAttrs.postInstall or "" + ''
+              cat > "$out/share/pkgconfig/toml++.pc" <<EOF
+              Name: toml++
+              Description: Alias for tomlplusplus
+              Version: ${oldAttrs.version}
+              Requires: tomlplusplus
+              EOF
+            '';
+          }
+        );
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.gcc
+            pkgs.pkg-config
+            pkgs.xmake
+            pkgs.cmake
+            pkgs.ninja
+            pkgs.python3
+            pkgs.gtest
+            pkgs.libuv
+            pkgs.llvmPackages_20.libstdcxxClang
+            # pkgs.llvmPackages_20.libllvm
+            pkgs.llvmPackages_20.bintools
+            pkgs.llvmPackages_20.compiler-rt
+            pkgs.llvmPackages_20.libunwind
+
+            tomlplusplus
+          ];
+
+          shellHook =
+            let
+              gcc = pkgs.gcc-unwrapped;
+              gccInclude = "${gcc}/include";
+              gccCxxInclude = "${gccInclude}/c++/${gcc.lib.version}";
+            in
+            ''
+              export NIX_CFLAGS_COMPILE+=" -isystem ${gccInclude}"
+              export NIX_CFLAGS_COMPILE+=" -isystem ${gccCxxInclude}"
+              export NIX_CFLAGS_COMPILE+=" -isystem ${gccCxxInclude}/$(gcc -dumpmachine)"
+            '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Add flake.nix to setup the development environment with nix.

The customized LLVM is excluded from nix and handled by xmake instead.
