### PR TITLE
fix: add missing include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_dependencies(clice-core generate_flatbuffers_schema generate_config)
 target_include_directories(clice-core PUBLIC
     "${PROJECT_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_BINARY_DIR}/generated"
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
 )
 target_link_libraries(clice-core PUBLIC
     clice_options


### PR DESCRIPTION
Without this patch, out-of-source building using CMake will generate following error:

```
E:\msys64\clang64\bin\c++.exe -DCLANG_BUILD_STATIC=1 -DSPDLOG_COMPILED_LIB -DSPDLOG_NO_EXCEPTIONS=1 -DSPDLOG_USE_STD_FORMAT=1 -IE:/Project/GitHub/clice/include -IE:/Project/GitHub/clice/build/generated -IE:/Project/GitHub/clice/build/_deps/libuv-src/include -IE:/Project/GitHub/clice/build/_deps/spdlog-src/include -IE:/Project/GitHub/clice/build/_deps/croaring-src/include -IE:/Project/GitHub/clice/build/_deps/croaring-src/cpp -IE:/Project/GitHub/clice/build/_deps/flatbuffers-src/include -isystem E:/Project/GitHub/clice/build/_deps/tomlplusplus-src/include -stdlib=libc++ -flto=thin -O3 -DNDEBUG -std=gnu++23 -fno-rtti -fno-exceptions -Wno-deprecated-declarations -Wno-undefined-inline -ffunction-sections -fdata-sections -MD -MT CMakeFiles/clice-core.dir/src/AST/Resolver.cpp.obj -MF CMakeFiles\clice-core.dir\src\AST\Resolver.cpp.obj.d -o CMakeFiles/clice-core.dir/src/AST/Resolver.cpp.obj -c E:/Project/GitHub/clice/src/AST/Resolver.cpp
E:/Project/GitHub/clice/src/AST/Resolver.cpp:7:10: fatal error: 'clang/Sema/TreeTransform.h' file not found
    7 | #include "clang/Sema/TreeTransform.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to expose additional include paths for the core library.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->