### PR TITLE
fix: use server's encoding kind

### DIFF
--- a/include/Server/Indexer.h
+++ b/include/Server/Indexer.h
@@ -5,6 +5,7 @@
 
 #include "Config.h"
 #include "Convert.h"
+
 #include "Async/Async.h"
 #include "Compiler/Command.h"
 #include "Index/MergedIndex.h"
@@ -21,8 +22,10 @@ class CompilationUnit;
 
 class Indexer {
 public:
-    Indexer(CompilationDatabase& database, config::Config& config) :
-        database(database), config(config) {}
+    Indexer(CompilationDatabase& database,
+            config::Config& config,
+            const PositionEncodingKind& kind) :
+        database(database), config(config), encoding_kind(kind) {}
 
     async::Task<> index(llvm::StringRef path);
 
@@ -69,6 +72,8 @@ private:
     CompilationDatabase& database;
 
     config::Config& config;
+
+    const PositionEncodingKind& encoding_kind;
 
     index::ProjectIndex project_index;
 

--- a/include/Server/Server.h
+++ b/include/Server/Server.h
@@ -230,7 +230,7 @@ private:
     /// All registered LSP callbacks.
     llvm::StringMap<Callback> callbacks;
 
-    PositionEncodingKind kind;
+    PositionEncodingKind kind = PositionEncodingKind::UTF16;
 
     std::string workspace;
 

--- a/src/Server/Indexer.cpp
+++ b/src/Server/Indexer.cpp
@@ -201,9 +201,8 @@ auto Indexer::lookup(llvm::StringRef path, std::uint32_t offset, RelationKind ki
             continue;
         }
 
-        /// FIXME: User server's encoding kind.
         ranges::sort(results, refl::less);
-        PositionConverter converter(*content, PositionEncodingKind::UTF16);
+        PositionConverter converter(*content, this->encoding_kind);
 
         for(auto result: results) {
             auto begin = converter.toPosition(result.begin);

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -95,7 +95,7 @@ async::Task<> Server::registerCapacity(llvm::StringRef id,
     });
 }
 
-Server::Server() : indexer(database, config) {
+Server::Server() : indexer(database, config, kind) {
     register_callback<&Server::on_initialize>("initialize");
     register_callback<&Server::on_initialized>("initialized");
     register_callback<&Server::on_shutdown>("shutdown");


### PR DESCRIPTION
- initialized `kind` with `PositionEncodingKind::UTF16` because of warning
- Added a field `encoding_kind` to `Indexer`. It was not named `kind` because it conflicted with a local parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced position encoding configuration to support multiple encoding types dynamically, providing more flexible positioning across different character encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->