### PR TITLE
docs(cmake): restore ASan workaround comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-fsanitize=address)
 
     if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        # clang-cl (MSVC frontend): manually link ASan runtime since clang-cl
+        # doesn't handle -fsanitize=address linking automatically.
         execute_process(
             COMMAND ${CMAKE_CXX_COMPILER} --print-resource-dir
             OUTPUT_VARIABLE CLANG_RESOURCE_DIR
@@ -87,6 +89,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     endif()
 
     if(WIN32)
+        # Disable Identical COMDAT Folding in Debug to avoid ASan ODR false positives.
         string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,/OPT:NOICF")
         string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,/OPT:NOICF")
     endif()


### PR DESCRIPTION
## Summary
- Restore comment explaining clang-cl manual ASan runtime linking workaround
- Restore comment explaining OPT:NOICF for ASan ODR false positives on Windows

These were accidentally removed in #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build configuration for Debug builds on Windows to enhance development and testing infrastructure with better error detection and optimization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->