### PR TITLE
Improve compilation database handling

### DIFF
--- a/include/Compiler/Command.h
+++ b/include/Compiler/Command.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <expected>
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Allocator.h"
 
 namespace clice {
 
@@ -14,8 +16,8 @@ namespace clice {
 /// @param out A vector to hold pointers to the processed arguments.
 /// @param buffer A storage buffer for the actual argument strings.
 std::expected<void, std::string> mangle_command(llvm::StringRef command,
-                                               llvm::SmallVectorImpl<const char*>& out,
-                                               llvm::SmallVectorImpl<char>& buffer);
+                                                llvm::SmallVectorImpl<const char*>& out,
+                                                llvm::SmallVectorImpl<char>& buffer);
 
 /// `CompilationDatabase` is responsible for managing the compile commands.
 ///
@@ -50,6 +52,25 @@ public:
         return commands.end();
     }
 
+    enum class Style {
+        GNU = 0,
+        MSVC,
+    };
+    using Self = CompilationDatabase;
+
+    void add_command(this Self& self,
+                     llvm::StringRef path,
+                     llvm::StringRef command,
+                     Style style = Style::GNU);
+
+    llvm::ArrayRef<const char*> get_command(this Self& self, llvm::StringRef path);
+
+private:
+    /// Save a string into memory pool. Make sure end with `\0`.
+    llvm::StringRef save_string(this Self& self, llvm::StringRef string);
+
+    std::vector<const char*> save_args(this Self& self, llvm::ArrayRef<const char*> args);
+
 private:
     /// A map between file path and compile commands.
     llvm::StringMap<std::string> commands;
@@ -61,6 +82,17 @@ private:
     /// **Note that** this only includes module interface unit, for module
     /// implementation unit, the scan could be delayed until compiling it.
     llvm::StringMap<std::string> moduleMap;
+
+    /// Memory pool for command arguments.
+    llvm::BumpPtrAllocator memory_pool;
+
+    /// For lookup whether we already have the key.
+    llvm::DenseSet<llvm::StringRef> unique;
+
+    // A map between file path and compile commands.
+    /// TODO: Path cannot represent unique file, we should use better, like inode ...
+    llvm::DenseMap<const char*, std::unique_ptr<std::vector<const char*>>> commands2;
 };
 
 }  // namespace clice
+

