### PR TITLE
test: add workspace loading test

### DIFF
--- a/tests/data/config/naive/clice.toml
+++ b/tests/data/config/naive/clice.toml
@@ -5,14 +5,14 @@ index_dir = "${workspace}/.clice/naive_index"
 
 # test string pattern
 [[rules]]
-patterns = "../*.cc"
+patterns = "**/**.cc"
 append = "-std=c++114514"
 remove = "-std=c++17"
 
 # test array pattern
 [[rules]]
-patterns = ["../*.ts", "../*.tsx"]
-append = ["--target=es6", "--tell-agent='我操大哥你别用 any 啊'"]
+patterns = ["**/**.ts", "**/**.tsx"]
+append = ["--target=es6", "--tell-agent='wtf DONT USE any ANY in my codebase!'"]
 remove = ["--target=es5", "--allow-js"]
 
 # test default

--- a/tests/unit/Server/Config.cpp
+++ b/tests/unit/Server/Config.cpp
@@ -1,5 +1,5 @@
-#include "Test/Test.h"
 #include "Server/Server.h"
+#include "Test/Test.h"
 
 #include <string>
 
@@ -14,31 +14,31 @@ suite<"Config"> config = [] {
         const auto res = conf.parse(NAIVE_WORKSPACE);
 
         expect(that % res.has_value() == true);
-        expect(that % conf.workspace == "clice");
+        expect(that % conf.workspace == NAIVE_WORKSPACE);
 
-        const auto &proj = conf.project;
+        const auto& proj = conf.project;
 
         expect(that % proj.cache_dir == "${workspace}/.clice/naive_cache");
         expect(that % proj.index_dir == "${workspace}/.clice/naive_index");
 
         expect(that % conf.rules.size() == 3);
-        const auto &str_rule = conf.rules[0];
-        const auto &arr_rule = conf.rules[1];
-        const auto &empty_rule = conf.rules[2];
+        const auto& str_rule = conf.rules[0];
+        const auto& arr_rule = conf.rules[1];
+        const auto& empty_rule = conf.rules[2];
 
         expect(that % str_rule.patterns.size() == 1);
         expect(that % str_rule.patterns[0] == "**/*.cc");
         expect(that % str_rule.append.size() == 1);
         expect(that % str_rule.append[0] == "-std=c++114514");
         expect(that % str_rule.remove.size() == 1);
-        expect(that % str_rule.remove[0] == "-foo");
+        expect(that % str_rule.remove[0] == "-std=c++17");
 
         expect(that % arr_rule.patterns.size() == 2);
-        expect(that % arr_rule.patterns[0] == "../*.ts");
-        expect(that % arr_rule.patterns[1] == "../*.tsx");
+        expect(that % arr_rule.patterns[0] == "**/*.ts");
+        expect(that % arr_rule.patterns[1] == "**/*.tsx");
         expect(that % arr_rule.append.size() == 2);
         expect(that % arr_rule.append[0] == "--target=es6");
-        expect(that % arr_rule.append[1] == "--tell-agent='我操大哥你别用 any 啊'");
+        expect(that % arr_rule.append[1] == "--tell-agent='wtf DONT USE any ANY in my codebase!'");
         expect(that % arr_rule.remove.size() == 2);
         expect(that % arr_rule.remove[0] == "--target=es5");
         expect(that % arr_rule.remove[1] == "--allow-js");
@@ -49,5 +49,5 @@ suite<"Config"> config = [] {
     };
 };
 
-} // namespace
-} // namespace clice::testing
+}  // namespace
+}  // namespace clice::testing


### PR DESCRIPTION
This PR adds test for config loading.

Part of #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests that validate parsing of a new naive TOML configuration: workspace name, cache/index directories, and three rule entries (two populated rules with patterns/append/remove lists and one empty/default rule).
* **Chores**
  * Added the corresponding naive TOML configuration used by the tests as a sample config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->