### PR TITLE
Chore: hide unrelated cli options in unit_test.

### DIFF
--- a/src/Driver/unit_tests.cc
+++ b/src/Driver/unit_tests.cc
@@ -17,16 +17,23 @@ namespace {
 
 namespace cl = llvm::cl;
 
+cl::OptionCategory unittest_category("Clice Unittest Options");
+
 cl::opt<std::string> test_dir("test-dir",
-                              cl::desc("specify the test source directory path"),
+                              cl::desc("Specify the test source directory path"),
                               cl::value_desc("path"),
-                              cl::Required);
+                              cl::Required,
+                              cl::cat(unittest_category));
 
-cl::opt<std::string> resource_dir("resource-dir", cl::desc("Resource dir path"));
+cl::opt<std::string> resource_dir("resource-dir",
+                                  cl::desc("Resource dir path"),
+                                  cl::cat(unittest_category));
 
-cl::opt<std::string> test_filter("test_filter");
+cl::opt<std::string> test_filter("test_filter",
+                                 cl::desc("A glob pattern to run subset of tests"),
+                                 cl::cat(unittest_category));
 
-cl::opt<bool> enable_example("enable-example", cl::init(false));
+cl::opt<bool> enable_example("enable-example", cl::init(false), cl::cat(unittest_category));
 
 std::optional<GlobPattern> pattern;
 
@@ -161,6 +168,7 @@ int Runner::run_tests() {
 
 int main(int argc, const char* argv[]) {
     llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+    llvm::cl::HideUnrelatedOptions(unittest_category);
     llvm::cl::ParseCommandLineOptions(argc, argv, "clice test\n");
 
     if(!test_filter.empty()) {


### PR DESCRIPTION
There are some extra command line options comes from LLVM in `unit_tests`. 
```

General options:

  --abort-on-max-devirt-iterations-reached                   - Abort when the max iterations for devirtualization CGSCC repeat pass is reached
  --allow-ginsert-as-artifact                                - Allow G_INSERT to be considered an artifact. Hack around AMDGPU test infinite loops.
  --atomic-counter-update-promoted                           - Do counter update using atomic fetch add  for promoted counters only
  --atomic-first-counter                                     - Use atomic fetch add for first counter in a function (usually the entry counter)
  --bounds-checking-single-trap                              - Use one trap block per function
  ...
``` 

Hidden them in unittest to show clean help message. 
```
OVERVIEW: clice test

USAGE: unit_tests [options]

OPTIONS:

Clice Unittest Options:

  --enable-example        - 
  --resource-dir=<string> - Resource dir path
  --test-dir=<path>       - Specify the test source directory path
  --test_filter=<string>  - A glob pattern to run subset of tests

Generic Options:

  --help                  - Display available options (--help-hidden for more)
  --help-list             - Display list of available options (--help-list-hidden for more)
  --version               - Display the version of this program
```