### PR TITLE
fix: improve some case that user's environment do not have driver installed

### DIFF
--- a/include/Compiler/Command.h
+++ b/include/Compiler/Command.h
@@ -11,9 +11,6 @@
 namespace clice {
 
 struct CommandOptions {
-    /// The file to get command for.
-    llvm::StringRef file;
-
     /// Attach resource directory to the command.
     bool resource_dir = false;
 
@@ -112,7 +109,8 @@ public:
     auto load_commands(this Self& self, llvm::StringRef json_content)
         -> std::expected<std::vector<UpdateInfo>, std::string>;
 
-    auto get_command(this Self& self, CommandOptions options) -> LookupInfo;
+    auto get_command(this Self& self, llvm::StringRef file, CommandOptions options = {})
+        -> LookupInfo;
 
 private:
     /// The memory pool to hold all cstring and command list.

--- a/include/Test/Tester.h
+++ b/include/Test/Tester.h
@@ -38,11 +38,10 @@ struct Tester {
         params.kind = CompilationUnit::Content;
 
         CommandOptions options;
-        options.file = src_path;
         options.resource_dir = true;
         options.query_driver = true;
         options.suppress_log = true;
-        params.arguments = database.get_command(options).arguments;
+        params.arguments = database.get_command(src_path, options).arguments;
 
         for(auto& [file, source]: sources.all_files) {
             if(file == src_path) {
@@ -75,11 +74,10 @@ struct Tester {
         params.kind = CompilationUnit::Preamble;
 
         CommandOptions options;
-        options.file = src_path;
         options.resource_dir = true;
         options.query_driver = true;
         options.suppress_log = true;
-        params.arguments = database.get_command(options).arguments;
+        params.arguments = database.get_command(src_path, options).arguments;
 
         auto path = fs::createTemporaryFile("clice", "pch");
         if(!path) {

--- a/src/Compiler/Command.cpp
+++ b/src/Compiler/Command.cpp
@@ -447,10 +447,11 @@ auto CompilationDatabase::load_commands(this Self& self, llvm::StringRef json_co
     return infos;
 }
 
-auto CompilationDatabase::get_command(this Self& self, CommandOptions options) -> LookupInfo {
+auto CompilationDatabase::get_command(this Self& self, llvm::StringRef file, CommandOptions options)
+    -> LookupInfo {
     LookupInfo info;
 
-    llvm::StringRef file = self.save_string(options.file);
+    file = self.save_string(file);
     auto it = self.command_infos.find(file.data());
     if(it != self.command_infos.end()) {
         info.dictionary = it->second.dictionary;

--- a/src/Server/Document.cpp
+++ b/src/Server/Document.cpp
@@ -241,10 +241,9 @@ async::Task<bool> build_pch_task(CompilationDatabase::LookupInfo& info,
 
 async::Task<bool> Server::build_pch(std::string file, std::string content) {
     CommandOptions options;
-    options.file = file;
     options.resource_dir = true;
     options.query_driver = true;
-    auto info = database.get_command(options);
+    auto info = database.get_command(file, options);
 
     auto bound = compute_preamble_bound(content);
     auto& open_file = opening_files.get_or_add(file);
@@ -300,13 +299,12 @@ async::Task<> Server::build_ast(std::string path, std::string content) {
     }
 
     CommandOptions options;
-    options.file = path;
     options.resource_dir = true;
     options.query_driver = true;
 
     CompilationParams params;
     params.kind = CompilationUnit::Content;
-    params.arguments = database.get_command(options).arguments;
+    params.arguments = database.get_command(path, options).arguments;
     params.add_remapped_file(path, content);
     params.pch = {pch->path, pch->preamble.size()};
     file->diagnostics->clear();

--- a/src/Server/Feature.cpp
+++ b/src/Server/Feature.cpp
@@ -26,13 +26,12 @@ auto Server::on_completion(proto::CompletionParams params) -> Result {
     auto& pch = opening_file->pch;
     {
         CommandOptions options;
-        options.file = path;
         options.resource_dir = true;
 
         /// Set compilation params ... .
         CompilationParams params;
         params.kind = CompilationUnit::Completion;
-        params.arguments = database.get_command(options).arguments;
+        params.arguments = database.get_command(path).arguments;
         params.add_remapped_file(path, content);
         params.pch = {pch->path, pch->preamble.size()};
         params.completion = {path, offset};
@@ -79,13 +78,12 @@ async::Task<json::Value> Server::on_signature_help(proto::SignatureHelpParams pa
     auto& pch = opening_file->pch;
     {
         CommandOptions options;
-        options.file = path;
         options.resource_dir = true;
 
         /// Set compilation params ... .
         CompilationParams params;
         params.kind = CompilationUnit::Completion;
-        params.arguments = database.get_command(options).arguments;
+        params.arguments = database.get_command(path, options).arguments;
         params.add_remapped_file(path, content);
         params.pch = {pch->path, pch->preamble.size()};
         params.completion = {path, offset};

--- a/src/Server/Indexer.cpp
+++ b/src/Server/Indexer.cpp
@@ -46,12 +46,9 @@ async::Task<> Indexer::index(CompilationUnit& unit) {
 }
 
 async::Task<> Indexer::index(llvm::StringRef file) {
-    CommandOptions options;
-    options.file = file;
-
     CompilationParams params;
     params.kind = CompilationUnit::Indexing;
-    params.arguments = database.get_command(options).arguments;
+    params.arguments = database.get_command(file).arguments;
 
     auto AST = co_await async::submit([&] { return compile(params); });
 

--- a/tests/unit/Compiler/Command.cpp
+++ b/tests/unit/Compiler/Command.cpp
@@ -61,9 +61,8 @@ suite<"Command"> command = [] {
         database.update_command("fake/", file, argv);
 
         CommandOptions options;
-        options.file = "main.cpp";
         options.suppress_log = true;
-        expect(that % printArgv(database.get_command(options).arguments) == result);
+        expect(that % printArgv(database.get_command(file, options).arguments) == result);
     };
 
     test("GetOptionID") = [] {
@@ -147,11 +146,8 @@ suite<"Command"> command = [] {
 
         CommandOptions options;
         options.suppress_log = true;
-
-        options.file = "test.cpp";
-        auto command1 = database.get_command(options).arguments;
-        options.file = "test2.cpp";
-        auto command2 = database.get_command(options).arguments;
+        auto command1 = database.get_command("test.cpp", options).arguments;
+        auto command2 = database.get_command("test2.cpp", options).arguments;
         expect(that % command1.size() == 3);
         expect(that % command2.size() == 3);
 


### PR DESCRIPTION
G++ is not installed on my machine, so `unit_tests` will cause a crash. 
I fixed that by skipping some test in develop environment without G++ (or other driver) installed. 
