### PR TITLE
add CONFIGURE_DEPENDS to cmake file GLOB_RECURSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ else()
 endif()
 
 # build clice core part as library
-file(GLOB_RECURSE CLICE_SOURCES
+file(GLOB_RECURSE CLICE_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_SOURCE_DIR}/src/AST/*.cpp"
     "${CMAKE_SOURCE_DIR}/src/Async/*.cpp"
     "${CMAKE_SOURCE_DIR}/src/Basic/*.cpp" 
@@ -132,7 +132,7 @@ target_link_options(clice PUBLIC ${CLICE_LINKER_FLAGS})
 
 # clice tests
 if(CLICE_ENABLE_TEST)
-    file(GLOB_RECURSE CLICE_TEST_SOURCES "${CMAKE_SOURCE_DIR}/tests/unit/*/*.cpp")
+    file(GLOB_RECURSE CLICE_TEST_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/tests/unit/*/*.cpp")
     add_executable(unit_tests "${CLICE_TEST_SOURCES}" "${CMAKE_SOURCE_DIR}/src/Driver/unit_tests.cc")
     target_include_directories(unit_tests PUBLIC "${CMAKE_SOURCE_DIR}")
 


### PR DESCRIPTION
`CONFIGURE_DEPENDS` can be added to check the new files or deleted files

https://cmake.org/cmake/help/latest/command/file.html
> Added in version 3.12: If the CONFIGURE_DEPENDS flag is specified, CMake will add logic to the main build system check target to rerun the flagged GLOB commands at build time. If any of the outputs change, CMake will regenerate the build system.