### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: windows-2025
             artifact_name: clice.7z
             asset_name: clice-x64-windows-msvc.7z
             toolchain: clang
 
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             artifact_name: clice.tar.xz
             asset_name: clice-x86_64-linux-gnu.tar.xz
             toolchain: clang-20
@@ -31,13 +31,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Setup llvm
-        if: matrix.os == 'windows-2022'
-        uses: MinoruSekine/setup-scoop@v4.0.1
-        with:
-          buckets: main
-          apps: llvm
-
       - name: Setup llvm & libstdc++ & cmake & ninja
         if: matrix.os == 'ubuntu-24.04'
         run: |


### PR DESCRIPTION
Linux precompiled binary require glibc2.35 (build on ubuntu 22.04)