### PR TITLE
build: enable xmake ci package cache

### DIFF
--- a/.github/workflows/xmake.yml
+++ b/.github/workflows/xmake.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Run tests
         run: xmake test --verbose
 
+      # Workaround `no space left on device`
+      - name: Remove llvm package
+        run: rm -rf /home/runner/.xmake/packages/c/clice-llvm
+
   macos:
     strategy:
       matrix:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tool version used in CI and enabled package caching to improve build reliability and speed across all platforms.
  * Added a post-run cleanup step in CI to prevent disk-space issues during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->