### PR TITLE
feat: add copy subcommand to build-llvm-libs.py

### DIFF
--- a/scripts/build-llvm-libs.py
+++ b/scripts/build-llvm-libs.py
@@ -216,7 +216,9 @@ def main():
         print("Usage: python build-llvm-libs.py <command> [options]")
         print("Commands:")
         print("  build <build_type>")
-        print("  copy")
+        print(
+            "  copy <build_type> [--source_dir <source_dir>] [--install_dir <install_dir>]"
+        )
         sys.exit(1)
     command = sys.argv[1]
     if command == "build":


### PR DESCRIPTION
I have built llvm 21 for other projects, while clice requires additional setup (copy headers). The copy subcommand merely performs this setup on the build directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI reworked into separate build and copy commands with updated usage and examples.
  * Build workflow now prints sanitizer, build type, and directories before running.

* **New Features**
  * Added a dedicated header-copy command and a --skip-copy option for the build flow.

* **Chores**
  * Release builds no longer produce shared libraries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->