### PR TITLE
feat: add zlib dependence in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
             pkgs.llvmPackages_20.bintools
             pkgs.llvmPackages_20.compiler-rt
             pkgs.llvmPackages_20.libunwind
-
+            pkgs.zlib 
             tomlplusplus
           ];
 


### PR DESCRIPTION
When using 
`nix develop --extra-experimental-features nix-command --extra-experimental-features flakes` to config the environment, xmake may get error in building. Addition of zlib in nix will fix this problem.