### PR TITLE
fix: add self-assignment check in move assignment operator for Task

### DIFF
--- a/include/Async/Task.h
+++ b/include/Async/Task.h
@@ -248,6 +248,9 @@ public:
     Task& operator= (const Task&) = delete;
 
     Task& operator= (Task&& other) noexcept {
+        if(this == &other) {
+            return *this;
+        }
         if(core) {
             core.destroy();
         }


### PR DESCRIPTION
maybe move assignment operator should do self-assignment check?