### PR TITLE
fix(highlight/references): filter non-highlightable definition references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,3 @@ tests/unit/Local/
 .claude/*
 !.claude/CLAUDE.md
 !.claude/commands/
-openspec/

--- a/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/.openspec.yaml
+++ b/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/design.md
+++ b/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/design.md
@@ -1,0 +1,92 @@
+# Filter non-highlightable definition references
+
+- Canonical Request Title: `fix(highlight/references): filter non-highlightable definition references`
+- Conventional Title: `fix(highlight/references)`
+
+## Context
+
+The index layer currently stores a symbol's display name, kind, and referenced files, then serves cross-file relation queries entirely from persisted metadata. That works for ordinary reference lookups, but it is insufficient for clangd-style `canHighlightName` filtering because the decision depends on the original `clang::DeclarationName` kind while AST nodes are no longer available in the query path. The implementation therefore needs a single AST-side predicate and a persisted symbol flag that survives TU builds, project-index merges, on-disk reloads, and open-file indexing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one shared declaration-name predicate that matches the requested highlightability policy.
+- Persist highlightability in symbol metadata across all index producers and consumers that participate in definition-origin reference highlighting.
+- Apply filtering in the query path so only highlight-oriented behavior changes.
+- Add negative and positive regression coverage for anonymous, operator-like, identifier, constructor, and destructor cases.
+
+**Non-Goals:**
+
+- Removing relations from the index during AST traversal or merge.
+- Changing go-to-definition, workspace-symbol, or general reference behavior outside the approved highlight-oriented path.
+- Expanding the scope beyond the requested `canHighlightName` policy.
+
+## Decisions
+
+### 1. Centralize the predicate in `ast_utility`
+
+Add a shared helper such as `ast::can_highlight_name(const clang::DeclarationName&)` in `src/semantic/ast_utility.*`.
+
+Rationale:
+
+- TU indexing and open-file indexing both have AST access, so they can compute the flag once from the real declaration name.
+- A shared helper avoids duplicating a fragile `DeclarationName` switch across index and query code.
+
+Alternatives considered:
+
+- Recompute in each caller: rejected because the logic would drift across producers.
+- Derive from stored display names: rejected because strings do not reliably distinguish anonymous, operator, selector, and other non-highlightable name kinds.
+
+### 2. Persist `highlightable_name` on `index::Symbol`
+
+Extend `index::Symbol` and the FlatBuffer schema so the flag is written by `TUIndex::serialize`, read by `TUIndex::from`, merged into `ProjectIndex`, and available to both persisted and open-file symbol tables.
+
+Rationale:
+
+- The relation query path runs without live AST nodes, so the decision must be available in symbol metadata.
+- Persisting the flag keeps behavior consistent across background indexing, cache reloads, and unsaved-buffer sessions.
+
+Alternatives considered:
+
+- Store the flag only in TU-local data: rejected because project-level queries read merged/persisted symbol tables.
+- Filter relations during indexing: rejected because the request explicitly preserves non-highlight flows and only changes highlight-oriented queries.
+
+### 3. Filter only the highlight-oriented definition-origin query path
+
+Gate the filter where indexed references are turned into highlight results for a symbol that resolves from a definition origin, instead of mutating stored relations.
+
+Rationale:
+
+- This isolates the behavior change to the requested feature surface.
+- Existing reference relations remain available for other index consumers and future features.
+
+Alternatives considered:
+
+- Remove `Reference` relations for non-highlightable definitions during build: rejected because it would silently change unrelated flows.
+- Apply the filter to every relation query: rejected because it is broader than the approved scope.
+
+### 4. Cover both metadata persistence and user-visible behavior in tests
+
+Add unit tests around index query behavior and integration coverage that exercises the persisted index path.
+
+Rationale:
+
+- The bug spans AST analysis, serialized metadata, project-index merge, and query-time filtering.
+- Positive tests are needed to prevent accidental regressions for constructors, destructors, and ordinary identifiers.
+
+## Risks / Trade-offs
+
+- Persisted-index schema drift can leave old shards without the new flag -> Mitigation: update the FlatBuffer schema and rely on normal reindexing/rewrite paths so rebuilt indexes always carry the field.
+- Open-file and on-disk indexing could diverge if they compute highlightability differently -> Mitigation: route both producers through the same `ast_utility` helper.
+- Filtering the wrong query path could change general references unexpectedly -> Mitigation: confine the check to the highlight-oriented definition-origin query and add regression coverage for unaffected flows.
+
+## Migration Plan
+
+- Add the new symbol field and serialization plumbing first so newly built TU and project indexes capture highlightability.
+- Rebuild or refresh index data through the existing background-indexing flow; no separate data migration is required.
+- Rollback is straightforward because the change is additive to symbol metadata and can be disabled by removing the query-time gate.
+
+## Open Questions
+
+- The implementation should confirm the exact server entry point that backs the owner-requested definition-origin highlight behavior and wire the filter there without broadening it to unrelated reference requests.

--- a/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/proposal.md
+++ b/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/proposal.md
@@ -1,0 +1,31 @@
+# Filter non-highlightable definition references
+
+- Canonical Request Title: `fix(highlight/references): filter non-highlightable definition references`
+- Conventional Title: `fix(highlight/references)`
+
+## Why
+
+Definition-origin reference highlighting currently trusts indexed symbol metadata without checking whether the originating declaration name can actually be highlighted in source. That creates noisy or impossible highlight results for anonymous and operator-like definitions, and the decision cannot be recovered at query time unless it is preserved in the index.
+
+## What Changes
+
+- Add a shared `clang::DeclarationName` predicate that mirrors clangd-style `canHighlightName` behavior for identifiers, constructors, destructors, and rejected name kinds.
+- Persist a `highlightable_name` flag through TU index construction, FlatBuffer serialization, project-index merge/load/save, and open-file symbol metadata.
+- Apply the filter only in the definition-origin reference-highlighting query path so non-highlight relation data stays intact.
+- Add regression coverage for negative cases such as anonymous or operator-like definitions and positive cases such as ordinary identifiers, constructors, and destructors.
+
+## Capabilities
+
+### New Capabilities
+
+- `def-ref-highlight-a1-p1-filter-non-highlightable-definition-references`: Definition-origin reference highlighting uses persisted symbol metadata to suppress non-highlightable definition names while preserving valid ones.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: `src/semantic/ast_utility.*`, `src/index/tu_index.*`, `src/index/schema.fbs`, `src/index/project_index.*`, and the index-backed relation query path in `src/server/`.
+- Affected behavior: indexed reference highlighting for definition-origin queries now matches clangd-style highlightable-name eligibility.
+- Verification: unit coverage in `tests/unit/index/index_query_tests.cpp` and integration coverage in `tests/integration/features/test_index.py` or an equivalent focused fixture.

--- a/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/specs/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/spec.md
+++ b/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/specs/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/spec.md
@@ -1,0 +1,47 @@
+# Filter non-highlightable definition references
+
+- Canonical Request Title: `fix(highlight/references): filter non-highlightable definition references`
+- Conventional Title: `fix(highlight/references)`
+
+## ADDED Requirements
+
+### Requirement: Non-highlightable definitions are excluded from definition-origin reference highlighting
+
+The system SHALL suppress indexed reference-highlighting results when the origin symbol resolves to a definition whose declaration name is not highlightable. Non-highlightable names include declarations without a written identifier token and clang `DeclarationName` kinds that follow the requested `canHighlightName` rejection policy, such as overloaded operators, conversion functions, deduction guides, literal operators, Objective-C selectors, and using directives.
+
+#### Scenario: Anonymous or operator-like definition
+
+- **WHEN** a definition-origin reference-highlighting query resolves to a symbol whose indexed metadata marks its declaration name as non-highlightable
+- **THEN** the query returns no indexed reference-highlight locations for that symbol
+
+### Requirement: Highlightable definitions remain eligible for reference highlighting
+
+The system SHALL continue returning indexed reference-highlighting results for definitions whose declaration names are highlightable, including non-empty identifiers, constructors, and destructors.
+
+#### Scenario: Identifier definition
+
+- **WHEN** a definition-origin reference-highlighting query resolves to a definition with a non-empty identifier name and indexed references
+- **THEN** the query returns the indexed reference-highlight locations for that symbol
+
+#### Scenario: Constructor or destructor definition
+
+- **WHEN** a definition-origin reference-highlighting query resolves to a constructor or destructor definition with indexed references
+- **THEN** the query returns the indexed reference-highlight locations for that symbol
+
+### Requirement: Highlightability is preserved across index persistence
+
+The system SHALL persist whether a symbol's declaration name is highlightable through translation-unit indexing, project-index merge, serialized index storage, and reload so query-time filtering does not depend on live AST access.
+
+#### Scenario: Reloaded project index
+
+- **WHEN** a symbol is indexed, persisted, and later queried through the reloaded project index without re-entering the AST
+- **THEN** the query uses the stored highlightable-name metadata to decide whether indexed reference-highlight locations are returned
+
+### Requirement: Non-highlight consumers keep the underlying reference relations
+
+The system SHALL apply the highlightability check in the highlight-oriented query path without removing the underlying indexed reference relations needed by other consumers.
+
+#### Scenario: Index build stores relations for a non-highlightable definition
+
+- **WHEN** a symbol with a non-highlightable definition name is indexed
+- **THEN** the index retains its stored reference relations so non-highlight-specific consumers can continue using them

--- a/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/tasks.md
+++ b/openspec/changes/def-ref-highlight-a1-p1-filter-non-highlightable-definition-references/tasks.md
@@ -1,0 +1,21 @@
+# Filter non-highlightable definition references
+
+- Canonical Request Title: `fix(highlight/references): filter non-highlightable definition references`
+- Conventional Title: `fix(highlight/references)`
+
+## 1. Shared Highlightability Metadata
+
+- [ ] 1.1 Add a shared `clang::DeclarationName` helper in `src/semantic/ast_utility.*` that matches the requested clangd-style `canHighlightName` policy.
+- [ ] 1.2 Extend `index::Symbol`, `src/index/schema.fbs`, and TU/project index serialization and merge paths so symbol metadata carries a persisted `highlightable_name` flag.
+- [ ] 1.3 Populate the same flag in every indexing producer that builds symbol tables, including background TU indexing and open-file indexing.
+
+## 2. Query Filtering
+
+- [ ] 2.1 Update the highlight-oriented definition-origin reference query path to skip reference-highlight results when the resolved symbol is marked non-highlightable.
+- [ ] 2.2 Keep stored relations and non-highlight query behavior unchanged outside that gated path.
+
+## 3. Regression Coverage
+
+- [ ] 3.1 Add unit tests that prove anonymous or operator-like definitions no longer yield indexed reference-highlight results.
+- [ ] 3.2 Add positive unit tests that prove ordinary identifiers, constructors, and destructors still yield indexed reference-highlight results.
+- [ ] 3.3 Extend integration coverage to verify the filter survives project-index persistence and open-file indexing.


### PR DESCRIPTION
Implement clangd-style canHighlightName filtering for definition-origin reference highlighting by adding a shared DeclarationName predicate, persisting a highlightable-name flag through the index pipeline, applying the filter in the query path, and covering both negative and positive symbol-name cases with regression tests.