### PR TITLE
fix: compiling C source file without `-std=c++20`

### DIFF
--- a/src/Compiler/Command.cpp
+++ b/src/Compiler/Command.cpp
@@ -690,8 +690,11 @@ CompilationContext CompilationDatabase::lookup(llvm::StringRef file,
     if(info) {
         directory = self->strings.get(info->directory);
         arguments = self->mangle_command(file, *info, options);
-    } else {
+        // TODO: other c++ suffixes
+    } else if(file.ends_with(".cpp") || file.ends_with(".hpp") || file.ends_with(".cc")) {
         arguments = {"clang++", "-std=c++20"};
+    } else {
+        arguments = {"clang"};
     }
 
     auto append_arg = [&](llvm::StringRef s) {


### PR DESCRIPTION
Otherwise, it fails to build pch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default compiler selection for files without cached compilation settings. C++ source files (.cpp, .hpp, .cc) now default to clang++ with C++20 standard support, while other file types default to clang.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->