### PR TITLE
fix: prevent bad argument pop back when querying toolchain

### DIFF
--- a/src/Compiler/Command.cpp
+++ b/src/Compiler/Command.cpp
@@ -730,7 +730,11 @@ CompilationContext CompilationDatabase::lookup(llvm::StringRef file,
             }
         }
 
-        arguments.pop_back();
+        if(arguments.empty()) {
+            LOG_WARN("failed to query toolchain: {}", file);
+        } else {
+            arguments.pop_back();
+        }
     }
 
     arguments.emplace_back(file.data());


### PR DESCRIPTION
When failed to query toolchain, `arguments` becomes empty and causes a memory bug on popping back the vector. It is another problem to fix the failures of query toolchain, but we don't focus that in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during compilation to gracefully manage toolchain query failures. The compiler now logs a clear warning message instead of encountering an error when expected data is missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->