### PR TITLE
Fix computePreambleBounds when has no preamble

### DIFF
--- a/unittests/Compiler/Preamble.cpp
+++ b/unittests/Compiler/Preamble.cpp
@@ -114,6 +114,8 @@ void EXPECT_BUILD_PCH(llvm::StringRef main_file,
 }
 
 TEST(Preamble, Bounds) {
+    EXPECT_BOUNDS({}, "int main(){}");
+
     EXPECT_BOUNDS({"0"}, "#include <iostream>$(0)");
     EXPECT_BOUNDS({"0"}, "#include <iostream>$(0)\n");
 


### PR DESCRIPTION
Fix computePreambleBounds in this case.

```cpp
int a; // no preamble (no include, no module)
```

The root cause of this bug is `clang::Token` has no default invalid state.