--- a/include/Compiler/Command.h
+++ b/include/Compiler/Command.h
@@ -7,56 +7,31 @@
 
 namespace clice {
 
-/// Processes and adjusts a raw compile command from compile_commands.json.
-///
-/// This function tokenizes the input command, removes unnecessary arguments,
-/// and ensures the resulting format is suitable for execution.
-///
-/// @param command The raw shell-escaped compile command.
-/// @param out A vector to hold pointers to the processed arguments.
-/// @param buffer A storage buffer for the actual argument strings.
-std::expected<void, std::string> mangle_command(llvm::StringRef command,
-                                                llvm::SmallVectorImpl<const char*>& out,
-                                                llvm::SmallVectorImpl<char>& buffer);
-
 /// `CompilationDatabase` is responsible for managing the compile commands.
 ///
 /// FIXME: currently we assume that a file only occurs once in the CDB.
 /// This is not always correct, but it is enough for now.
 class CompilationDatabase {
 public:
-    /// Update the compile commands with the given file.
-    void updateCommands(llvm::StringRef file);
+    using Self = CompilationDatabase;
 
-    /// Update the compile commands with the given file and compile command.
-    void updateCommand(llvm::StringRef file, llvm::StringRef command);
+    /// Update the compile commands with the given file.
+    void update_commands(this Self& self, llvm::StringRef file);
 
     /// Update the module map with the given file and module name.
-    void updateModule(llvm::StringRef file, llvm::StringRef name);
-
-    /// Lookup the compile commands of the given file.
-    llvm::StringRef getCommand(llvm::StringRef file);
+    void update_module(llvm::StringRef file, llvm::StringRef name);
 
     /// Lookup the module interface unit file path of the given module name.
-    llvm::StringRef getModuleFile(llvm::StringRef name);
+    llvm::StringRef get_module_file(llvm::StringRef name);
 
     auto size() const {
         return commands.size();
-    }
-
-    auto begin() {
-        return commands.begin();
-    }
-
-    auto end() {
-        return commands.end();
     }
 
     enum class Style {
         GNU = 0,
         MSVC,
     };
-    using Self = CompilationDatabase;
 
     void add_command(this Self& self,
                      llvm::StringRef path,
@@ -72,9 +47,6 @@ private:
     std::vector<const char*> save_args(this Self& self, llvm::ArrayRef<const char*> args);
 
 private:
-    /// A map between file path and compile commands.
-    llvm::StringMap<std::string> commands;
-
     /// For C++20 module, we only can got dependent module name
     /// in source context. But we need dependent module file path
     /// to build PCM. So we will scan(preprocess) all project files
@@ -91,7 +63,7 @@ private:
 
     // A map between file path and compile commands.
     /// TODO: Path cannot represent unique file, we should use better, like inode ...
-    llvm::DenseMap<const char*, std::unique_ptr<std::vector<const char*>>> commands2;
+    llvm::DenseMap<const char*, std::unique_ptr<std::vector<const char*>>> commands;
 };
 
 }  // namespace clice

--- a/include/Compiler/Compilation.h
+++ b/include/Compiler/Compilation.h
@@ -16,7 +16,7 @@ struct CompilationParams {
     llvm::SmallString<128> outPath;
 
     /// Responsible for storing the arguments.
-    llvm::SmallString<1024> command;
+    llvm::ArrayRef<const char*> arguments;
 
     llvm::IntrusiveRefCntPtr<vfs::FileSystem> vfs = new ThreadSafeFS();
 
@@ -32,6 +32,7 @@ struct CompilationParams {
     /// The memory buffers for all remapped file.
     llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> buffers;
 
+    
     void add_remapped_file(llvm::StringRef path,
                            llvm::StringRef content,
                            std::uint32_t bound = -1) {

--- a/include/Test/CTest.h
+++ b/include/Test/CTest.h
@@ -3,12 +3,14 @@
 #include "Test.h"
 #include "Annotation.h"
 #include "Server/Protocol.h"
+#include "Compiler/Command.h"
 #include "Compiler/Compilation.h"
 
 namespace clice::testing {
 
 struct Tester {
     CompilationParams params;
+    CompilationDatabase database;
     std::optional<CompilationUnit> unit;
     std::string src_path;
 
@@ -77,7 +79,10 @@ public:
     }
 
     Tester& compile(llvm::StringRef standard = "-std=c++20") {
-        params.command = std::format("clang++ {} {} -fms-extensions", standard, src_path);
+        auto command = std::format("clang++ {} {} -fms-extensions", standard, src_path);
+        database.add_command(src_path, command);
+        params.arguments = database.get_command(src_path);
+        
         auto info = clice::compile(params);
         ASSERT_TRUE(info);
         this->unit.emplace(std::move(*info));

--- a/src/Compiler/Compilation.cpp
+++ b/src/Compiler/Compilation.cpp
@@ -42,18 +42,13 @@ auto create_invocation(CompilationParams& params,
                        llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine>& diagnostic_engine)
     -> std::expected<std::unique_ptr<clang::CompilerInvocation>, std::string> {
 
-    /// Split orgin command into c-style command arguments for creating invocation.
-    llvm::SmallString<1024> buffer;
-    llvm::SmallVector<const char*, 32> args;
-    TRY_OR_RETURN(mangle_command(params.command, args, buffer));
-
     /// Create clang invocation.
     clang::CreateInvocationOptions options = {
         .Diags = diagnostic_engine,
         .VFS = params.vfs,
     };
 
-    auto invocation = clang::createInvocation(args, options);
+    auto invocation = clang::createInvocation(params.arguments, options);
     if(!invocation) {
         return report_diagnostics("fail to create compiler invocation", *diagnostics);
     }
@@ -221,7 +216,7 @@ std::expected<CompilationUnit, std::string> compile(CompilationParams& params, P
 
     out.path = params.outPath.str();
     /// out.preamble = params.content.substr(0, *params.bound);
-    out.command = params.command.str();
+    /// out.command = params.arguments.str();
     /// FIXME: out.deps = info->deps();
 
     return clang_compile<clang::GeneratePCHAction>(params, [&](clang::CompilerInstance& instance) {

--- a/src/Server/Indexer.cpp
+++ b/src/Server/Indexer.cpp
@@ -47,7 +47,7 @@ async::Task<> Indexer::index(CompilationUnit& unit) {
 
 async::Task<> Indexer::index(llvm::StringRef file) {
     CompilationParams params;
-    params.command = database.getCommand(file);
+    params.arguments = database.get_command(file);
 
     auto AST = co_await async::submit([&] { return compile(params); });
 

--- a/src/Server/Scheduler.cpp
+++ b/src/Server/Scheduler.cpp
@@ -54,7 +54,7 @@ async::Task<json::Value> Scheduler::completion(std::string path, std::uint32_t o
 
     /// Set compilation params ... .
     CompilationParams params;
-    params.command = database.getCommand(path);
+    params.arguments = database.get_command(path);
     params.add_remapped_file(path, openFile->content);
     params.pch = {PCH->path, PCH->preamble.size()};
     params.completion = {path, offset};
@@ -74,8 +74,9 @@ async::Task<bool> Scheduler::isPCHOutdated(llvm::StringRef path, llvm::StringRef
     }
 
     /// Check command and preamble matchs.
-    auto command = database.getCommand(path);
-    if(openFile->PCH->command != command || openFile->PCH->preamble != preamble) {
+    auto command = database.get_command(path);
+    /// FIXME: check command. openFile->PCH->command != command
+    if(openFile->PCH->preamble != preamble) {
         co_return true;
     }
 
@@ -104,7 +105,7 @@ async::Task<> Scheduler::buildPCH(std::string path, std::string content) {
                                             std::uint32_t bound,
                                             std::string content) -> async::Task<> {
         CompilationParams params;
-        params.command = scheduler.database.getCommand(path);
+        params.arguments = scheduler.database.get_command(path);
         params.outPath = path::join(config::index.dir, path::filename(path) + ".pch");
         params.add_remapped_file(path, content, bound);
 
@@ -161,7 +162,7 @@ async::Task<> Scheduler::buildAST(std::string path, std::string content) {
     }
 
     CompilationParams params;
-    params.command = database.getCommand(path);
+    params.arguments = database.get_command(path);
     params.add_remapped_file(path, content);
     params.pch = {PCH->path, PCH->preamble.size()};
 

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -118,7 +118,7 @@ async::Task<json::Value> Server::onInitialize(json::Value value) {
     config::init(converter.workspace());
 
     for(auto& dir: config::server.compile_commands_dirs) {
-        database.updateCommands(dir + "/compile_commands.json");
+        database.update_commands(dir + "/compile_commands.json");
     }
 
     co_return result;

--- a/unittests/Compiler/Command.cpp
+++ b/unittests/Compiler/Command.cpp
@@ -5,9 +5,45 @@ namespace clice::testing {
 
 namespace {
 
-TEST(CompilationDatabase, Command) {}
+TEST(Command, SimpleAddGet) {
+    CompilationDatabase database;
+    database.add_command("test.cpp", "clang++ -std=c++23 test.cpp");
+    auto command = database.get_command("test.cpp");
+    ASSERT_EQ(command.size(), 3);
 
-TEST(CompilationDatabase, Module) {}
+    using namespace std::literals;
+    EXPECT_EQ(command[0], "clang++"sv);
+    EXPECT_EQ(command[1], "-std=c++23"sv);
+    EXPECT_EQ(command[2], "test.cpp"sv);
+}
+
+TEST(Command, Reuse) {
+    CompilationDatabase database;
+    database.add_command("test.cpp", "clang++ -std=c++23 test.cpp");
+    database.add_command("test2.cpp", "clang++ -std=c++23 test2.cpp");
+
+    auto command1 = database.get_command("test.cpp");
+    auto command2 = database.get_command("test2.cpp");
+    ASSERT_EQ(command1.size(), 3);
+    ASSERT_EQ(command2.size(), 3);
+
+    using namespace std::literals;
+    EXPECT_EQ(command1[0], "clang++"sv);
+    EXPECT_EQ(command1[1], "-std=c++23"sv);
+    EXPECT_EQ(command1[2], "test.cpp"sv);
+
+    EXPECT_EQ(command1[0], command2[0]);
+    EXPECT_EQ(command1[1], command2[1]);
+    EXPECT_EQ(command2[2], "test2.cpp"sv);
+}
+
+TEST(Command, Merge) {}
+
+TEST(Command, Filter) {}
+
+TEST(Command, QueryDriver) {}
+
+TEST(Command, Module) {}
 
 }  // namespace
 

--- a/unittests/Compiler/Diagnostic.cpp
+++ b/unittests/Compiler/Diagnostic.cpp
@@ -9,17 +9,26 @@ namespace {
 using namespace clice;
 
 TEST(Diagnostic, CommandError) {
+    std::vector<const char*> arguments = {
+        "clang++",
+    };
+
     CompilationParams params;
     /// miss input file.
-    params.command = "clang++";
+    params.arguments = arguments;
     params.add_remapped_file("main.cpp", "int main() { return 0; }");
     auto unit = compile(params);
     ASSERT_FALSE(unit);
 }
 
 TEST(Diagnostic, Error) {
+    std::vector<const char*> arguments = {
+        "clang++",
+        "main.cpp",
+    };
+
     CompilationParams params;
-    params.command = "clang++ main.cpp";
+    params.arguments = arguments;
     params.add_remapped_file("main.cpp", "int main() { return 0 }");
     auto unit = compile(params);
     ASSERT_TRUE(unit);

--- a/unittests/Compiler/Module.cpp
+++ b/unittests/Compiler/Module.cpp
@@ -10,9 +10,17 @@ PCMInfo buildPCM(llvm::StringRef file, llvm::StringRef code) {
     llvm::SmallString<128> outPath;
     fs::createUniquePath(llvm::Twine(file) + "%%%%%%.pcm", outPath, true);
 
+    std::string path = file.str();
+    std::vector<const char*> arguments = {
+        "clang++",
+        "-std=c++20",
+        "-xc++",
+        path.c_str(),
+    };
+
     CompilationParams params;
     params.outPath = outPath;
-    params.command = "clang++ -std=c++20 -x c++ " + file.str();
+    params.arguments = arguments;
     params.add_remapped_file(file, code);
     params.add_remapped_file("./test.h", "export int foo2();");
 
@@ -26,8 +34,15 @@ PCMInfo buildPCM(llvm::StringRef file, llvm::StringRef code) {
 }
 
 ModuleInfo scan(llvm::StringRef content) {
+    std::vector<const char*> arguments = {
+        "clang++",
+        "-std=c++20",
+        "-xc++",
+        "main.ixx",
+    };
+
     CompilationParams params;
-    params.command = "clang++ -std=c++20 -x c++ main.ixx";
+    params.arguments = arguments;
     params.add_remapped_file("main.ixx", content);
     params.add_remapped_file("./test.h", "export module A");
     auto info = scanModule(params);

--- a/unittests/Feature/CodeCompletion.cpp
+++ b/unittests/Feature/CodeCompletion.cpp
@@ -22,7 +22,9 @@ int main() {
 
     Annotation annotation = {code};
     CompilationParams params;
-    params.command = "clang++ -std=c++20 main.cpp";
+            std::vector<const char*> arguments = {"clang++", "-std=c++20", "main.cpp"};
+        params.arguments = arguments;
+        
     params.completion = {"main.cpp", annotation.offset("pos")};
     params.add_remapped_file("main.cpp", annotation.source());
 

--- a/unittests/Feature/SignatureHelp.cpp
+++ b/unittests/Feature/SignatureHelp.cpp
@@ -19,7 +19,9 @@ int main() {
 )cpp";
 
     CompilationParams params;
-    params.command = "clang++ -std=c++20 main.cpp";
+    std::vector<const char*> arguments = {"clang++", "-std=c++20", "main.cpp"};
+    params.arguments = arguments;
+
     params.add_remapped_file("main.cpp", code);
     /// params.completion = {"main.cpp", 9, 10};
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -193,15 +193,9 @@ package("llvm")
             package:add("defines", "CLANG_BUILD_STATIC")
         end
 
-        if has_config("llvm") then
-            os.vcp("bin", package:installdir())
-            os.vcp("lib", package:installdir())
-            os.vcp("include", package:installdir())
-        else
-            os.mv("bin", package:installdir())
-            os.mv("lib", package:installdir())
-            os.mv("include", package:installdir())
-        end
+        os.vcp("bin", package:installdir())
+        os.vcp("lib", package:installdir())
+        os.vcp("include", package:installdir())
     end)
 
 if has_config("release") then


### PR DESCRIPTION
1. Use llvm's Tokenize function rather than rewrite it ourselves
2. Use string pool to store commands