### PR TITLE
fix: prevent worker crashes from null ASTConsumer, invalid FileID, and missing PCH cache dir

### DIFF
--- a/benchmarks/scan_benchmark.cpp
+++ b/benchmarks/scan_benchmark.cpp
@@ -26,7 +26,7 @@
 #include "support/path_pool.h"
 #include "syntax/dependency_graph.h"
 
-#include "kota/codec/json/serializer.h"
+#include "kota/codec/json/json.h"
 #include "kota/deco/deco.h"
 #include "llvm/Support/FileSystem.h"
 

--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -219,9 +219,10 @@ public:
 
     auto CreateASTConsumer(clang::CompilerInstance& instance, llvm::StringRef file)
         -> std::unique_ptr<clang::ASTConsumer> final {
-        return std::make_unique<ProxyASTConsumer>(
-            WrapperFrontendAction::CreateASTConsumer(instance, file),
-            unit);
+        auto consumer = WrapperFrontendAction::CreateASTConsumer(instance, file);
+        if(!consumer)
+            return nullptr;
+        return std::make_unique<ProxyASTConsumer>(std::move(consumer), unit);
     }
 
     /// Make this public.

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -81,7 +81,8 @@ auto CompilationUnitRef::file_offset(clang::SourceLocation location) -> std::uin
 }
 
 auto CompilationUnitRef::file_path(clang::FileID fid) -> llvm::StringRef {
-    assert(fid.isValid() && "Invalid fid");
+    if(!fid.isValid())
+        return {};
     if(auto it = self->path_cache.find(fid); it != self->path_cache.end()) {
         return it->second;
     }

--- a/src/server/compiler.cpp
+++ b/src/server/compiler.cpp
@@ -490,6 +490,22 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
     auto completion = std::make_shared<kota::event>();
     workspace.pch_cache[path_id].building = completion;
 
+    if(workspace.config.project.cache_dir.empty()) {
+        LOG_WARN("PCH build skipped: cache_dir is not configured");
+        workspace.pch_cache[path_id].building.reset();
+        completion->set();
+        co_return false;
+    }
+
+    // Ensure the PCH cache directory exists.
+    auto pch_dir = path::join(workspace.config.project.cache_dir, "cache", "pch");
+    if(auto ec = llvm::sys::fs::create_directories(pch_dir)) {
+        LOG_WARN("Cannot create PCH cache dir {}: {}", pch_dir, ec.message());
+        workspace.pch_cache[path_id].building.reset();
+        completion->set();
+        co_return false;
+    }
+
     // Build a new PCH via stateless worker.
     worker::BuildParams bp;
     bp.kind = worker::BuildKind::BuildPCH;

--- a/src/server/compiler.h
+++ b/src/server/compiler.h
@@ -14,7 +14,7 @@
 #include "syntax/completion.h"
 
 #include "kota/async/async.h"
-#include "kota/codec/raw_value.h"
+#include "kota/codec/json/json.h"
 #include "kota/ipc/codec/json.h"
 #include "kota/ipc/lsp/protocol.h"
 #include "kota/ipc/peer.h"

--- a/src/server/config.cpp
+++ b/src/server/config.cpp
@@ -7,7 +7,7 @@
 #include "support/logging.h"
 
 #include "kota/codec/json/json.h"
-#include "kota/codec/toml.h"
+#include "kota/codec/toml/toml.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"

--- a/src/server/master_server.cpp
+++ b/src/server/master_server.cpp
@@ -56,9 +56,9 @@ MasterServer::MasterServer(kota::event_loop& loop,
 
 MasterServer::~MasterServer() = default;
 
-kota::task<> MasterServer::load_workspace() {
+void MasterServer::load_workspace() {
     if(workspace_root.empty())
-        co_return;
+        return;
 
     auto& cfg = workspace.config.project;
 
@@ -125,7 +125,7 @@ kota::task<> MasterServer::load_workspace() {
 
     if(cdb_path.empty()) {
         LOG_WARN("No compile_commands.json found in workspace {}", workspace_root);
-        co_return;
+        return;
     }
 
     auto count = workspace.cdb.load(cdb_path);
@@ -331,7 +331,7 @@ void MasterServer::register_handlers() {
             indexer.schedule();
         };
 
-        loop.schedule(load_workspace());
+        load_workspace();
     });
 
     peer.on_request(

--- a/src/server/master_server.h
+++ b/src/server/master_server.h
@@ -12,7 +12,7 @@
 #include "server/workspace.h"
 
 #include "kota/async/async.h"
-#include "kota/codec/raw_value.h"
+#include "kota/codec/json/json.h"
 #include "kota/ipc/peer.h"
 #include "llvm/ADT/DenseMap.h"
 

--- a/src/server/master_server.h
+++ b/src/server/master_server.h
@@ -73,7 +73,7 @@ private:
     std::string session_log_dir;
     std::string init_options_json;  ///< Raw JSON from initializationOptions, consumed once.
 
-    kota::task<> load_workspace();
+    void load_workspace();
 
     using RawResult = kota::task<kota::codec::RawValue, kota::ipc::Error>;
 };

--- a/src/server/protocol.h
+++ b/src/server/protocol.h
@@ -9,7 +9,7 @@
 
 #include "syntax/token.h"
 
-#include "kota/codec/raw_value.h"
+#include "kota/codec/json/json.h"
 #include "kota/ipc/lsp/protocol.h"
 #include "kota/ipc/protocol.h"
 

--- a/src/server/worker_common.h
+++ b/src/server/worker_common.h
@@ -8,8 +8,7 @@
 
 #include "compile/compilation.h"
 
-#include "kota/codec/json/serializer.h"
-#include "kota/codec/raw_value.h"
+#include "kota/codec/json/json.h"
 #include "kota/ipc/codec/json.h"
 
 namespace clice {

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -6,7 +6,7 @@
 #include "support/filesystem.h"
 
 #include "kota/codec/json/json.h"
-#include "kota/codec/toml.h"
+#include "kota/codec/toml/toml.h"
 
 namespace clice::testing {
 

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -5,7 +5,7 @@
 #include "server/protocol.h"
 #include "server/worker_test_helpers.h"
 
-#include "kota/codec/raw_value.h"
+#include "kota/codec/json/json.h"
 
 namespace clice::testing {
 

--- a/tests/unit/server/stateless_worker_tests.cpp
+++ b/tests/unit/server/stateless_worker_tests.cpp
@@ -6,7 +6,6 @@
 #include "server/worker_test_helpers.h"
 
 #include "kota/codec/bincode/bincode.h"
-#include "kota/codec/raw_value.h"
 
 namespace clice::testing {
 


### PR DESCRIPTION
## Summary

Three pre-existing bugs cause worker processes to crash with SEGV or SIGABRT. On the main branch these crashes are silent (workers die, requests fail fast with "transport closed", tests still pass because null responses are accepted). However when combined with #432's worker respawn mechanism, the crash-respawn-crash cycle on low-core CI machines causes request timeouts and smoke test hangs.

### Fixes

- **compilation.cpp**: `ProxyAction::CreateASTConsumer` now checks for null before passing to `MultiplexConsumer`. When the wrapped action's `CreateASTConsumer` fails (e.g. missing system headers during PCH generation), this previously caused a null pointer dereference, SEGV, ASAN kills the stateless worker.
- **compilation_unit.cpp**: `file_path()` returns empty `StringRef` on invalid `FileID` instead of asserting. The assert fired when `IncludeGraph::from()` called `file_path(interested_file())` on an AST compiled with synthesized default commands (no compile_commands.json, clang++ -std=c++20 fallback, no system headers, invalid main file ID), SIGABRT, stateful worker crash.
- **compiler.cpp**: `ensure_pch` now creates the PCH cache directory before sending the build request. Previously, when `load_workspace()` exited early (no compile_commands.json), the cache subdirectories were never created, causing every PCH write to fail with "No such file or directory".
- **master_server.cpp/h**: `load_workspace()` changed from `kota::task<>` to plain `void` -- it contains only synchronous filesystem operations and no co_await, so the coroutine wrapper was unnecessary. Called directly instead of via `loop.schedule()`.

## Test plan

- [x] Verified zero SEGV/SIGABRT/assertion crashes in worker stderr after fix
- [x] rapid_edit.jsonl smoke test passes 3/3 runs consistently (34s each)
- [x] Behavior matches main branch (both return 134 responses, 0 pending)
- [x] Debug build with ASAN (detect_leaks=0) -- clean run, no sanitizer reports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/clice-io/codesmith/clice/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for AST consumer creation with null checks and a clear failure path.
  * Safer file-path access that returns empty for invalid identifiers instead of asserting.
  * PCH cache handling now validates cache configuration, attempts directory creation, logs warnings, and aborts PCH builds on failure.

* **Refactor**
  * Workspace loading changed from asynchronous to synchronous execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->