### PR TITLE
fix: skip unhighlightable definition references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,3 @@ tests/unit/Local/
 .claude/*
 !.claude/CLAUDE.md
 !.claude/commands/
-openspec/

--- a/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/.openspec.yaml
+++ b/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/design.md
+++ b/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/design.md
@@ -1,0 +1,56 @@
+## Context
+
+This proposal materializes `Filter Unhighlightable Definition References` for the canonical request `fix: skip unhighlightable definition references` (`fix`). clice does not currently expose a dedicated `textDocument/documentHighlight` feature, but both `feature::semantic_tokens` and `index::TUIndex` consume `SemanticVisitor::handleDeclOccurrence`, so permissive `NamedDecl` occurrence emission can surface as bogus highlightable ranges in multiple places.
+
+`src/semantic/ast_utility.cpp` already centralizes `DeclarationName`-specific behavior such as identifier extraction and display-name formatting. That makes it the natural place to mirror clangd's `canHighlightName` switch and keep the semantic-token path and any index-backed highlight occurrence path aligned.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add one shared helper that mirrors clangd's `canHighlightName(clang::DeclarationName)` acceptance rules.
+- Stop emitting highlightable `NamedDecl` source occurrences for unsupported name kinds while preserving ordinary identifiers and constructors/destructors.
+- Preserve symbol normalization, relation emission, and other navigation metadata that do not depend on highlightable source ranges.
+- Add regression tests that lock both skipped and preserved cases.
+
+**Non-Goals:**
+- Add a new `textDocument/documentHighlight` implementation.
+- Introduce special multi-token highlighting for operators or ObjC selectors in this change.
+- Change symbol display names, hover text, completion labels, or USR generation.
+
+## Decisions
+
+### Add the helper in shared AST utilities
+
+Place a `canHighlightName`-equivalent helper in `src/semantic/ast_utility.*`, next to the existing `DeclarationName` helpers. This keeps the accepted/rejected name-kind policy in one place and avoids duplicated switches across semantic-token and index consumers.
+
+Alternative considered: duplicate the logic inside each consumer. Rejected because it would drift quickly and make regression fixes harder.
+
+### Guard occurrence emission instead of relation emission
+
+Apply the helper only where clice materializes highlightable `NamedDecl` source occurrences. The bug is about ranges that are exposed for highlighting/reference-style behavior, not about the relation graph itself, so `handleRelation` paths should continue to run even when no highlightable name range is emitted.
+
+Alternative considered: guard all `SemanticVisitor::handleDeclOccurrence` forwarding in the base visitor. Rejected because it would silently change every current and future occurrence consumer and make navigation regressions harder to isolate.
+
+### Keep TUIndex symbol and relation data intact
+
+If TUIndex occurrence storage needs the same guard, the implementation should suppress only the occurrence records that represent highlightable ranges. Symbol creation, normalization, and relation insertion should still proceed so definition/reference, call hierarchy, and similar navigation features keep their backing metadata.
+
+Alternative considered: skip whole symbols or relations for unhighlightable names. Rejected because the request is narrowly about highlightability, not symbol existence.
+
+### Lock behavior with focused semantic-token and index tests
+
+Semantic-token tests should cover anonymous or empty identifiers plus operator/conversion/literal names being skipped, and ordinary identifiers plus constructors/destructors still being emitted. TUIndex tests should verify skipped names do not appear as highlightable occurrence ranges and that unrelated relation data remains intact.
+
+## Risks / Trade-offs
+
+- [Filtering TUIndex occurrences can affect cursor resolution paths that rely on occurrence lookup] -> Mitigation: keep the guard scoped to highlightable occurrences, preserve relation data, and add index regression tests that cover unaffected identifier navigation.
+- [Clang declaration-name kinds can drift from clangd's helper over time] -> Mitigation: mirror clangd's switch structure closely and encode accepted/rejected kinds in tests.
+- [Constructors and destructors do not use ordinary identifier spelling] -> Mitigation: add explicit positive tests so the helper does not accidentally reject them during refactors.
+
+## Migration Plan
+
+No data migration is required. Rollout is the normal code-and-test path for this fix, and the TUIndex-side guard can be backed out independently if validation shows an unexpected navigation regression.
+
+## Open Questions
+
+None at proposal time. Implementation should confirm whether any direct cursor-resolution path needs separate handling for operator-like names beyond the scope of this fix.

--- a/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/proposal.md
+++ b/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The canonical request `fix: skip unhighlightable definition references` (`fix`) targets a mismatch between clice and clangd: clice can emit highlight and reference occurrences for `NamedDecl`s whose `DeclarationName` has no highlightable source spelling. That leaks misleading ranges for anonymous declarations and special name kinds such as operators, conversions, and literal operators into the existing semantic-token and index-backed occurrence pipeline.
+
+## What Changes
+
+- Add a reusable helper equivalent to clangd's `canHighlightName(clang::DeclarationName)` that accepts non-empty identifiers plus constructors and destructors, and rejects anonymous or empty identifiers, ObjC selectors, conversion functions, overloaded operators, deduction guides, literal operators, and using-directive names.
+- Apply that helper at the `NamedDecl` occurrence emission boundary used for highlightable source ranges so unhighlightable names stop producing highlight/reference occurrences while relation graphs and symbol metadata remain available for navigation.
+- Add focused regression coverage for skipped anonymous/operator/conversion/literal cases and preserved identifier/constructor/destructor cases in semantic-token and TUIndex-oriented unit tests.
+
+## Capabilities
+
+### New Capabilities
+- `skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere`: Filter highlightable definition/reference occurrences to declaration names that have a concrete source spelling, matching the `skip-unhighlightable-definition-references` objective.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Shared semantic AST utilities in `src/semantic/ast_utility.*` gain the reusable declaration-name guard.
+- Highlightable occurrence emitters in `src/feature/semantic_tokens.cpp` and, if required by the current occurrence pipeline, `src/index/tu_index.cpp` adopt the new guard without changing relation-only paths.
+- Regression coverage is added in `tests/unit/feature/semantic_tokens_tests.cpp` and `tests/unit/index/tu_index_tests.cpp`, with validation centered on `pixi run unit-test Debug` and broader `pixi run test Debug` when feasible.

--- a/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/specs/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/spec.md
+++ b/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/specs/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Highlightable declaration occurrences are filtered by declaration name kind
+The system SHALL emit highlightable definition and reference occurrences for a `NamedDecl` only when its `DeclarationName` has a concrete highlightable spelling. Non-empty identifiers, constructors, and destructors MUST remain eligible. Anonymous or empty identifiers, ObjC selectors, conversion functions, overloaded operators, deduction guides, literal operators, and using-directive names MUST NOT produce highlightable declaration occurrences.
+
+#### Scenario: Ordinary identifiers and constructor-style names remain highlightable
+- **WHEN** clice builds semantic-token or index-backed highlight occurrences for a declaration with a non-empty identifier, constructor name, or destructor name
+- **THEN** the corresponding declaration or reference range is emitted as a highlightable occurrence
+
+#### Scenario: Unhighlightable declaration names are skipped
+- **WHEN** clice encounters an anonymous or empty identifier, ObjC selector, conversion function, overloaded operator, deduction guide, literal operator, or using-directive name
+- **THEN** it does not emit a highlightable declaration occurrence for that source location
+
+### Requirement: Skipping highlightable occurrences does not remove unrelated relation data
+The system SHALL preserve non-highlight semantic and index relations when a declaration name fails the highlightability check. Filtering an unhighlightable declaration occurrence MUST NOT remove otherwise valid declaration, definition, reference, or call relations for other symbols in the same translation unit.
+
+#### Scenario: Index relations remain available around skipped names
+- **WHEN** a translation unit contains an unhighlightable declaration name and other symbols that still participate in declaration, definition, reference, or call relations
+- **THEN** the unhighlightable name is absent from highlightable occurrence ranges
+- **AND** the unrelated relation data for the other symbols remains queryable

--- a/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/tasks.md
+++ b/openspec/changes/skip-unhighlightable-refs-a1-p1-filter-unhighlightable-definition-refere/tasks.md
@@ -1,0 +1,14 @@
+## 1. Shared Highlightability Guard
+
+- [ ] 1.1 Add a clangd-equivalent `canHighlightName` helper for `clang::DeclarationName` in the shared semantic AST utilities.
+- [ ] 1.2 Apply the helper at the `NamedDecl` occurrence emitters that produce highlightable source ranges without changing relation-only paths.
+
+## 2. Regression Coverage
+
+- [ ] 2.1 Add semantic-token unit tests proving anonymous or empty identifiers plus operator/conversion/literal names are skipped while ordinary identifiers and constructors/destructors remain highlighted.
+- [ ] 2.2 Add TUIndex regression tests that confirm skipped names do not appear as highlightable occurrence ranges and unrelated navigation relations still remain queryable.
+
+## 3. Validation
+
+- [ ] 3.1 Run targeted semantic-token and TUIndex unit coverage with the existing unit-test workflow, such as `pixi run unit-test Debug`.
+- [ ] 3.2 Run the broader `pixi run test Debug` suite if the targeted tests pass and the full run is feasible in the lane.


### PR DESCRIPTION
Create and implement an OpenSpec change `skip-unhighlightable-definition-references`: add a clangd-equivalent `canHighlightName` helper for `clang::DeclarationName`, apply it at clice's NamedDecl highlight/reference occurrence emission boundary, and add regression tests for skipped anonymous/operator/conversion/literal/selector-style names while preserving normal identifiers and constructors/destructors.