### PR TITLE
Add Bazel instructions to quick-start.md

### DIFF
--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -46,7 +46,10 @@ Note: This option only works when cmake's generator is set to makefile and ninja
 
 ### Bazel
 
-Bazel has no native support to generate a compilation database. The current go-to solution is https://github.com/hedronvision/bazel-compile-commands-extractor which creates a `compile_command.json` file in the root of the workspace based on `bazel aquery` results.
+Bazel has no native support to generate a compilation database. The recommended solution is to use [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor). After setting it up, you can generate `compile_commands.json` with:
+
+```bash
+bazel run @hedron_compile_commands//:refresh_all
 
 ### Visual Studio
 

--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -46,7 +46,7 @@ Note: This option only works when cmake's generator is set to makefile and ninja
 
 ### Bazel
 
-TODO:
+Bazel has no native support to generate a compilation database. The current go-to solution is https://github.com/hedronvision/bazel-compile-commands-extractor which creates a `compile_command.json` file in the root of the workspace based on `bazel aquery` results.
 
 ### Visual Studio
 

--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -50,6 +50,7 @@ Bazel has no native support to generate a compilation database. The recommended 
 
 ```bash
 bazel run @hedron_compile_commands//:refresh_all
+```
 
 ### Visual Studio
 

--- a/docs/zh/guide/quick-start.md
+++ b/docs/zh/guide/quick-start.md
@@ -47,7 +47,11 @@ cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 ### Bazel
 
-TODO:
+Bazel 不支持直接生成编译数据库，推荐使用 [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor)。在安装好之后，你可以这样生成 `compile_commands.json`:
+
+```bash
+bazel run @hedron_compile_commands//:refresh_all
+```
 
 ### Visual Studio
 


### PR DESCRIPTION
It is currently the easiest way of starting