### PR TITLE
build: install clice executable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ target_link_libraries(clice PRIVATE clice-core)
 target_compile_options(clice PUBLIC ${CLICE_CXX_FLAGS})
 target_link_options(clice PUBLIC ${CLICE_LINKER_FLAGS})
 # install clice executable
-install(TARGETS clice RUNTIME DESTINATION bin)
+install(TARGETS clice RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # clice tests
 if(CLICE_ENABLE_TEST)


### PR DESCRIPTION
With this change, after `cmake --install build`, the `clice` executable will appear in the bin directory. This will be used and tested in the docker build script.