### PR TITLE
Also Handle `InitializeParams::rootUri`

### DIFF
--- a/include/Protocol/Lifecycle.h
+++ b/include/Protocol/Lifecycle.h
@@ -64,7 +64,14 @@ struct InitializeParams {
     /// This property is only available if the client supports workspace folders.
     /// It can be `null` if the client supports workspace folders but none are
     /// configured.
-    array<WorkspaceFolder> workspaceFolders;
+    optional<array<WorkspaceFolder>> workspaceFolders;
+
+    /// The rootUri of the workspace. Is null if no
+    /// folder is open. If both `rootPath` and `rootUri` are set
+    /// `rootUri` wins.
+    ///
+    /// Deprecated in favour of `workspaceFolders`
+    optional<URI> rootUri;
 };
 
 struct ServerCapabilities {

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -10,11 +10,11 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
     /// FIXME: adjust position encoding.
     kind = PositionEncodingKind::UTF16;
     workspace = mapping.to_path(([&] -> std::string {
-        if(params.rootUri) {
-            return *params.rootUri;
-        }
         if(params.workspaceFolders) {
             return ((*params.workspaceFolders))[0].uri;
+        }
+        if(params.rootUri) {
+            return *params.rootUri;
         }
 
         log::fatal("The client should provide one workspace folder or rootUri at least!");

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -7,13 +7,18 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
               params.clientInfo.name,
               params.clientInfo.verion);
 
-    if(params.workspaceFolders.empty()) {
-        log::fatal("The client should provide one workspace folder at least!");
-    }
-
     /// FIXME: adjust position encoding.
     kind = PositionEncodingKind::UTF16;
-    workspace = mapping.to_path(params.workspaceFolders[0].uri);
+    workspace = mapping.to_path(([&] -> std::string {
+        if(params.rootUri) {
+            return *params.rootUri;
+        }
+        if(params.workspaceFolders) {
+            return ((*params.workspaceFolders))[0].uri;
+        }
+
+        log::fatal("The client should provide one workspace folder or rootUri at least!");
+    })());
 
     /// Initialize configuration.
     config::init(workspace);

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -10,8 +10,8 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
     /// FIXME: adjust position encoding.
     kind = PositionEncodingKind::UTF16;
     workspace = mapping.to_path(([&] -> std::string {
-        if(params.workspaceFolders) {
-            return ((*params.workspaceFolders))[0].uri;
+        if(params.workspaceFolders && !params.workspaceFolders->empty()) {
+            return params.workspaceFolders->front().uri;
         }
         if(params.rootUri) {
             return *params.rootUri;


### PR DESCRIPTION
- Changed workspaceFolders to be an optional array.
- Added rootUri as an optional field, deprecated in favor of workspaceFolders.
- Updated on_initialize method to handle both workspaceFolders and rootUri, ensuring at least one is provided.

This should work with 99% lsp client, according to [config.rs](https://github.com/Myriad-Dreamin/tinymist/blob/955af95c20e0809da62ce37b8b5dde0e0b7b0631/crates/tinymist/src/config.rs#L184-L198)

I also notice that we are cooking a home-made proto, I suggest switch generator-based solution. Although following repos don't have a C++ generator, we can learn from them, which both uses a [scheme](https://raw.githubusercontent.com/microsoft/lsprotocol/refs/heads/main/generator/lsp.json) extracted from the official LSP, and make a generator easily:
- [microsoft lsprotocol](https://github.com/microsoft/lsprotocol)
- [rust lspt](https://docs.rs/lspt/latest/lspt/)