### PR TITLE
feat: replace compile_commands_dirs with compile_commands_paths

### DIFF
--- a/docs/clice.toml
+++ b/docs/clice.toml
@@ -21,8 +21,8 @@ cache_dir = "${workspace}/.clice/cache"
 # Directory for storing index files.
 index_dir = "${workspace}/.clice/index"
 logging_dir = "${workspace}/.clice/logging"
-# Compile commands directories to search for compile_commands.json files.
-compile_commands_dirs = ["${workspace}/build"]
+# Compile commands files or directories to search for compile_commands.json files.
+compile_commands_paths = ["${workspace}/build"]
 
 # Control the behavior for specific files. Note that Clice matches rules
 # in order. If you want to add your own rules, either delete this rule

--- a/include/Server/Config.h
+++ b/include/Server/Config.h
@@ -21,7 +21,7 @@ struct ProjectOptions {
 
     std::string logging_dir = "${workspace}/.clice/logging";
 
-    std::vector<std::string> compile_commands_dirs = {"${workspace}/build"};
+    std::vector<std::string> compile_commands_paths = {"${workspace}/build"};
 };
 
 struct Rule {

--- a/src/Server/Lifecycle.cpp
+++ b/src/Server/Lifecycle.cpp
@@ -1,5 +1,7 @@
 #include "Server/Server.h"
 
+#include <llvm/Support/FileSystem.h>
+
 namespace clice {
 
 async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
@@ -36,8 +38,12 @@ async::Task<json::Value> Server::on_initialize(proto::InitializeParams params) {
     opening_files.set_capability(config.project.max_active_file);
 
     /// Load compile commands.json
-    for(auto& dir: config.project.compile_commands_dirs) {
-        database.load_compile_database(path::join(dir, "compile_commands.json"));
+    for(auto& dir_or_file: config.project.compile_commands_paths) {
+        if(fs::is_directory(dir_or_file)) {
+            database.load_compile_database(path::join(dir_or_file, "compile_commands.json"));
+        } else {
+            database.load_compile_database(dir_or_file);
+        }
     }
 
     /// Load cache info.


### PR DESCRIPTION
This PR adds `compile_commands_paths` and removes `compile_commands_dirs`. For each path in `compile_commands_paths`, it:
- checks if the file entry at the path is a directory, and loads if there is a `dir/compile_commands.json`.
- otherwise, reads the file content as a json compilation database at the path.

This PR removes `compile_commands_dirs` without considering compability with clangd, according to the offline discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compile commands configuration now supports both file and directory paths for more flexible compile_commands.json lookup, instead of directories only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->