### PR TITLE
feat: logging color

### DIFF
--- a/bin/clice.cc
+++ b/bin/clice.cc
@@ -55,11 +55,14 @@ cl::opt<std::string> resource_dir{
     cl::desc(R"(The path of the clang resource directory, default is "../../lib/clang/version")"),
 };
 
-cl::opt<std::string> log_color{
+cl::opt<logging::ColorMode> log_color{
     "log-color",
     cl::cat(category),
     cl::value_desc("always|auto|never"),
-    cl::init("auto"),
+    cl::init(logging::ColorMode::automatic),
+    cl::values(clEnumValN(logging::ColorMode::automatic, "auto", ""),
+               clEnumValN(logging::ColorMode::always, "always", ""),
+               clEnumValN(logging::ColorMode::never, "never", "")),
     cl::desc("When to use terminal colors, default is auto"),
 };
 
@@ -78,16 +81,8 @@ cl::opt<logging::Level> log_level{
 
 void init_log() {
     using namespace logging;
-    if(auto color_mode = llvm::StringRef{log_color}; !color_mode.compare("never")) {
-        options.color = false;
-    } else if(!color_mode.compare("always")) {
-        options.color = true;
-    } else {
-        // Auto mode
-        options.color = llvm::sys::Process::StandardErrIsDisplayed();
-    }
+    options.color = log_color;
     options.level = log_level;
-
     logging::create_stderr_logger("clice", logging::options);
 }
 

--- a/include/Support/Logging.h
+++ b/include/Support/Logging.h
@@ -6,10 +6,11 @@
 namespace clice::logging {
 
 using Level = spdlog::level::level_enum;
+using ColorMode = spdlog::color_mode;
 
 struct Options {
     Level level = Level::info;
-    bool color = false;
+    ColorMode color = ColorMode::automatic;
 };
 
 extern Options options;

--- a/src/Support/Logging.cpp
+++ b/src/Support/Logging.cpp
@@ -11,11 +11,7 @@ Options options;
 
 void create_stderr_logger(std::string_view name, const Options& options) {
     std::shared_ptr<spdlog::logger> logger;
-    if(options.color) {
-        logger = spdlog::stderr_color_mt(std::string(name));
-    } else {
-        logger = spdlog::stderr_logger_mt(std::string(name));
-    }
+    logger = spdlog::stderr_color_mt(std::string(name), options.color);
     logger->set_level(options.level);
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [thread %t] [%s:%#] %v");
     spdlog::set_default_logger(std::move(logger));


### PR DESCRIPTION
The `--log-color` option cannot work since refactor of logging api.