### PR TITLE
fix: resolve executable path when run via PATH

### DIFF
--- a/src/clice.cc
+++ b/src/clice.cc
@@ -95,19 +95,46 @@ auto search_in_path(std::string_view name) -> std::string {
 
 #ifdef _WIN32
     constexpr char path_sep = ';';
-    constexpr auto is_executable = [](const std::filesystem::path& p) {
-        return std::filesystem::exists(p) && !std::filesystem::is_directory(p);
+
+    // Get PATHEXT or use default extensions
+    std::vector<std::string> extensions;
+    const char* pathext_env = std::getenv("PATHEXT");
+    if(pathext_env) {
+        std::string_view pathext_view(pathext_env);
+        size_t ext_start = 0;
+        while(ext_start < pathext_view.size()) {
+            size_t ext_end = pathext_view.find(';', ext_start);
+            if(ext_end == std::string_view::npos) {
+                ext_end = pathext_view.size();
+            }
+            std::string_view ext = pathext_view.substr(ext_start, ext_end - ext_start);
+            if(!ext.empty()) {
+                extensions.emplace_back(ext);
+            }
+            ext_start = ext_end + 1;
+        }
+    } else {
+        extensions = {".exe", ".cmd", ".bat", ".com"};
+    }
+
+    // Check if name already has an extension
+    bool has_extension = name.find('.') != std::string_view::npos;
+
+    auto is_executable = [](const std::filesystem::path& p) {
+        std::error_code ec;
+        auto status = std::filesystem::status(p, ec);
+        return !ec && std::filesystem::exists(status) && !std::filesystem::is_directory(status);
     };
 #else
     constexpr char path_sep = ':';
-    constexpr auto is_executable = [](const std::filesystem::path& p) {
+    auto is_executable = [](const std::filesystem::path& p) {
         std::error_code ec;
         auto status = std::filesystem::status(p, ec);
         if(ec || !std::filesystem::exists(status) || std::filesystem::is_directory(status)) {
             return false;
         }
-        return (status.permissions() & (std::filesystem::perms::owner_exec | 
-                                        std::filesystem::perms::group_exec | 
+        return (status.permissions() & (std::filesystem::perms::owner_exec |
+                                        std::filesystem::perms::group_exec |
                                         std::filesystem::perms::others_exec)) != std::filesystem::perms::none;
     };
 #endif
@@ -119,20 +146,42 @@ auto search_in_path(std::string_view name) -> std::string {
         if(end == std::string_view::npos) {
             end = path_view.size();
         }
-        
+
         std::string_view dir = path_view.substr(start, end - start);
         if(!dir.empty()) {
+#ifdef _WIN32
+            // Try the name as-is first
             std::filesystem::path full_path = std::filesystem::path(dir) / name;
             std::error_code ec;
             auto canonical = std::filesystem::canonical(full_path, ec);
             if(!ec && is_executable(canonical)) {
                 return canonical.string();
             }
+
+            // If name doesn't have an extension, try each PATHEXT extension
+            if(!has_extension) {
+                for(const auto& ext : extensions) {
+                    std::string name_with_ext = std::string(name) + ext;
+                    full_path = std::filesystem::path(dir) / name_with_ext;
+                    canonical = std::filesystem::canonical(full_path, ec);
+                    if(!ec && is_executable(canonical)) {
+                        return canonical.string();
+                    }
+                }
+            }
+#else
+            std::filesystem::path full_path = std::filesystem::path(dir) / name;
+            std::error_code ec;
+            auto canonical = std::filesystem::canonical(full_path, ec);
+            if(!ec && is_executable(canonical)) {
+                return canonical.string();
+            }
+#endif
         }
-        
+
         start = end + 1;
     }
-    
+
     return std::string(name);
 }
 


### PR DESCRIPTION
When clice is executed via PATH (e.g., 'clice' instead of '/path/to/clice'), resolve_self_path() incorrectly resolves the path relative to current directory instead of the actual executable location. This causes worker pool to fail with 'no such file or directory' error.

Add search_in_path() function to search PATH environment variable when argv[0] contains no path separators.

Fixes: worker pool fails to start when clice is in PATH https://github.com/clice-io/clice/issues/358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved executable discovery and resolution across platforms, with better PATH scanning, Windows extension handling, and more robust path canonicalization when an executable is found.

* **Chores**
  * Updated internal module and build references.
  * No changes to public APIs or exported interfaces; added internal notes for future refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->