### PR TITLE
Avoid reallocing memory and string data copying repeatedly

### DIFF
--- a/include/Async/FileSystem.h
+++ b/include/Async/FileSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 
 #include "libuv.h"
 #include "Task.h"
@@ -85,6 +86,7 @@ Result<void> write(std::string path,
 
 struct Stats {
     std::chrono::milliseconds mtime;
+    size_t size;
 };
 
 Result<Stats> stat(std::string path);


### PR DESCRIPTION
First stat the file to get the file size, and reserve `string content` by file size to avoid reallocing memory and copying string data  repeatedly.