### PR TITLE
Fix toOffset when position.character == 0

### DIFF
--- a/src/Server/LSPConverter.cpp
+++ b/src/Server/LSPConverter.cpp
@@ -80,6 +80,10 @@ std::uint32_t toOffset(llvm::StringRef content,
     content = content.take_until([](char c) { return c == '\n'; });
     assert(position.character <= content.size() && "Character value is out of range");
 
+    if(position.character == 0) {
+        return offset;
+    }
+
     if(kind == PositionEncodingKind::UTF8) {
         offset += position.character;
         return offset;


### PR DESCRIPTION
Fix crash of `toOffset("int xyz;", {0,0});`