### PR TITLE
fix: xmake spdlog force non-system

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -40,7 +40,8 @@ if has_config("release") then
 end
 
 add_defines("TOML_EXCEPTIONS=0")
-add_requires(libuv_require, "spdlog[header_only=n,std_format,noexcept]" ,"toml++", "croaring", "flatbuffers")
+add_requires("spdlog", {system=false, version="1.15.3", configs = {header_only = false, std_format = true, noexcept = true}})
+add_requires(libuv_require, "toml++", "croaring", "flatbuffers")
 add_requires("clice-llvm", {alias = "llvm"})
 
 add_rules("mode.release", "mode.debug", "mode.releasedbg")


### PR DESCRIPTION
This fixes #298 on my WSL machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized build dependency declarations for clearer resolution.
  * Explicitly set the logging library to a fixed version with defined configuration.
  * Separated remaining third-party dependencies into a distinct declaration for more granular control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->