### PR TITLE
fix: linking required LLVM libs only

### DIFF
--- a/cmake/llvm.cmake
+++ b/cmake/llvm.cmake
@@ -101,11 +101,13 @@ function(setup_llvm LLVM_VERSION)
             clangToolingSyntax
         )
     else()
-        file(GLOB LLVM_LIBRARIES CONFIGURE_DEPENDS "${LLVM_INSTALL_PATH}/lib/libLLVM[a-zA-Z]*${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        file(GLOB CLANG_LIBRARIES CONFIGURE_DEPENDS "${LLVM_INSTALL_PATH}/lib/libclang[a-zA-Z]*${CMAKE_STATIC_LIBRARY_SUFFIX}")
-        set(OTHER_REQUIRED_LIBS
-            "${LLVM_INSTALL_PATH}/lib/libz${CMAKE_STATIC_LIBRARY_SUFFIX}"
-            "${LLVM_INSTALL_PATH}/lib/libzstd${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        file(GLOB LLVM_LIBRARIES CONFIGURE_DEPENDS "${LLVM_INSTALL_PATH}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LLVM[a-zA-Z]*${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        file(GLOB CLANG_LIBRARIES CONFIGURE_DEPENDS "${LLVM_INSTALL_PATH}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clang[a-zA-Z]*${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        # TODO: find a better way to find out whether zlib and zstd are needed
+        # Currently link if present in the LLVM lib directory
+        file(GLOB OTHER_REQUIRED_LIBS CONFIGURE_DEPENDS
+            "${LLVM_INSTALL_PATH}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}z${CMAKE_STATIC_LIBRARY_SUFFIX}"
+            "${LLVM_INSTALL_PATH}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}zstd${CMAKE_STATIC_LIBRARY_SUFFIX}"
         )
         target_link_libraries(llvm-libs INTERFACE ${LLVM_LIBRARIES} ${CLANG_LIBRARIES} ${OTHER_REQUIRED_LIBS})
         target_compile_definitions(llvm-libs INTERFACE CLANG_BUILD_STATIC=1)


### PR DESCRIPTION
This patch restricts the GLOB expression to only LLVM & Clang libraries, avoiding linking to a large list of libraries when using system LLVM.

Also, this patch explicitly avoids linking to `LLVM-<ver>` and `clang-cpp`, as they will cause lots of duplicate symbol errors

Below is a small set of errors generated when linking to `clang-cpp`:
```
ld.lld: error: duplicate symbol: clang::ast_matchers::internal::DynTypedMatcher::constructRestrictedWrapper(clang::ast_matchers::internal::DynTypedMatcher const&, clang::ASTNodeKind)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::Stmt::getEndLoc() const
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ast_matchers::internal::createAndVerifyRegex(llvm::StringRef, llvm::Regex::RegexFlags, llvm::StringRef)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ast_matchers::internal::BoundNodesTreeBuilder::addMatch(clang::ast_matchers::internal::BoundNodesTreeBuilder const&)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::Stmt::getStmtClassName() const
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ast_matchers::internal::getExpansionLocOfMacro(llvm::StringRef, clang::SourceLocation, clang::ASTContext const&)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::transformer::remove(std::__1::function<llvm::Expected<clang::CharSourceRange> (clang::ast_matchers::MatchFinder::MatchResult const&)>)
>>> defined at libclangTransformer.a(RewriteRule.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ast_matchers::internal::hasAnyOverloadedOperatorNameFunc(llvm::ArrayRef<llvm::StringRef const*>)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::transformer::detail::makeEditGenerator(clang::transformer::ASTEdit)
>>> defined at libclangTransformer.a(RewriteRule.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::Stmt::stripLabelLikeStatements() const
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::Stmt::IgnoreContainers(bool)
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::WhileStmt::getConditionVariable()
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ValueStmt::getExprStmt() const
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::ast_matchers::internal::matchesAnyBase(clang::CXXRecordDecl const&, clang::ast_matchers::internal::Matcher<clang::CXXBaseSpecifier> const&, clang::ast_matchers::internal::ASTMatchFinder*, clang::ast_matchers::internal::BoundNodesTreeBuilder*)
>>> defined at libclangASTMatchers.a(ASTMatchersInternal.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::IfStmt::getConditionVariable()
>>> defined at libclangAST.a(Stmt.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)

ld.lld: error: duplicate symbol: clang::transformer::detail::buildMatchers(clang::transformer::RewriteRuleBase const&)
>>> defined at libclangTransformer.a(RewriteRule.cpp.obj)
>>> defined at libclang-cpp.dll.a(libclang-cpp.dll)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to explicitly discover and link LLVM and Clang libraries plus optional z/zstd compression libraries; updated linking to include these groups and retained the static Clang build definition, resulting in more reliable and consistent compilation across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->