### PR TITLE
feat(server): agentic query API, daemon mode, and relay mode

### DIFF
--- a/src/clice.cc
+++ b/src/clice.cc
@@ -48,6 +48,33 @@ struct Options {
            required = false)
     <std::string> path;
 
+    DecoKV(
+        style = KVStyle::JoinedOrSeparate,
+        help =
+            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles)",
+        required = false)
+    <std::string> method;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Symbol name for agentic queries",
+           required = false)
+    <std::string> name;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Search query for symbolSearch",
+           required = false)
+    <std::string> query;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Line number for position-based lookup",
+           required = false)
+    <int> line;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Direction: callers/callees or supertypes/subtypes",
+           required = false)
+    <std::string> direction;
+
     DecoKV(style = KVStyle::JoinedOrSeparate,
            help = "Unix domain socket path for daemon mode",
            required = false)
@@ -160,18 +187,21 @@ int main(int argc, const char** argv) {
     }
 
     if(mode == "agentic") {
-        auto host = opts.host.value_or("127.0.0.1");
         auto port = opts.port.value_or(0);
-        auto path = opts.path.value_or("");
         if(port <= 0) {
             LOG_ERROR("--port is required for agentic mode");
             return 1;
         }
-        if(path.empty()) {
-            LOG_ERROR("--path is required for agentic mode");
-            return 1;
-        }
-        return clice::run_agentic_mode(host, port, path);
+        clice::AgenticQueryOptions aq;
+        aq.host = opts.host.value_or("127.0.0.1");
+        aq.port = port;
+        aq.method = opts.method.value_or("compileCommand");
+        aq.path = opts.path.value_or("");
+        aq.name = opts.name.value_or("");
+        aq.query = opts.query.value_or("");
+        aq.line = opts.line.value_or(0);
+        aq.direction = opts.direction.value_or("");
+        return clice::run_agentic_mode(aq);
     }
 
     if(mode == "relay") {

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -51,7 +51,9 @@ struct Options {
     DecoKV(
         style = KVStyle::JoinedOrSeparate,
         help =
-            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, status, shutdown)",
+            "Agentic method (compileCommand, symbolSearch, definition, references, "
+            "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, "
+            "fileDeps, impactAnalysis, status, shutdown)",
         required = false)
     <std::string> method;
 
@@ -179,9 +181,15 @@ int main(int argc, const char** argv) {
     }
 
     if(mode == "daemon") {
+        auto workspace = opts.workspace.value_or("");
+        if(workspace.empty()) {
+            LOG_ERROR("--workspace is required for daemon mode");
+            return 1;
+        }
+
         clice::DaemonOptions daemon_opts;
         daemon_opts.socket_path = opts.socket.value_or("");
-        daemon_opts.workspace = opts.workspace.value_or("");
+        daemon_opts.workspace = std::move(workspace);
         daemon_opts.self_path = argv[0];
         return clice::run_daemon_mode(daemon_opts);
     }

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -51,7 +51,7 @@ struct Options {
     DecoKV(
         style = KVStyle::JoinedOrSeparate,
         help =
-            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles)",
+            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, status)",
         required = false)
     <std::string> method;
 

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -51,7 +51,7 @@ struct Options {
     DecoKV(
         style = KVStyle::JoinedOrSeparate,
         help =
-            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, status)",
+            "Agentic method (compileCommand, symbolSearch, definition, references, " "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, status, shutdown)",
         required = false)
     <std::string> method;
 

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -17,9 +17,11 @@ namespace clice {
 using kota::deco::decl::KVStyle;
 
 struct Options {
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Running mode: pipe, socket, agentic, stateless-worker, stateful-worker",
-           required = false)
+    DecoKV(
+        style = KVStyle::JoinedOrSeparate,
+        help =
+            "Running mode: pipe, socket, daemon, relay, agentic, stateless-worker, stateful-worker",
+        required = false)
     <std::string> mode;
 
     DecoKV(style = KVStyle::JoinedOrSeparate, help = "Socket mode address", required = false)
@@ -45,6 +47,16 @@ struct Options {
            help = "File path for agentic queries",
            required = false)
     <std::string> path;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Unix domain socket path for daemon mode",
+           required = false)
+    <std::string> socket;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Workspace root directory for daemon mode",
+           required = false)
+    <std::string> workspace;
 
     // Internal options (passed from master to worker processes)
     DecoKV(style = KVStyle::JoinedOrSeparate,
@@ -139,6 +151,14 @@ int main(int argc, const char** argv) {
         return clice::run_server_mode(server_opts);
     }
 
+    if(mode == "daemon") {
+        clice::DaemonOptions daemon_opts;
+        daemon_opts.socket_path = opts.socket.value_or("");
+        daemon_opts.workspace = opts.workspace.value_or("");
+        daemon_opts.self_path = argv[0];
+        return clice::run_daemon_mode(daemon_opts);
+    }
+
     if(mode == "agentic") {
         auto host = opts.host.value_or("127.0.0.1");
         auto port = opts.port.value_or(0);
@@ -152,6 +172,11 @@ int main(int argc, const char** argv) {
             return 1;
         }
         return clice::run_agentic_mode(host, port, path);
+    }
+
+    if(mode == "relay") {
+        auto socket = opts.socket.value_or("");
+        return clice::run_relay_mode(socket);
     }
 
     LOG_ERROR("unknown mode '{}'", mode);

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -642,6 +642,11 @@ void Indexer::resume_indexing() {
     }
 }
 
+kota::task<> Indexer::stop() {
+    bg_tasks.cancel();
+    co_await bg_tasks.join();
+}
+
 void Indexer::schedule() {
     if(!*workspace.config.project.enable_indexing || indexing_active || indexing_scheduled)
         return;
@@ -651,7 +656,10 @@ void Indexer::schedule() {
         index_idle_timer = std::make_shared<kota::timer>(kota::timer::create(loop));
     }
     index_idle_timer->start(std::chrono::milliseconds(*workspace.config.project.idle_timeout_ms));
-    loop.schedule(run_background_indexing());
+
+    if(!bg_tasks.spawn(run_background_indexing())) {
+        indexing_scheduled = false;
+    }
 }
 
 kota::task<> Indexer::index_one(std::uint32_t server_path_id) {
@@ -734,72 +742,54 @@ kota::task<> Indexer::run_background_indexing() {
     indexing_active = true;
 
     kota::cancellation_source monitor_cancel;
-    kota::task_group<> index_group(loop);
-    index_group.spawn(kota::with_token(monitor_resources(), monitor_cancel.token()));
+    bg_tasks.spawn(kota::with_token(monitor_resources(), monitor_cancel.token()));
 
     std::stable_partition(
         index_queue.begin() + index_queue_pos,
         index_queue.end(),
         [this](std::uint32_t id) { return workspace.path_to_module.contains(id); });
 
-    auto batch = index_queue.size() - index_queue_pos;
-    std::size_t inflight = 0;
+    auto total = index_queue.size() - index_queue_pos;
     std::size_t dispatched = 0;
     std::size_t completed = 0;
-    std::size_t finished = 0;
-    kota::event completion_event;
 
     std::optional<lsp::ProgressReporter<kota::ipc::JsonPeer>> progress;
     if(peer) {
         progress.emplace(*peer, protocol::ProgressToken(std::string("clice/backgroundIndex")));
         auto create_result = co_await progress->create();
         if(!create_result.has_error()) {
-            progress->begin("Indexing", std::format("0/{} files", batch), 0);
+            progress->begin("Indexing", std::format("0/{} files", total), 0);
         } else {
             progress.reset();
         }
     }
 
-    while(index_queue_pos < index_queue.size() || inflight > 0) {
-        while(index_queue_pos < index_queue.size() && inflight < max_concurrent) {
-            if(pause_depth > 0) {
-                co_await resume_event.wait();
-            }
+    while(index_queue_pos < index_queue.size()) {
+        if(pause_depth > 0) {
+            co_await resume_event.wait();
+        }
 
+        kota::task_group<> batch(loop);
+        std::size_t batch_dispatched = 0;
+
+        while(index_queue_pos < index_queue.size() && batch_dispatched < max_concurrent) {
             auto server_path_id = index_queue[index_queue_pos++];
-
             auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
             if(sessions.contains(server_path_id) || !need_update(file_path)) {
                 ++completed;
                 continue;
             }
-
-            ++inflight;
-            ++dispatched;
-
-            index_group.spawn([](Indexer* self,
-                                 std::uint32_t id,
-                                 std::size_t& inflight_ref,
-                                 std::size_t& finished_ref,
-                                 kota::event& done) -> kota::task<> {
-                co_await self->index_one(id);
-                --inflight_ref;
-                ++finished_ref;
-                done.set();
-            }(this, server_path_id, inflight, finished, completion_event));
+            batch.spawn(index_one(server_path_id));
+            ++batch_dispatched;
         }
 
-        if(inflight == 0)
-            break;
-
-        co_await completion_event.wait();
-        completion_event.reset();
-
-        completed += std::exchange(finished, 0);
+        co_await batch.join();
+        dispatched += batch_dispatched;
+        completed += batch_dispatched;
 
         if(progress) {
-            auto pct = batch > 0 ? static_cast<std::uint32_t>(completed * 100 / batch) : 100;
-            progress->report(std::format("{}/{} files", completed, batch), pct);
+            auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;
+            progress->report(std::format("{}/{} files", completed, total), pct);
         }
     }
 
@@ -808,7 +798,6 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     monitor_cancel.cancel();
-    co_await index_group.join();
 
     indexing_active = false;
     LOG_INFO("Background indexing complete: {} files dispatched", dispatched);

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -805,6 +805,7 @@ void Indexer::schedule() {
 
     if(!bg_tasks.spawn(run_background_indexing())) {
         indexing_scheduled = false;
+        LOG_WARN("Failed to spawn background indexing task (task group stopped)");
     }
 }
 
@@ -910,34 +911,41 @@ kota::task<> Indexer::run_background_indexing() {
         }
     }
 
+    kota::task_group<> workers(loop);
+    std::size_t in_flight = 0;
+    kota::event slot_available;
+
     while(index_queue_pos < index_queue.size()) {
-        if(pause_depth > 0) {
+        if(pause_depth > 0)
             co_await resume_event.wait();
+
+        auto server_path_id = index_queue[index_queue_pos++];
+        auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
+        if(sessions.contains(server_path_id) || !need_update(file_path)) {
+            ++completed;
+            continue;
         }
 
-        kota::task_group<> batch(loop);
-        std::size_t batch_dispatched = 0;
+        while(in_flight >= max_concurrent) {
+            slot_available.reset();
+            co_await slot_available.wait();
+        }
 
-        while(index_queue_pos < index_queue.size() && batch_dispatched < max_concurrent) {
-            auto server_path_id = index_queue[index_queue_pos++];
-            auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
-            if(sessions.contains(server_path_id) || !need_update(file_path)) {
-                ++completed;
-                continue;
+        ++in_flight;
+        ++dispatched;
+        workers.spawn([&, server_path_id]() -> kota::task<> {
+            co_await index_one(server_path_id);
+            --in_flight;
+            ++completed;
+            if(progress) {
+                auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;
+                progress->report(std::format("{}/{} files", completed, total), pct);
             }
-            batch.spawn(index_one(server_path_id));
-            ++batch_dispatched;
-        }
-
-        co_await batch.join();
-        dispatched += batch_dispatched;
-        completed += batch_dispatched;
-
-        if(progress) {
-            auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;
-            progress->report(std::format("{}/{} files", completed, total), pct);
-        }
+            slot_available.set();
+        }());
     }
+
+    co_await workers.join();
 
     if(progress) {
         progress->end(std::format("Indexed {} files", dispatched));

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -447,6 +447,152 @@ std::optional<SymbolInfo> Indexer::resolve_symbol(index::SymbolHash hash) {
     return SymbolInfo{hash, std::move(name), kind, def_loc->uri, def_loc->range};
 }
 
+static std::string extract_line(llvm::StringRef content, std::uint32_t offset) {
+    if(content.empty() || offset >= content.size())
+        return {};
+    std::size_t line_start = 0;
+    if(offset > 0) {
+        auto pos = content.rfind('\n', offset - 1);
+        if(pos != llvm::StringRef::npos)
+            line_start = pos + 1;
+    }
+    auto line_end = content.find('\n', offset);
+    if(line_end == llvm::StringRef::npos)
+        line_end = content.size();
+    return content.slice(line_start, line_end).str();
+}
+
+std::optional<Indexer::DefinitionText> Indexer::get_definition_text(index::SymbolHash hash) {
+    for(auto& [id, sess]: sessions) {
+        if(!sess.file_index || !sess.file_index->mapper)
+            continue;
+        auto it = sess.file_index->file_index.relations.find(hash);
+        if(it == sess.file_index->file_index.relations.end())
+            continue;
+        for(auto& rel: it->second) {
+            if(rel.kind.value() != RelationKind::Definition)
+                continue;
+            auto def_range = std::bit_cast<LocalSourceRange>(rel.target_symbol);
+            if(def_range.begin >= def_range.end)
+                continue;
+            llvm::StringRef content = sess.file_index->content;
+            if(def_range.end > content.size())
+                continue;
+            auto start = sess.file_index->mapper->to_position(def_range.begin);
+            auto end = sess.file_index->mapper->to_position(def_range.end);
+            if(!start || !end)
+                continue;
+            return DefinitionText{
+                .file = std::string(workspace.path_pool.resolve(id)),
+                .start_line = static_cast<int>(start->line) + 1,
+                .end_line = static_cast<int>(end->line) + 1,
+                .text =
+                    std::string(content.substr(def_range.begin, def_range.end - def_range.begin)),
+            };
+        }
+    }
+
+    auto sym_it = workspace.project_index.symbols.find(hash);
+    if(sym_it == workspace.project_index.symbols.end())
+        return std::nullopt;
+
+    for(auto file_id: sym_it->second.reference_files) {
+        if(is_proj_path_open(file_id))
+            continue;
+        auto shard_it = workspace.merged_indices.find(file_id);
+        if(shard_it == workspace.merged_indices.end())
+            continue;
+        auto* m = shard_it->second.mapper();
+        if(!m)
+            continue;
+        auto content = shard_it->second.index.content();
+
+        std::optional<DefinitionText> result;
+        shard_it->second.index.lookup(
+            hash,
+            RelationKind::Definition,
+            [&](const index::Relation& r) {
+                auto def_range = std::bit_cast<LocalSourceRange>(r.target_symbol);
+                if(def_range.begin >= def_range.end || def_range.end > content.size())
+                    return true;
+                auto start = m->to_position(def_range.begin);
+                auto end = m->to_position(def_range.end);
+                if(!start || !end)
+                    return true;
+                result = DefinitionText{
+                    .file = workspace.project_index.path_pool.path(file_id).str(),
+                    .start_line = static_cast<int>(start->line) + 1,
+                    .end_line = static_cast<int>(end->line) + 1,
+                    .text = std::string(
+                        content.substr(def_range.begin, def_range.end - def_range.begin)),
+                };
+                return false;
+            });
+        if(result)
+            return result;
+    }
+
+    return std::nullopt;
+}
+
+std::vector<Indexer::ReferenceWithContext> Indexer::collect_references(index::SymbolHash hash,
+                                                                       RelationKind kind) {
+    std::vector<ReferenceWithContext> results;
+
+    auto sym_it = workspace.project_index.symbols.find(hash);
+    if(sym_it != workspace.project_index.symbols.end()) {
+        for(auto file_id: sym_it->second.reference_files) {
+            if(is_proj_path_open(file_id))
+                continue;
+            auto shard_it = workspace.merged_indices.find(file_id);
+            if(shard_it == workspace.merged_indices.end())
+                continue;
+            auto* m = shard_it->second.mapper();
+            if(!m)
+                continue;
+            auto content = shard_it->second.index.content();
+            auto file_path = workspace.project_index.path_pool.path(file_id);
+
+            shard_it->second.index.lookup(hash, kind, [&](const index::Relation& r) {
+                auto start = m->to_position(r.range.begin);
+                if(!start)
+                    return true;
+                results.push_back(ReferenceWithContext{
+                    .file = file_path.str(),
+                    .line = static_cast<int>(start->line) + 1,
+                    .context = extract_line(content, r.range.begin),
+                });
+                return true;
+            });
+        }
+    }
+
+    for(auto& [id, sess]: sessions) {
+        if(!sess.file_index || !sess.file_index->mapper)
+            continue;
+        auto it = sess.file_index->file_index.relations.find(hash);
+        if(it == sess.file_index->file_index.relations.end())
+            continue;
+        auto file_path = workspace.path_pool.resolve(id);
+        llvm::StringRef content = sess.file_index->content;
+
+        for(auto& rel: it->second) {
+            if(rel.kind != kind)
+                continue;
+            auto start = sess.file_index->mapper->to_position(rel.range.begin);
+            if(!start)
+                continue;
+            results.push_back(ReferenceWithContext{
+                .file = file_path.str(),
+                .line = static_cast<int>(start->line) + 1,
+                .context = extract_line(content, rel.range.begin),
+            });
+        }
+    }
+
+    return results;
+}
+
 std::vector<protocol::CallHierarchyIncomingCall>
     Indexer::find_incoming_calls(index::SymbolHash hash) {
     llvm::DenseMap<index::SymbolHash, std::vector<protocol::Range>> caller_ranges;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -167,6 +167,25 @@ public:
     std::vector<protocol::SymbolInformation> search_symbols(llvm::StringRef query,
                                                             std::size_t max_results = 100);
 
+    struct DefinitionText {
+        std::string file;
+        int start_line;
+        int end_line;
+        std::string text;
+    };
+
+    /// Get full definition text for a symbol, using stored index ranges and content.
+    std::optional<DefinitionText> get_definition_text(index::SymbolHash hash);
+
+    struct ReferenceWithContext {
+        std::string file;
+        int line;
+        std::string context;
+    };
+
+    /// Collect references (or definitions) with context lines from stored content.
+    std::vector<ReferenceWithContext> collect_references(index::SymbolHash hash, RelationKind kind);
+
     /// Cancel background indexing and wait for all tasks to settle.
     kota::task<> stop();
 

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -61,8 +61,8 @@ public:
             WorkerPool& pool,
             Compiler& compiler,
             std::function<bool(std::uint32_t)> is_file_open = {}) :
-        loop(loop), workspace(workspace), sessions(sessions), pool(pool), compiler(compiler),
-        is_file_open(std::move(is_file_open)) {}
+        loop(loop), bg_tasks(loop), workspace(workspace), sessions(sessions), pool(pool),
+        compiler(compiler), is_file_open(std::move(is_file_open)) {}
 
     /// Set the LSP peer for progress reporting.  Must be called before
     /// schedule() if progress notifications are desired.
@@ -167,6 +167,9 @@ public:
     std::vector<protocol::SymbolInformation> search_symbols(llvm::StringRef query,
                                                             std::size_t max_results = 100);
 
+    /// Cancel background indexing and wait for all tasks to settle.
+    kota::task<> stop();
+
     /// Whether background indexing is currently idle (no active or queued work).
     bool is_idle() const {
         return !indexing_active && index_queue_pos >= index_queue.size();
@@ -223,6 +226,7 @@ private:
 
 private:
     kota::event_loop& loop;
+    kota::task_group<> bg_tasks;
     Workspace& workspace;
     llvm::DenseMap<std::uint32_t, Session>& sessions;
     WorkerPool& pool;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -167,6 +167,21 @@ public:
     std::vector<protocol::SymbolInformation> search_symbols(llvm::StringRef query,
                                                             std::size_t max_results = 100);
 
+    /// Whether background indexing is currently idle (no active or queued work).
+    bool is_idle() const {
+        return !indexing_active && index_queue_pos >= index_queue.size();
+    }
+
+    /// Number of files remaining in the indexing queue.
+    std::size_t pending_files() const {
+        return index_queue_pos < index_queue.size() ? index_queue.size() - index_queue_pos : 0;
+    }
+
+    /// Total files that were enqueued in the current (or last) indexing round.
+    std::size_t total_queued() const {
+        return index_queue.size();
+    }
+
     /// Convert internal SymbolKind to LSP SymbolKind.
     static protocol::SymbolKind to_lsp_symbol_kind(SymbolKind kind);
 

--- a/src/server/protocol/agentic.h
+++ b/src/server/protocol/agentic.h
@@ -202,6 +202,15 @@ struct TypeHierarchyResult {
     std::vector<TypeHierarchyEntry> subtypes;
 };
 
+struct StatusParams {};
+
+struct StatusResult {
+    bool idle = true;
+    int pending = 0;
+    int total = 0;
+    int indexed = 0;
+};
+
 }  // namespace clice::agentic
 
 namespace kota::ipc::protocol {
@@ -270,6 +279,12 @@ template <>
 struct RequestTraits<clice::agentic::TypeHierarchyParams> {
     using Result = clice::agentic::TypeHierarchyResult;
     constexpr inline static std::string_view method = "agentic/typeHierarchy";
+};
+
+template <>
+struct RequestTraits<clice::agentic::StatusParams> {
+    using Result = clice::agentic::StatusResult;
+    constexpr inline static std::string_view method = "agentic/status";
 };
 
 }  // namespace kota::ipc::protocol

--- a/src/server/protocol/agentic.h
+++ b/src/server/protocol/agentic.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -17,6 +19,189 @@ struct CompileCommandResult {
     std::vector<std::string> arguments;
 };
 
+struct FileInfo {
+    std::string path;
+    std::string kind;
+    std::optional<std::string> module_name;
+};
+
+struct ProjectFilesParams {
+    std::optional<std::string> filter;
+};
+
+struct ProjectFilesResult {
+    std::vector<FileInfo> files;
+    int total = 0;
+};
+
+struct DepEntry {
+    std::string path;
+    int depth = 0;
+};
+
+struct FileDepsParams {
+    std::string path;
+    std::optional<std::string> direction;
+    std::optional<int> depth;
+};
+
+struct FileDepsResult {
+    std::string file;
+    std::vector<DepEntry> includes;
+    std::vector<DepEntry> includers;
+};
+
+struct ImpactAnalysisParams {
+    std::string path;
+};
+
+struct ImpactAnalysisResult {
+    std::vector<std::string> direct_dependents;
+    std::vector<std::string> transitive_dependents;
+    std::vector<std::string> affected_modules;
+};
+
+struct SymbolEntry {
+    std::string name;
+    std::string kind;
+    std::string file;
+    int line = 0;
+    std::optional<std::string> container;
+    std::uint64_t symbol_id = 0;
+};
+
+struct SymbolSearchParams {
+    std::string query;
+    std::optional<std::vector<std::string>> kind_filter;
+    std::optional<int> max_results;
+};
+
+struct SymbolSearchResult {
+    std::vector<SymbolEntry> symbols;
+};
+
+struct ReadSymbolParams {
+    std::optional<std::string> name;
+    std::optional<std::string> path;
+    std::optional<int> line;
+    std::optional<std::uint64_t> symbol_id;
+};
+
+struct ReadSymbolResult {
+    std::string name;
+    std::string kind;
+    std::string file;
+    int start_line = 0;
+    int end_line = 0;
+    std::string text;
+    std::optional<std::string> signature;
+    std::uint64_t symbol_id = 0;
+};
+
+struct DocumentSymbolEntry {
+    std::string name;
+    std::string kind;
+    int start_line = 0;
+    int end_line = 0;
+    std::uint64_t symbol_id = 0;
+};
+
+struct DocumentSymbolsParams {
+    std::string path;
+};
+
+struct DocumentSymbolsResult {
+    std::vector<DocumentSymbolEntry> symbols;
+};
+
+struct DefinitionParams {
+    std::optional<std::string> name;
+    std::optional<std::string> path;
+    std::optional<int> line;
+    std::optional<std::uint64_t> symbol_id;
+};
+
+struct LocationEntry {
+    std::string file;
+    int start_line = 0;
+    int end_line = 0;
+    std::string text;
+};
+
+struct DefinitionResult {
+    std::string name;
+    std::string kind;
+    std::uint64_t symbol_id = 0;
+    std::optional<LocationEntry> definition;
+};
+
+struct ReferenceEntry {
+    std::string file;
+    int line = 0;
+    std::string context;
+};
+
+struct ReferencesParams {
+    std::optional<std::string> name;
+    std::optional<std::string> path;
+    std::optional<int> line;
+    std::optional<std::uint64_t> symbol_id;
+    std::optional<bool> include_declaration;
+};
+
+struct ReferencesResult {
+    std::string name;
+    std::string kind;
+    std::uint64_t symbol_id = 0;
+    std::vector<ReferenceEntry> references;
+    int total = 0;
+};
+
+struct CallGraphEntry {
+    std::string name;
+    std::string kind;
+    std::string file;
+    int line = 0;
+    std::uint64_t symbol_id = 0;
+};
+
+struct CallGraphParams {
+    std::optional<std::string> name;
+    std::optional<std::string> path;
+    std::optional<int> line;
+    std::optional<std::uint64_t> symbol_id;
+    std::optional<std::string> direction;
+    std::optional<int> depth;
+};
+
+struct CallGraphResult {
+    CallGraphEntry root;
+    std::vector<CallGraphEntry> callers;
+    std::vector<CallGraphEntry> callees;
+};
+
+struct TypeHierarchyEntry {
+    std::string name;
+    std::string kind;
+    std::string file;
+    int line = 0;
+    std::uint64_t symbol_id = 0;
+};
+
+struct TypeHierarchyParams {
+    std::optional<std::string> name;
+    std::optional<std::string> path;
+    std::optional<int> line;
+    std::optional<std::uint64_t> symbol_id;
+    std::optional<std::string> direction;
+};
+
+struct TypeHierarchyResult {
+    TypeHierarchyEntry root;
+    std::vector<TypeHierarchyEntry> supertypes;
+    std::vector<TypeHierarchyEntry> subtypes;
+};
+
 }  // namespace clice::agentic
 
 namespace kota::ipc::protocol {
@@ -25,6 +210,66 @@ template <>
 struct RequestTraits<clice::agentic::CompileCommandParams> {
     using Result = clice::agentic::CompileCommandResult;
     constexpr inline static std::string_view method = "agentic/compileCommand";
+};
+
+template <>
+struct RequestTraits<clice::agentic::ProjectFilesParams> {
+    using Result = clice::agentic::ProjectFilesResult;
+    constexpr inline static std::string_view method = "agentic/projectFiles";
+};
+
+template <>
+struct RequestTraits<clice::agentic::FileDepsParams> {
+    using Result = clice::agentic::FileDepsResult;
+    constexpr inline static std::string_view method = "agentic/fileDeps";
+};
+
+template <>
+struct RequestTraits<clice::agentic::ImpactAnalysisParams> {
+    using Result = clice::agentic::ImpactAnalysisResult;
+    constexpr inline static std::string_view method = "agentic/impactAnalysis";
+};
+
+template <>
+struct RequestTraits<clice::agentic::SymbolSearchParams> {
+    using Result = clice::agentic::SymbolSearchResult;
+    constexpr inline static std::string_view method = "agentic/symbolSearch";
+};
+
+template <>
+struct RequestTraits<clice::agentic::ReadSymbolParams> {
+    using Result = clice::agentic::ReadSymbolResult;
+    constexpr inline static std::string_view method = "agentic/readSymbol";
+};
+
+template <>
+struct RequestTraits<clice::agentic::DocumentSymbolsParams> {
+    using Result = clice::agentic::DocumentSymbolsResult;
+    constexpr inline static std::string_view method = "agentic/documentSymbols";
+};
+
+template <>
+struct RequestTraits<clice::agentic::DefinitionParams> {
+    using Result = clice::agentic::DefinitionResult;
+    constexpr inline static std::string_view method = "agentic/definition";
+};
+
+template <>
+struct RequestTraits<clice::agentic::ReferencesParams> {
+    using Result = clice::agentic::ReferencesResult;
+    constexpr inline static std::string_view method = "agentic/references";
+};
+
+template <>
+struct RequestTraits<clice::agentic::CallGraphParams> {
+    using Result = clice::agentic::CallGraphResult;
+    constexpr inline static std::string_view method = "agentic/callGraph";
+};
+
+template <>
+struct RequestTraits<clice::agentic::TypeHierarchyParams> {
+    using Result = clice::agentic::TypeHierarchyResult;
+    constexpr inline static std::string_view method = "agentic/typeHierarchy";
 };
 
 }  // namespace kota::ipc::protocol

--- a/src/server/protocol/agentic.h
+++ b/src/server/protocol/agentic.h
@@ -211,6 +211,8 @@ struct StatusResult {
     int indexed = 0;
 };
 
+struct ShutdownParams {};
+
 }  // namespace clice::agentic
 
 namespace kota::ipc::protocol {
@@ -285,6 +287,11 @@ template <>
 struct RequestTraits<clice::agentic::StatusParams> {
     using Result = clice::agentic::StatusResult;
     constexpr inline static std::string_view method = "agentic/status";
+};
+
+template <>
+struct NotificationTraits<clice::agentic::ShutdownParams> {
+    constexpr inline static std::string_view method = "agentic/shutdown";
 };
 
 }  // namespace kota::ipc::protocol

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -874,6 +874,11 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         result.indexed = static_cast<int>(ws.merged_indices.size());
         co_return result;
     });
+
+    peer.on_notification([&srv](const ShutdownParams&) {
+        LOG_INFO("agentic/shutdown received, shutting down");
+        srv.schedule_shutdown();
+    });
 }
 
 }  // namespace clice

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -75,6 +75,80 @@ static std::string read_file_lines(llvm::StringRef file_path, int start_line, in
     return content.slice(start_pos, end_pos).str();
 }
 
+struct DefinitionText {
+    std::string text;
+    int end_line;
+};
+
+static DefinitionText read_definition_text(llvm::StringRef file_path, int start_line) {
+    auto buf = llvm::MemoryBuffer::getFile(file_path);
+    if(!buf)
+        return {"", start_line};
+    llvm::StringRef content = (*buf)->getBuffer();
+
+    int current = 1;
+    std::size_t start_pos = 0;
+    while(current < start_line && start_pos < content.size()) {
+        if(content[start_pos] == '\n')
+            ++current;
+        ++start_pos;
+    }
+    if(current != start_line)
+        return {"", start_line};
+
+    int depth = 0;
+    bool found_brace = false;
+    std::size_t end_pos = start_pos;
+    int end_line = start_line;
+
+    while(end_pos < content.size()) {
+        char c = content[end_pos];
+        if(c == '{') {
+            ++depth;
+            found_brace = true;
+        } else if(c == '}') {
+            --depth;
+            if(found_brace && depth == 0) {
+                ++end_pos;
+                while(end_pos < content.size() && content[end_pos] != '\n')
+                    ++end_pos;
+                if(end_pos < content.size())
+                    ++end_pos;
+                return {content.slice(start_pos, end_pos).str(), end_line};
+            }
+        } else if(c == '\n') {
+            ++end_line;
+        } else if(c == '/' && end_pos + 1 < content.size()) {
+            if(content[end_pos + 1] == '/') {
+                while(end_pos < content.size() && content[end_pos] != '\n')
+                    ++end_pos;
+                continue;
+            }
+        } else if(c == '\'' || c == '"') {
+            char quote = c;
+            ++end_pos;
+            while(end_pos < content.size() && content[end_pos] != quote) {
+                if(content[end_pos] == '\\')
+                    ++end_pos;
+                ++end_pos;
+            }
+        }
+
+        if(!found_brace && c == ';') {
+            ++end_pos;
+            while(end_pos < content.size() && content[end_pos] != '\n')
+                ++end_pos;
+            if(end_pos < content.size())
+                ++end_pos;
+            return {content.slice(start_pos, end_pos).str(), end_line};
+        }
+
+        ++end_pos;
+    }
+
+    return {content.slice(start_pos, end_pos).str(), end_line};
+}
+
 static std::string path_from_uri(llvm::StringRef uri) {
     auto parsed = lsp::URI::parse(uri);
     if(parsed.has_value()) {
@@ -479,10 +553,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             auto file = path_from_uri(def_loc->uri);
             int start = static_cast<int>(def_loc->range.start.line) + 1;
-            int end = static_cast<int>(def_loc->range.end.line) + 1;
-            if(end < start)
-                end = start;
-            auto text = read_file_lines(file, start, end);
+            auto [text, end] = read_definition_text(file, start);
 
             co_return ReadSymbolResult{
                 .name = rs.name,
@@ -498,6 +569,11 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&,
                const DocumentSymbolsParams& params) -> RequestResult<DocumentSymbolsParams> {
+            auto is_document_level = [](SymbolKind kind) {
+                return kind != SymbolKind::Parameter && kind != SymbolKind::Label &&
+                       kind != SymbolKind::MacroParameter;
+            };
+
             DocumentSymbolsResult result;
 
             auto server_id = srv.workspace.path_pool.intern(params.path);
@@ -511,6 +587,8 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                         std::string name;
                         SymbolKind kind;
                         if(!srv.indexer.find_symbol_info(hash, name, kind))
+                            continue;
+                        if(!is_document_level(kind))
                             continue;
                         if(fi.mapper) {
                             auto start = fi.mapper->to_position(rel.range.begin);
@@ -542,6 +620,8 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             for(auto& [hash, symbol]: srv.workspace.project_index.symbols) {
                 if(symbol.name.empty())
+                    continue;
+                if(!is_document_level(symbol.kind))
                     continue;
                 if(!symbol.reference_files.contains(proj_id))
                     continue;
@@ -590,10 +670,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             if(def_loc) {
                 auto file = path_from_uri(def_loc->uri);
                 int start = static_cast<int>(def_loc->range.start.line) + 1;
-                int end = static_cast<int>(def_loc->range.end.line) + 1;
-                if(end < start)
-                    end = start;
-                auto text = read_file_lines(file, start, end);
+                auto [text, end] = read_definition_text(file, start);
                 result.definition = LocationEntry{
                     .file = std::move(file),
                     .start_line = start,

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -1,27 +1,259 @@
 #include "server/service/agent_client.h"
 
+#include <algorithm>
 #include <format>
+#include <ranges>
 #include <string>
 #include <vector>
 
 #include "server/protocol/agentic.h"
 #include "server/service/master_server.h"
+#include "support/filesystem.h"
+#include "support/logging.h"
+
+#include "kota/ipc/lsp/uri.h"
+#include "kota/meta/enum.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace clice {
 
 using kota::ipc::RequestResult;
 using RequestContext = kota::ipc::JsonPeer::RequestContext;
+namespace lsp = kota::ipc::lsp;
+namespace protocol = kota::ipc::protocol;
+
+static std::string_view symbol_kind_name(SymbolKind kind) {
+    constexpr auto names = kota::meta::reflection<SymbolKind::Kind>::member_names;
+    auto idx = static_cast<std::size_t>(kind.value());
+    if(idx < names.size())
+        return names[idx];
+    return "Unknown";
+}
+
+static std::string read_file_line(llvm::StringRef file_path, int line) {
+    auto buf = llvm::MemoryBuffer::getFile(file_path);
+    if(!buf)
+        return {};
+    llvm::StringRef content = (*buf)->getBuffer();
+    int current = 1;
+    std::size_t pos = 0;
+    while(current < line && pos < content.size()) {
+        if(content[pos] == '\n')
+            ++current;
+        ++pos;
+    }
+    if(current != line)
+        return {};
+    auto end = content.find('\n', pos);
+    if(end == llvm::StringRef::npos)
+        end = content.size();
+    return content.slice(pos, end).str();
+}
+
+static std::string read_file_lines(llvm::StringRef file_path, int start_line, int end_line) {
+    auto buf = llvm::MemoryBuffer::getFile(file_path);
+    if(!buf)
+        return {};
+    llvm::StringRef content = (*buf)->getBuffer();
+    int current = 1;
+    std::size_t start_pos = 0;
+    while(current < start_line && start_pos < content.size()) {
+        if(content[start_pos] == '\n')
+            ++current;
+        ++start_pos;
+    }
+    if(current != start_line)
+        return {};
+    std::size_t end_pos = start_pos;
+    while(current <= end_line && end_pos < content.size()) {
+        if(content[end_pos] == '\n')
+            ++current;
+        ++end_pos;
+    }
+    return content.slice(start_pos, end_pos).str();
+}
+
+static std::string path_from_uri(llvm::StringRef uri) {
+    auto parsed = lsp::URI::parse(uri);
+    if(parsed.has_value()) {
+        auto fp = parsed->file_path();
+        if(fp.has_value())
+            return std::move(*fp);
+    }
+    return uri.str();
+}
+
+struct ResolvedSymbol {
+    index::SymbolHash hash = 0;
+    std::string name;
+    SymbolKind kind;
+    std::string file;
+    int line = 0;
+};
+
+static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolParams& loc,
+                                                   Workspace& workspace,
+                                                   llvm::DenseMap<std::uint32_t, Session>& sessions,
+                                                   Indexer& indexer) {
+    if(loc.symbol_id.has_value() && *loc.symbol_id != 0) {
+        auto hash = static_cast<index::SymbolHash>(*loc.symbol_id);
+        std::string name;
+        SymbolKind kind;
+        if(!indexer.find_symbol_info(hash, name, kind))
+            return {};
+        auto def_loc = indexer.find_definition_location(hash);
+        if(!def_loc)
+            return {};
+        auto file = path_from_uri(def_loc->uri);
+        int line_num = static_cast<int>(def_loc->range.start.line) + 1;
+        return {
+            {hash, std::move(name), kind, std::move(file), line_num}
+        };
+    }
+
+    if(loc.name.has_value() && !loc.name->empty()) {
+        std::string query_lower = llvm::StringRef(*loc.name).lower();
+        std::vector<ResolvedSymbol> candidates;
+        std::vector<ResolvedSymbol> exact_matches;
+        llvm::DenseSet<index::SymbolHash> seen;
+
+        auto try_symbol = [&](index::SymbolHash hash, const index::Symbol& symbol) {
+            if(symbol.name.empty())
+                return;
+            if(llvm::StringRef(symbol.name).lower().find(query_lower) == std::string::npos)
+                return;
+            auto def_loc = indexer.find_definition_location(hash);
+            if(!def_loc)
+                return;
+            if(!seen.insert(hash).second)
+                return;
+
+            auto file = path_from_uri(def_loc->uri);
+            int line_num = static_cast<int>(def_loc->range.start.line) + 1;
+
+            if(loc.path.has_value() && !loc.path->empty()) {
+                if(!llvm::StringRef(file).ends_with(*loc.path) &&
+                   !llvm::StringRef(*loc.path).ends_with(llvm::sys::path::filename(file)))
+                    return;
+            }
+
+            bool is_exact = llvm::StringRef(symbol.name).lower() == query_lower ||
+                            llvm::StringRef(symbol.name).ends_with("::" + *loc.name);
+
+            ResolvedSymbol rs{hash, symbol.name, symbol.kind, std::move(file), line_num};
+            if(is_exact)
+                exact_matches.push_back(std::move(rs));
+            else
+                candidates.push_back(std::move(rs));
+        };
+
+        for(auto& [hash, symbol]: workspace.project_index.symbols)
+            try_symbol(hash, symbol);
+        for(auto& [_, sess]: sessions) {
+            if(!sess.file_index)
+                continue;
+            for(auto& [hash, symbol]: sess.file_index->symbols)
+                try_symbol(hash, symbol);
+        }
+
+        if(!exact_matches.empty())
+            return exact_matches;
+        return candidates;
+    }
+
+    if(loc.path.has_value() && loc.line.has_value()) {
+        auto path_str = *loc.path;
+        auto target_line = static_cast<protocol::uinteger>(*loc.line - 1);
+
+        auto server_id = workspace.path_pool.intern(path_str);
+        auto* sess = sessions.contains(server_id) ? &sessions[server_id] : nullptr;
+        if(sess && sess->file_index) {
+            auto& fi = *sess->file_index;
+            if(fi.mapper) {
+                for(auto& [hash, rels]: fi.file_index.relations) {
+                    for(auto& rel: rels) {
+                        if(rel.kind.value() != RelationKind::Definition)
+                            continue;
+                        auto start = fi.mapper->to_position(rel.range.begin);
+                        if(start && start->line == target_line) {
+                            std::string name;
+                            SymbolKind kind;
+                            if(indexer.find_symbol_info(hash, name, kind))
+                                return {
+                                    {hash, std::move(name), kind, path_str, *loc.line}
+                                };
+                        }
+                    }
+                }
+            }
+        }
+
+        auto it = workspace.project_index.path_pool.find(path_str);
+        if(it == workspace.project_index.path_pool.cache.end())
+            return {};
+
+        auto proj_id = it->second;
+        auto shard_it = workspace.merged_indices.find(proj_id);
+        if(shard_it == workspace.merged_indices.end())
+            return {};
+
+        for(auto& [hash, symbol]: workspace.project_index.symbols) {
+            if(!symbol.reference_files.contains(proj_id))
+                continue;
+            bool found = false;
+            shard_it->second.find_relations(hash,
+                                            RelationKind::Definition,
+                                            [&](const index::Relation&, protocol::Range range) {
+                                                if(range.start.line == target_line) {
+                                                    found = true;
+                                                    return false;
+                                                }
+                                                return true;
+                                            });
+            if(found)
+                return {
+                    {hash, symbol.name, symbol.kind, path_str, *loc.line}
+                };
+        }
+
+        return {};
+    }
+
+    return {};
+}
+
+static agentic::SymbolEntry to_symbol_entry(const ResolvedSymbol& rs) {
+    return {
+        .name = rs.name,
+        .kind = std::string(symbol_kind_name(rs.kind)),
+        .file = rs.file,
+        .line = rs.line,
+        .symbol_id = rs.hash,
+    };
+}
+
+static std::uint64_t extract_symbol_id(const std::optional<protocol::LSPAny>& data) {
+    if(!data.has_value())
+        return 0;
+    if(auto* val = std::get_if<std::int64_t>(&static_cast<const protocol::LSPVariant&>(*data)))
+        return static_cast<std::uint64_t>(*val);
+    return 0;
+}
 
 AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     server(server), peer(peer) {
     using namespace agentic;
 
+    auto& srv = this->server;
+
     peer.on_request(
-        [this](RequestContext&,
+        [&srv](RequestContext&,
                const CompileCommandParams& params) -> RequestResult<CompileCommandParams> {
             std::string directory;
             std::vector<std::string> arguments;
-            if(!this->server.compiler.fill_compile_args(params.path, directory, arguments)) {
+            if(!srv.compiler.fill_compile_args(params.path, directory, arguments)) {
                 co_return kota::outcome_error(
                     kota::ipc::Error{std::format("no compile command found for {}", params.path)});
             }
@@ -31,6 +263,529 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 .directory = std::move(directory),
                 .arguments = std::move(arguments),
             };
+        });
+
+    peer.on_request([&srv](RequestContext&,
+                           const ProjectFilesParams& params) -> RequestResult<ProjectFilesParams> {
+        auto& ws = srv.workspace;
+        auto filter = params.filter.value_or("all");
+
+        ProjectFilesResult result;
+        llvm::DenseSet<std::uint32_t> seen;
+
+        for(auto& entry: ws.cdb.get_entries()) {
+            if(!seen.insert(entry.file).second)
+                continue;
+            auto file_path = ws.cdb.resolve_path(entry.file);
+            if(file_path.empty())
+                continue;
+
+            std::string kind_str;
+            auto mod_it = ws.path_to_module.find(ws.path_pool.intern(file_path));
+            if(mod_it != ws.path_to_module.end()) {
+                kind_str = "module";
+            } else {
+                auto ext = llvm::sys::path::extension(file_path);
+                if(ext == ".h" || ext == ".hpp" || ext == ".hxx" || ext == ".hh")
+                    kind_str = "header";
+                else
+                    kind_str = "source";
+            }
+
+            if(filter != "all" && filter != kind_str)
+                continue;
+
+            FileInfo fi;
+            fi.path = file_path.str();
+            fi.kind = std::move(kind_str);
+            if(mod_it != ws.path_to_module.end())
+                fi.module_name = mod_it->second;
+            result.files.push_back(std::move(fi));
+        }
+
+        if(filter == "all" || filter == "header") {
+            for(auto& [path_id, shard]: ws.merged_indices) {
+                if(seen.contains(path_id))
+                    continue;
+                auto path_str = ws.project_index.path_pool.path(path_id);
+                auto ext = llvm::sys::path::extension(path_str);
+                if(ext == ".h" || ext == ".hpp" || ext == ".hxx" || ext == ".hh") {
+                    seen.insert(path_id);
+                    result.files.push_back(FileInfo{
+                        .path = path_str.str(),
+                        .kind = "header",
+                    });
+                }
+            }
+        }
+
+        result.total = static_cast<int>(result.files.size());
+        co_return result;
+    });
+
+    peer.on_request(
+        [&srv](RequestContext&, const FileDepsParams& params) -> RequestResult<FileDepsParams> {
+            auto& ws = srv.workspace;
+            auto path_id = ws.path_pool.intern(params.path);
+            auto direction = params.direction.value_or("both");
+            auto max_depth = params.depth.value_or(1);
+
+            FileDepsResult result;
+            result.file = params.path;
+
+            if(direction == "includes" || direction == "both") {
+                auto includes = ws.dep_graph.get_all_includes(path_id);
+                for(auto inc_id: includes) {
+                    auto real_id = inc_id & DependencyGraph::PATH_ID_MASK;
+                    auto inc_path = ws.path_pool.resolve(real_id);
+                    result.includes.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
+                }
+
+                if(max_depth == 0 || max_depth > 1) {
+                    llvm::DenseSet<std::uint32_t> visited;
+                    visited.insert(path_id);
+                    for(auto& dep: result.includes)
+                        visited.insert(ws.path_pool.intern(dep.path));
+
+                    for(std::size_t i = 0; i < result.includes.size(); ++i) {
+                        if(max_depth > 0 && result.includes[i].depth >= max_depth)
+                            continue;
+                        auto dep_id = ws.path_pool.intern(result.includes[i].path);
+                        auto sub = ws.dep_graph.get_all_includes(dep_id);
+                        for(auto sub_id: sub) {
+                            auto real_id = sub_id & DependencyGraph::PATH_ID_MASK;
+                            if(!visited.insert(real_id).second)
+                                continue;
+                            auto sub_path = ws.path_pool.resolve(real_id);
+                            result.includes.push_back(DepEntry{
+                                .path = sub_path.str(),
+                                .depth = result.includes[i].depth + 1,
+                            });
+                        }
+                    }
+                }
+            }
+
+            if(direction == "includers" || direction == "both") {
+                auto includers = ws.dep_graph.get_includers(path_id);
+                for(auto inc_id: includers) {
+                    auto inc_path = ws.path_pool.resolve(inc_id);
+                    result.includers.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
+                }
+            }
+
+            co_return result;
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&,
+               const ImpactAnalysisParams& params) -> RequestResult<ImpactAnalysisParams> {
+            auto& ws = srv.workspace;
+            auto path_id = ws.path_pool.intern(params.path);
+
+            ImpactAnalysisResult result;
+
+            auto direct_includers = ws.dep_graph.get_includers(path_id);
+            for(auto inc_id: direct_includers) {
+                result.direct_dependents.push_back(ws.path_pool.resolve(inc_id).str());
+            }
+
+            auto hosts = ws.dep_graph.find_host_sources(path_id);
+            llvm::DenseSet<std::uint32_t> seen;
+            seen.insert(path_id);
+            for(auto inc_id: direct_includers)
+                seen.insert(inc_id);
+            for(auto host_id: hosts) {
+                if(seen.insert(host_id).second)
+                    result.transitive_dependents.push_back(ws.path_pool.resolve(host_id).str());
+            }
+
+            for(auto host_id: hosts) {
+                auto it = ws.path_to_module.find(host_id);
+                if(it != ws.path_to_module.end())
+                    result.affected_modules.push_back(it->second);
+            }
+            auto mod_it = ws.path_to_module.find(path_id);
+            if(mod_it != ws.path_to_module.end())
+                result.affected_modules.push_back(mod_it->second);
+
+            co_return result;
+        });
+
+    peer.on_request([&srv](RequestContext&,
+                           const SymbolSearchParams& params) -> RequestResult<SymbolSearchParams> {
+        auto max = params.max_results.value_or(100);
+        std::string query_lower = llvm::StringRef(params.query).lower();
+
+        SymbolSearchResult result;
+        llvm::DenseSet<index::SymbolHash> seen;
+
+        auto try_symbol = [&](index::SymbolHash hash, const index::Symbol& symbol) {
+            if(static_cast<int>(result.symbols.size()) >= max)
+                return;
+            if(symbol.name.empty())
+                return;
+            if(!query_lower.empty() &&
+               llvm::StringRef(symbol.name).lower().find(query_lower) == std::string::npos)
+                return;
+            if(params.kind_filter.has_value()) {
+                auto kind_name = std::string(symbol_kind_name(symbol.kind));
+                auto& filter = *params.kind_filter;
+                if(std::ranges::find(filter, kind_name) == filter.end())
+                    return;
+            }
+            auto def_loc = srv.indexer.find_definition_location(hash);
+            if(!def_loc)
+                return;
+            if(!seen.insert(hash).second)
+                return;
+            auto file = path_from_uri(def_loc->uri);
+            result.symbols.push_back(SymbolEntry{
+                .name = symbol.name,
+                .kind = std::string(symbol_kind_name(symbol.kind)),
+                .file = std::move(file),
+                .line = static_cast<int>(def_loc->range.start.line) + 1,
+                .symbol_id = hash,
+            });
+        };
+
+        for(auto& [hash, symbol]: srv.workspace.project_index.symbols)
+            try_symbol(hash, symbol);
+        for(auto& [_, sess]: srv.sessions) {
+            if(!sess.file_index)
+                continue;
+            for(auto& [hash, symbol]: sess.file_index->symbols)
+                try_symbol(hash, symbol);
+        }
+
+        co_return result;
+    });
+
+    peer.on_request(
+        [&srv](RequestContext&, const ReadSymbolParams& params) -> RequestResult<ReadSymbolParams> {
+            auto candidates = resolve_locator(params, srv.workspace, srv.sessions, srv.indexer);
+            if(candidates.empty())
+                co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
+            if(candidates.size() > 1) {
+                co_return kota::outcome_error(kota::ipc::Error{
+                    std::format("ambiguous: {} candidates, use symbolId to disambiguate",
+                                candidates.size())});
+            }
+
+            auto& rs = candidates[0];
+            auto def_loc = srv.indexer.find_definition_location(rs.hash);
+            if(!def_loc)
+                co_return kota::outcome_error(kota::ipc::Error{"definition not found"});
+
+            auto file = path_from_uri(def_loc->uri);
+            int start = static_cast<int>(def_loc->range.start.line) + 1;
+            int end = static_cast<int>(def_loc->range.end.line) + 1;
+            if(end < start)
+                end = start;
+            auto text = read_file_lines(file, start, end);
+
+            co_return ReadSymbolResult{
+                .name = rs.name,
+                .kind = std::string(symbol_kind_name(rs.kind)),
+                .file = std::move(file),
+                .start_line = start,
+                .end_line = end,
+                .text = std::move(text),
+                .symbol_id = rs.hash,
+            };
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&,
+               const DocumentSymbolsParams& params) -> RequestResult<DocumentSymbolsParams> {
+            DocumentSymbolsResult result;
+
+            auto server_id = srv.workspace.path_pool.intern(params.path);
+            auto sess_it = srv.sessions.find(server_id);
+            if(sess_it != srv.sessions.end() && sess_it->second.file_index) {
+                auto& fi = *sess_it->second.file_index;
+                for(auto& [hash, rels]: fi.file_index.relations) {
+                    for(auto& rel: rels) {
+                        if(rel.kind.value() != RelationKind::Definition)
+                            continue;
+                        std::string name;
+                        SymbolKind kind;
+                        if(!srv.indexer.find_symbol_info(hash, name, kind))
+                            continue;
+                        if(fi.mapper) {
+                            auto start = fi.mapper->to_position(rel.range.begin);
+                            auto end = fi.mapper->to_position(rel.range.end);
+                            if(start && end) {
+                                result.symbols.push_back(DocumentSymbolEntry{
+                                    .name = std::move(name),
+                                    .kind = std::string(symbol_kind_name(kind)),
+                                    .start_line = static_cast<int>(start->line) + 1,
+                                    .end_line = static_cast<int>(end->line) + 1,
+                                    .symbol_id = hash,
+                                });
+                            }
+                        }
+                        break;
+                    }
+                }
+                co_return result;
+            }
+
+            auto it = srv.workspace.project_index.path_pool.find(params.path);
+            if(it == srv.workspace.project_index.path_pool.cache.end())
+                co_return result;
+
+            auto proj_id = it->second;
+            auto shard_it = srv.workspace.merged_indices.find(proj_id);
+            if(shard_it == srv.workspace.merged_indices.end())
+                co_return result;
+
+            for(auto& [hash, symbol]: srv.workspace.project_index.symbols) {
+                if(symbol.name.empty())
+                    continue;
+                if(!symbol.reference_files.contains(proj_id))
+                    continue;
+
+                shard_it->second.find_relations(
+                    hash,
+                    RelationKind::Definition,
+                    [&](const index::Relation&, protocol::Range range) {
+                        result.symbols.push_back(DocumentSymbolEntry{
+                            .name = symbol.name,
+                            .kind = std::string(symbol_kind_name(symbol.kind)),
+                            .start_line = static_cast<int>(range.start.line) + 1,
+                            .end_line = static_cast<int>(range.end.line) + 1,
+                            .symbol_id = hash,
+                        });
+                        return true;
+                    });
+            }
+
+            co_return result;
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&, const DefinitionParams& params) -> RequestResult<DefinitionParams> {
+            auto candidates = resolve_locator(
+                ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
+                srv.workspace,
+                srv.sessions,
+                srv.indexer);
+            if(candidates.empty())
+                co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
+            if(candidates.size() > 1) {
+                co_return kota::outcome_error(kota::ipc::Error{
+                    std::format("ambiguous: {} candidates, use symbolId to disambiguate",
+                                candidates.size())});
+            }
+
+            auto& rs = candidates[0];
+            auto def_loc = srv.indexer.find_definition_location(rs.hash);
+
+            DefinitionResult result;
+            result.name = rs.name;
+            result.kind = std::string(symbol_kind_name(rs.kind));
+            result.symbol_id = rs.hash;
+
+            if(def_loc) {
+                auto file = path_from_uri(def_loc->uri);
+                int start = static_cast<int>(def_loc->range.start.line) + 1;
+                int end = static_cast<int>(def_loc->range.end.line) + 1;
+                if(end < start)
+                    end = start;
+                auto text = read_file_lines(file, start, end);
+                result.definition = LocationEntry{
+                    .file = std::move(file),
+                    .start_line = start,
+                    .end_line = end,
+                    .text = std::move(text),
+                };
+            }
+
+            co_return result;
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&, const ReferencesParams& params) -> RequestResult<ReferencesParams> {
+            auto candidates = resolve_locator(
+                ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
+                srv.workspace,
+                srv.sessions,
+                srv.indexer);
+            if(candidates.empty())
+                co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
+            if(candidates.size() > 1) {
+                co_return kota::outcome_error(kota::ipc::Error{
+                    std::format("ambiguous: {} candidates, use symbolId to disambiguate",
+                                candidates.size())});
+            }
+
+            auto& rs = candidates[0];
+            auto& ws = srv.workspace;
+
+            ReferencesResult result;
+            result.name = rs.name;
+            result.kind = std::string(symbol_kind_name(rs.kind));
+            result.symbol_id = rs.hash;
+
+            auto collect = [&](RelationKind kind) {
+                auto sym_it = ws.project_index.symbols.find(rs.hash);
+                if(sym_it != ws.project_index.symbols.end()) {
+                    for(auto file_id: sym_it->second.reference_files) {
+                        auto shard_it = ws.merged_indices.find(file_id);
+                        if(shard_it == ws.merged_indices.end())
+                            continue;
+                        auto file_path = ws.project_index.path_pool.path(file_id);
+                        shard_it->second.find_relations(
+                            rs.hash,
+                            kind,
+                            [&](const auto&, protocol::Range range) {
+                                int line_num = static_cast<int>(range.start.line) + 1;
+                                result.references.push_back(ReferenceEntry{
+                                    .file = file_path.str(),
+                                    .line = line_num,
+                                    .context = read_file_line(file_path, line_num),
+                                });
+                                return true;
+                            });
+                    }
+                }
+                for(auto& [sid, sess]: srv.sessions) {
+                    if(!sess.file_index)
+                        continue;
+                    auto file_path = ws.path_pool.resolve(sid);
+                    sess.file_index->find_relations(
+                        rs.hash,
+                        kind,
+                        [&](const auto&, protocol::Range range) {
+                            int line_num = static_cast<int>(range.start.line) + 1;
+                            result.references.push_back(ReferenceEntry{
+                                .file = file_path.str(),
+                                .line = line_num,
+                                .context = read_file_line(file_path, line_num),
+                            });
+                            return true;
+                        });
+                }
+            };
+
+            collect(RelationKind::Reference);
+            if(params.include_declaration.value_or(false))
+                collect(RelationKind::Definition);
+
+            result.total = static_cast<int>(result.references.size());
+            co_return result;
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&, const CallGraphParams& params) -> RequestResult<CallGraphParams> {
+            auto candidates = resolve_locator(
+                ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
+                srv.workspace,
+                srv.sessions,
+                srv.indexer);
+            if(candidates.empty())
+                co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
+            if(candidates.size() > 1) {
+                co_return kota::outcome_error(kota::ipc::Error{
+                    std::format("ambiguous: {} candidates, use symbolId to disambiguate",
+                                candidates.size())});
+            }
+
+            auto& rs = candidates[0];
+            auto direction = params.direction.value_or("both");
+
+            CallGraphResult result;
+            result.root = CallGraphEntry{
+                .name = rs.name,
+                .kind = std::string(symbol_kind_name(rs.kind)),
+                .file = rs.file,
+                .line = rs.line,
+                .symbol_id = rs.hash,
+            };
+
+            if(direction == "callers" || direction == "both") {
+                auto incoming = srv.indexer.find_incoming_calls(rs.hash);
+                for(auto& call: incoming) {
+                    result.callers.push_back(CallGraphEntry{
+                        .name = call.from.name,
+                        .kind = std::string("Function"),
+                        .file = path_from_uri(call.from.uri),
+                        .line = static_cast<int>(call.from.range.start.line) + 1,
+                        .symbol_id = extract_symbol_id(call.from.data),
+                    });
+                }
+            }
+
+            if(direction == "callees" || direction == "both") {
+                auto outgoing = srv.indexer.find_outgoing_calls(rs.hash);
+                for(auto& call: outgoing) {
+                    result.callees.push_back(CallGraphEntry{
+                        .name = call.to.name,
+                        .kind = std::string("Function"),
+                        .file = path_from_uri(call.to.uri),
+                        .line = static_cast<int>(call.to.range.start.line) + 1,
+                        .symbol_id = extract_symbol_id(call.to.data),
+                    });
+                }
+            }
+
+            co_return result;
+        });
+
+    peer.on_request(
+        [&srv](RequestContext&,
+               const TypeHierarchyParams& params) -> RequestResult<TypeHierarchyParams> {
+            auto candidates = resolve_locator(
+                ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
+                srv.workspace,
+                srv.sessions,
+                srv.indexer);
+            if(candidates.empty())
+                co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
+            if(candidates.size() > 1) {
+                co_return kota::outcome_error(kota::ipc::Error{
+                    std::format("ambiguous: {} candidates, use symbolId to disambiguate",
+                                candidates.size())});
+            }
+
+            auto& rs = candidates[0];
+            auto direction = params.direction.value_or("both");
+
+            TypeHierarchyResult result;
+            result.root = TypeHierarchyEntry{
+                .name = rs.name,
+                .kind = std::string(symbol_kind_name(rs.kind)),
+                .file = rs.file,
+                .line = rs.line,
+                .symbol_id = rs.hash,
+            };
+
+            if(direction == "supertypes" || direction == "both") {
+                for(auto& item: srv.indexer.find_supertypes(rs.hash)) {
+                    result.supertypes.push_back(TypeHierarchyEntry{
+                        .name = item.name,
+                        .kind = std::string("Class"),
+                        .file = path_from_uri(item.uri),
+                        .line = static_cast<int>(item.range.start.line) + 1,
+                        .symbol_id = extract_symbol_id(item.data),
+                    });
+                }
+            }
+
+            if(direction == "subtypes" || direction == "both") {
+                for(auto& item: srv.indexer.find_subtypes(rs.hash)) {
+                    result.subtypes.push_back(TypeHierarchyEntry{
+                        .name = item.name,
+                        .kind = std::string("Class"),
+                        .file = path_from_uri(item.uri),
+                        .line = static_cast<int>(item.range.start.line) + 1,
+                        .symbol_id = extract_symbol_id(item.data),
+                    });
+                }
+            }
+
+            co_return result;
         });
 }
 

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -864,6 +864,16 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             co_return result;
         });
+
+    peer.on_request([&srv](RequestContext&, const StatusParams&) -> RequestResult<StatusParams> {
+        auto& ws = srv.workspace;
+        StatusResult result;
+        result.idle = srv.indexer.is_idle();
+        result.pending = static_cast<int>(srv.indexer.pending_files());
+        result.total = static_cast<int>(ws.cdb.get_entries().size());
+        result.indexed = static_cast<int>(ws.merged_indices.size());
+        co_return result;
+    });
 }
 
 }  // namespace clice

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -31,16 +31,6 @@ static std::string_view symbol_kind_name(SymbolKind kind) {
     return "Unknown";
 }
 
-static std::string path_from_uri(llvm::StringRef uri) {
-    auto parsed = lsp::URI::parse(uri);
-    if(parsed.has_value()) {
-        auto fp = parsed->file_path();
-        if(fp.has_value())
-            return std::move(*fp);
-    }
-    return uri.str();
-}
-
 struct ResolvedSymbol {
     index::SymbolHash hash = 0;
     std::string name;
@@ -62,7 +52,7 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
         auto def_loc = indexer.find_definition_location(hash);
         if(!def_loc)
             return {};
-        auto file = path_from_uri(def_loc->uri);
+        auto file = uri_to_path(def_loc->uri);
         int line_num = static_cast<int>(def_loc->range.start.line) + 1;
         return {
             {hash, std::move(name), kind, std::move(file), line_num}
@@ -86,7 +76,7 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
             if(!seen.insert(hash).second)
                 return;
 
-            auto file = path_from_uri(def_loc->uri);
+            auto file = uri_to_path(def_loc->uri);
             int line_num = static_cast<int>(def_loc->range.start.line) + 1;
 
             if(loc.path.has_value() && !loc.path->empty()) {
@@ -187,21 +177,12 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
     return {};
 }
 
-static agentic::SymbolEntry to_symbol_entry(const ResolvedSymbol& rs) {
-    return {
-        .name = rs.name,
-        .kind = std::string(symbol_kind_name(rs.kind)),
-        .file = rs.file,
-        .line = rs.line,
-        .symbol_id = rs.hash,
-    };
-}
-
 static std::uint64_t extract_symbol_id(const std::optional<protocol::LSPAny>& data) {
     if(!data.has_value())
         return 0;
     if(auto* val = std::get_if<std::int64_t>(&static_cast<const protocol::LSPVariant&>(*data)))
         return static_cast<std::uint64_t>(*val);
+    LOG_WARN("extract_symbol_id: unexpected LSPAny variant type");
     return 0;
 }
 
@@ -237,11 +218,15 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         llvm::DenseSet<std::uint32_t> seen;
 
         for(auto& entry: ws.cdb.get_entries()) {
-            if(!seen.insert(entry.file).second)
-                continue;
             auto file_path = ws.cdb.resolve_path(entry.file);
             if(file_path.empty())
                 continue;
+
+            auto proj_it = ws.project_index.path_pool.find(file_path);
+            if(proj_it != ws.project_index.path_pool.cache.end()) {
+                if(!seen.insert(proj_it->second).second)
+                    continue;
+            }
 
             std::string kind_str;
             auto mod_it = ws.path_to_module.find(ws.path_pool.intern(file_path));
@@ -342,8 +327,11 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 if(max_depth == 0 || max_depth > 1) {
                     llvm::DenseSet<std::uint32_t> visited;
                     visited.insert(path_id);
-                    for(auto& dep: result.includers)
-                        visited.insert(ws.path_pool.cache.find(dep.path)->second);
+                    for(auto& dep: result.includers) {
+                        auto it = ws.path_pool.cache.find(dep.path);
+                        if(it != ws.path_pool.cache.end())
+                            visited.insert(it->second);
+                    }
 
                     for(std::size_t i = 0; i < result.includers.size(); ++i) {
                         if(max_depth > 0 && result.includers[i].depth >= max_depth)
@@ -433,7 +421,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 return;
             if(!seen.insert(hash).second)
                 return;
-            auto file = path_from_uri(def_loc->uri);
+            auto file = uri_to_path(def_loc->uri);
             result.symbols.push_back(SymbolEntry{
                 .name = symbol.name,
                 .kind = std::string(symbol_kind_name(symbol.kind)),
@@ -486,8 +474,14 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         [&srv](RequestContext&,
                const DocumentSymbolsParams& params) -> RequestResult<DocumentSymbolsParams> {
             auto is_document_level = [](SymbolKind kind) {
-                return kind != SymbolKind::Parameter && kind != SymbolKind::Label &&
-                       kind != SymbolKind::MacroParameter;
+                return kind == SymbolKind::Namespace || kind == SymbolKind::Class ||
+                       kind == SymbolKind::Struct || kind == SymbolKind::Union ||
+                       kind == SymbolKind::Enum || kind == SymbolKind::Type ||
+                       kind == SymbolKind::Field || kind == SymbolKind::EnumMember ||
+                       kind == SymbolKind::Function || kind == SymbolKind::Method ||
+                       kind == SymbolKind::Variable || kind == SymbolKind::Macro ||
+                       kind == SymbolKind::Concept || kind == SymbolKind::Module ||
+                       kind == SymbolKind::Operator || kind == SymbolKind::Attribute;
             };
 
             DocumentSymbolsResult result;
@@ -520,9 +514,9 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                                     .end_line = static_cast<int>(end->line) + 1,
                                     .symbol_id = hash,
                                 });
+                                break;
                             }
                         }
-                        break;
                     }
                 }
                 co_return result;
@@ -667,15 +661,26 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 .symbol_id = rs.hash,
             };
 
+            auto resolve_kind = [&](std::uint64_t sym_id) -> std::string {
+                if(sym_id == 0)
+                    return "Function";
+                std::string name;
+                SymbolKind kind;
+                if(srv.indexer.find_symbol_info(sym_id, name, kind))
+                    return std::string(symbol_kind_name(kind));
+                return "Function";
+            };
+
             if(direction == "callers" || direction == "both") {
                 auto incoming = srv.indexer.find_incoming_calls(rs.hash);
                 for(auto& call: incoming) {
+                    auto sid = extract_symbol_id(call.from.data);
                     result.callers.push_back(CallGraphEntry{
                         .name = call.from.name,
-                        .kind = std::string("Function"),
-                        .file = path_from_uri(call.from.uri),
+                        .kind = resolve_kind(sid),
+                        .file = uri_to_path(call.from.uri),
                         .line = static_cast<int>(call.from.range.start.line) + 1,
-                        .symbol_id = extract_symbol_id(call.from.data),
+                        .symbol_id = sid,
                     });
                 }
             }
@@ -683,12 +688,13 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             if(direction == "callees" || direction == "both") {
                 auto outgoing = srv.indexer.find_outgoing_calls(rs.hash);
                 for(auto& call: outgoing) {
+                    auto sid = extract_symbol_id(call.to.data);
                     result.callees.push_back(CallGraphEntry{
                         .name = call.to.name,
-                        .kind = std::string("Function"),
-                        .file = path_from_uri(call.to.uri),
+                        .kind = resolve_kind(sid),
+                        .file = uri_to_path(call.to.uri),
                         .line = static_cast<int>(call.to.range.start.line) + 1,
-                        .symbol_id = extract_symbol_id(call.to.data),
+                        .symbol_id = sid,
                     });
                 }
             }
@@ -724,26 +730,38 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                 .symbol_id = rs.hash,
             };
 
+            auto resolve_kind = [&](std::uint64_t sym_id) -> std::string {
+                if(sym_id == 0)
+                    return "Class";
+                std::string name;
+                SymbolKind kind;
+                if(srv.indexer.find_symbol_info(sym_id, name, kind))
+                    return std::string(symbol_kind_name(kind));
+                return "Class";
+            };
+
             if(direction == "supertypes" || direction == "both") {
                 for(auto& item: srv.indexer.find_supertypes(rs.hash)) {
+                    auto sid = extract_symbol_id(item.data);
                     result.supertypes.push_back(TypeHierarchyEntry{
                         .name = item.name,
-                        .kind = std::string("Class"),
-                        .file = path_from_uri(item.uri),
+                        .kind = resolve_kind(sid),
+                        .file = uri_to_path(item.uri),
                         .line = static_cast<int>(item.range.start.line) + 1,
-                        .symbol_id = extract_symbol_id(item.data),
+                        .symbol_id = sid,
                     });
                 }
             }
 
             if(direction == "subtypes" || direction == "both") {
                 for(auto& item: srv.indexer.find_subtypes(rs.hash)) {
+                    auto sid = extract_symbol_id(item.data);
                     result.subtypes.push_back(TypeHierarchyEntry{
                         .name = item.name,
-                        .kind = std::string("Class"),
-                        .file = path_from_uri(item.uri),
+                        .kind = resolve_kind(sid),
+                        .file = uri_to_path(item.uri),
                         .line = static_cast<int>(item.range.start.line) + 1,
-                        .symbol_id = extract_symbol_id(item.data),
+                        .symbol_id = sid,
                     });
                 }
             }

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -15,7 +15,6 @@
 #include "kota/meta/enum.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/MemoryBuffer.h"
 
 namespace clice {
 
@@ -30,123 +29,6 @@ static std::string_view symbol_kind_name(SymbolKind kind) {
     if(idx < names.size())
         return names[idx];
     return "Unknown";
-}
-
-static std::string read_file_line(llvm::StringRef file_path, int line) {
-    auto buf = llvm::MemoryBuffer::getFile(file_path);
-    if(!buf)
-        return {};
-    llvm::StringRef content = (*buf)->getBuffer();
-    int current = 1;
-    std::size_t pos = 0;
-    while(current < line && pos < content.size()) {
-        if(content[pos] == '\n')
-            ++current;
-        ++pos;
-    }
-    if(current != line)
-        return {};
-    auto end = content.find('\n', pos);
-    if(end == llvm::StringRef::npos)
-        end = content.size();
-    return content.slice(pos, end).str();
-}
-
-static std::string read_file_lines(llvm::StringRef file_path, int start_line, int end_line) {
-    auto buf = llvm::MemoryBuffer::getFile(file_path);
-    if(!buf)
-        return {};
-    llvm::StringRef content = (*buf)->getBuffer();
-    int current = 1;
-    std::size_t start_pos = 0;
-    while(current < start_line && start_pos < content.size()) {
-        if(content[start_pos] == '\n')
-            ++current;
-        ++start_pos;
-    }
-    if(current != start_line)
-        return {};
-    std::size_t end_pos = start_pos;
-    while(current <= end_line && end_pos < content.size()) {
-        if(content[end_pos] == '\n')
-            ++current;
-        ++end_pos;
-    }
-    return content.slice(start_pos, end_pos).str();
-}
-
-struct DefinitionText {
-    std::string text;
-    int end_line;
-};
-
-static DefinitionText read_definition_text(llvm::StringRef file_path, int start_line) {
-    auto buf = llvm::MemoryBuffer::getFile(file_path);
-    if(!buf)
-        return {"", start_line};
-    llvm::StringRef content = (*buf)->getBuffer();
-
-    int current = 1;
-    std::size_t start_pos = 0;
-    while(current < start_line && start_pos < content.size()) {
-        if(content[start_pos] == '\n')
-            ++current;
-        ++start_pos;
-    }
-    if(current != start_line)
-        return {"", start_line};
-
-    int depth = 0;
-    bool found_brace = false;
-    std::size_t end_pos = start_pos;
-    int end_line = start_line;
-
-    while(end_pos < content.size()) {
-        char c = content[end_pos];
-        if(c == '{') {
-            ++depth;
-            found_brace = true;
-        } else if(c == '}') {
-            --depth;
-            if(found_brace && depth == 0) {
-                ++end_pos;
-                while(end_pos < content.size() && content[end_pos] != '\n')
-                    ++end_pos;
-                if(end_pos < content.size())
-                    ++end_pos;
-                return {content.slice(start_pos, end_pos).str(), end_line};
-            }
-        } else if(c == '\n') {
-            ++end_line;
-        } else if(c == '/' && end_pos + 1 < content.size()) {
-            if(content[end_pos + 1] == '/') {
-                while(end_pos < content.size() && content[end_pos] != '\n')
-                    ++end_pos;
-                continue;
-            }
-        } else if(c == '\'' || c == '"') {
-            char quote = c;
-            ++end_pos;
-            while(end_pos < content.size() && content[end_pos] != quote) {
-                if(content[end_pos] == '\\')
-                    ++end_pos;
-                ++end_pos;
-            }
-        }
-
-        if(!found_brace && c == ';') {
-            ++end_pos;
-            while(end_pos < content.size() && content[end_pos] != '\n')
-                ++end_pos;
-            if(end_pos < content.size())
-                ++end_pos;
-            return {content.slice(start_pos, end_pos).str(), end_line};
-        }
-
-        ++end_pos;
-    }
-
-    return {content.slice(start_pos, end_pos).str(), end_line};
 }
 
 static std::string path_from_uri(llvm::StringRef uri) {
@@ -208,9 +90,14 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
             int line_num = static_cast<int>(def_loc->range.start.line) + 1;
 
             if(loc.path.has_value() && !loc.path->empty()) {
-                if(!llvm::StringRef(file).ends_with(*loc.path) &&
-                   !llvm::StringRef(*loc.path).ends_with(llvm::sys::path::filename(file)))
+                llvm::StringRef wanted(*loc.path);
+                bool basename_only = wanted.find_last_of("/\\") == llvm::StringRef::npos;
+                if(basename_only) {
+                    if(llvm::sys::path::filename(file) != wanted)
+                        return;
+                } else if(!llvm::StringRef(file).ends_with(wanted)) {
                     return;
+                }
             }
 
             bool is_exact = llvm::StringRef(symbol.name).lower() == query_lower ||
@@ -241,8 +128,10 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
         auto path_str = *loc.path;
         auto target_line = static_cast<protocol::uinteger>(*loc.line - 1);
 
-        auto server_id = workspace.path_pool.intern(path_str);
-        auto* sess = sessions.contains(server_id) ? &sessions[server_id] : nullptr;
+        auto pool_it = workspace.path_pool.cache.find(path_str);
+        auto server_id = pool_it != workspace.path_pool.cache.end() ? pool_it->second : ~0u;
+        auto* sess =
+            server_id != ~0u && sessions.contains(server_id) ? &sessions[server_id] : nullptr;
         if(sess && sess->file_index) {
             auto& fi = *sess->file_index;
             if(fi.mapper) {
@@ -400,7 +289,10 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
     peer.on_request(
         [&srv](RequestContext&, const FileDepsParams& params) -> RequestResult<FileDepsParams> {
             auto& ws = srv.workspace;
-            auto path_id = ws.path_pool.intern(params.path);
+            auto pool_it = ws.path_pool.cache.find(params.path);
+            if(pool_it == ws.path_pool.cache.end())
+                co_return FileDepsResult{.file = params.path};
+            auto path_id = pool_it->second;
             auto direction = params.direction.value_or("both");
             auto max_depth = params.depth.value_or(1);
 
@@ -446,6 +338,31 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                     auto inc_path = ws.path_pool.resolve(inc_id);
                     result.includers.push_back(DepEntry{.path = inc_path.str(), .depth = 1});
                 }
+
+                if(max_depth == 0 || max_depth > 1) {
+                    llvm::DenseSet<std::uint32_t> visited;
+                    visited.insert(path_id);
+                    for(auto& dep: result.includers)
+                        visited.insert(ws.path_pool.cache.find(dep.path)->second);
+
+                    for(std::size_t i = 0; i < result.includers.size(); ++i) {
+                        if(max_depth > 0 && result.includers[i].depth >= max_depth)
+                            continue;
+                        auto dep_it = ws.path_pool.cache.find(result.includers[i].path);
+                        if(dep_it == ws.path_pool.cache.end())
+                            continue;
+                        auto sub = ws.dep_graph.get_includers(dep_it->second);
+                        for(auto sub_id: sub) {
+                            if(!visited.insert(sub_id).second)
+                                continue;
+                            auto sub_path = ws.path_pool.resolve(sub_id);
+                            result.includers.push_back(DepEntry{
+                                .path = sub_path.str(),
+                                .depth = result.includers[i].depth + 1,
+                            });
+                        }
+                    }
+                }
             }
 
             co_return result;
@@ -455,7 +372,10 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         [&srv](RequestContext&,
                const ImpactAnalysisParams& params) -> RequestResult<ImpactAnalysisParams> {
             auto& ws = srv.workspace;
-            auto path_id = ws.path_pool.intern(params.path);
+            auto pool_it = ws.path_pool.cache.find(params.path);
+            if(pool_it == ws.path_pool.cache.end())
+                co_return ImpactAnalysisResult{};
+            auto path_id = pool_it->second;
 
             ImpactAnalysisResult result;
 
@@ -547,21 +467,17 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             }
 
             auto& rs = candidates[0];
-            auto def_loc = srv.indexer.find_definition_location(rs.hash);
-            if(!def_loc)
+            auto def_text = srv.indexer.get_definition_text(rs.hash);
+            if(!def_text)
                 co_return kota::outcome_error(kota::ipc::Error{"definition not found"});
-
-            auto file = path_from_uri(def_loc->uri);
-            int start = static_cast<int>(def_loc->range.start.line) + 1;
-            auto [text, end] = read_definition_text(file, start);
 
             co_return ReadSymbolResult{
                 .name = rs.name,
                 .kind = std::string(symbol_kind_name(rs.kind)),
-                .file = std::move(file),
-                .start_line = start,
-                .end_line = end,
-                .text = std::move(text),
+                .file = std::move(def_text->file),
+                .start_line = def_text->start_line,
+                .end_line = def_text->end_line,
+                .text = std::move(def_text->text),
                 .symbol_id = rs.hash,
             };
         });
@@ -576,7 +492,10 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
             DocumentSymbolsResult result;
 
-            auto server_id = srv.workspace.path_pool.intern(params.path);
+            auto pool_it = srv.workspace.path_pool.cache.find(params.path);
+            if(pool_it == srv.workspace.path_pool.cache.end())
+                co_return result;
+            auto server_id = pool_it->second;
             auto sess_it = srv.sessions.find(server_id);
             if(sess_it != srv.sessions.end() && sess_it->second.file_index) {
                 auto& fi = *sess_it->second.file_index;
@@ -660,22 +579,18 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             }
 
             auto& rs = candidates[0];
-            auto def_loc = srv.indexer.find_definition_location(rs.hash);
 
             DefinitionResult result;
             result.name = rs.name;
             result.kind = std::string(symbol_kind_name(rs.kind));
             result.symbol_id = rs.hash;
 
-            if(def_loc) {
-                auto file = path_from_uri(def_loc->uri);
-                int start = static_cast<int>(def_loc->range.start.line) + 1;
-                auto [text, end] = read_definition_text(file, start);
+            if(auto def_text = srv.indexer.get_definition_text(rs.hash)) {
                 result.definition = LocationEntry{
-                    .file = std::move(file),
-                    .start_line = start,
-                    .end_line = end,
-                    .text = std::move(text),
+                    .file = std::move(def_text->file),
+                    .start_line = def_text->start_line,
+                    .end_line = def_text->end_line,
+                    .text = std::move(def_text->text),
                 };
             }
 
@@ -698,57 +613,28 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             }
 
             auto& rs = candidates[0];
-            auto& ws = srv.workspace;
 
             ReferencesResult result;
             result.name = rs.name;
             result.kind = std::string(symbol_kind_name(rs.kind));
             result.symbol_id = rs.hash;
 
-            auto collect = [&](RelationKind kind) {
-                auto sym_it = ws.project_index.symbols.find(rs.hash);
-                if(sym_it != ws.project_index.symbols.end()) {
-                    for(auto file_id: sym_it->second.reference_files) {
-                        auto shard_it = ws.merged_indices.find(file_id);
-                        if(shard_it == ws.merged_indices.end())
-                            continue;
-                        auto file_path = ws.project_index.path_pool.path(file_id);
-                        shard_it->second.find_relations(
-                            rs.hash,
-                            kind,
-                            [&](const auto&, protocol::Range range) {
-                                int line_num = static_cast<int>(range.start.line) + 1;
-                                result.references.push_back(ReferenceEntry{
-                                    .file = file_path.str(),
-                                    .line = line_num,
-                                    .context = read_file_line(file_path, line_num),
-                                });
-                                return true;
-                            });
-                    }
+            for(auto& ref: srv.indexer.collect_references(rs.hash, RelationKind::Reference)) {
+                result.references.push_back(ReferenceEntry{
+                    .file = std::move(ref.file),
+                    .line = ref.line,
+                    .context = std::move(ref.context),
+                });
+            }
+            if(params.include_declaration.value_or(false)) {
+                for(auto& ref: srv.indexer.collect_references(rs.hash, RelationKind::Definition)) {
+                    result.references.push_back(ReferenceEntry{
+                        .file = std::move(ref.file),
+                        .line = ref.line,
+                        .context = std::move(ref.context),
+                    });
                 }
-                for(auto& [sid, sess]: srv.sessions) {
-                    if(!sess.file_index)
-                        continue;
-                    auto file_path = ws.path_pool.resolve(sid);
-                    sess.file_index->find_relations(
-                        rs.hash,
-                        kind,
-                        [&](const auto&, protocol::Range range) {
-                            int line_num = static_cast<int>(range.start.line) + 1;
-                            result.references.push_back(ReferenceEntry{
-                                .file = file_path.str(),
-                                .line = line_num,
-                                .context = read_file_line(file_path, line_num),
-                            });
-                            return true;
-                        });
-                }
-            };
-
-            collect(RelationKind::Reference);
-            if(params.include_declaration.value_or(false))
-                collect(RelationKind::Definition);
+            }
 
             result.total = static_cast<int>(result.references.size());
             co_return result;
@@ -866,12 +752,11 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
         });
 
     peer.on_request([&srv](RequestContext&, const StatusParams&) -> RequestResult<StatusParams> {
-        auto& ws = srv.workspace;
         StatusResult result;
         result.idle = srv.indexer.is_idle();
         result.pending = static_cast<int>(srv.indexer.pending_files());
-        result.total = static_cast<int>(ws.cdb.get_entries().size());
-        result.indexed = static_cast<int>(ws.merged_indices.size());
+        result.total = static_cast<int>(srv.indexer.total_queued());
+        result.indexed = std::max(0, result.total - result.pending);
         co_return result;
     });
 

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -14,45 +14,91 @@
 
 namespace clice {
 
-static kota::task<> agentic_request(kota::ipc::JsonPeer& peer, int& exit_code, std::string path) {
-    auto result =
-        co_await peer.send_request(agentic::CompileCommandParams{.path = std::move(path)});
-
+template <typename Params>
+static kota::task<bool> send_and_print(kota::ipc::JsonPeer& peer, Params params) {
+    auto result = co_await peer.send_request(std::move(params));
     if(!result) {
         LOG_ERROR("request failed: {}", result.error().message);
+        co_return false;
+    }
+    auto json = kota::codec::json::to_string<kota::ipc::lsp_config>(*result);
+    std::println("{}", json ? *json : "null");
+    co_return true;
+}
+
+static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
+                                    int& exit_code,
+                                    const AgenticQueryOptions& opts) {
+    bool ok = false;
+
+    if(opts.method == "compileCommand") {
+        ok = co_await send_and_print(peer, agentic::CompileCommandParams{.path = opts.path});
+    } else if(opts.method == "projectFiles") {
+        auto filter = opts.query.empty() ? std::nullopt : std::optional(opts.query);
+        ok = co_await send_and_print(peer, agentic::ProjectFilesParams{.filter = filter});
+    } else if(opts.method == "symbolSearch") {
+        ok = co_await send_and_print(peer, agentic::SymbolSearchParams{.query = opts.query});
+    } else if(opts.method == "definition") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
+        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+        ok = co_await send_and_print(
+            peer,
+            agentic::DefinitionParams{.name = name, .path = path, .line = line});
+    } else if(opts.method == "references") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        ok = co_await send_and_print(peer, agentic::ReferencesParams{.name = name});
+    } else if(opts.method == "readSymbol") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        ok = co_await send_and_print(peer, agentic::ReadSymbolParams{.name = name});
+    } else if(opts.method == "documentSymbols") {
+        ok = co_await send_and_print(peer, agentic::DocumentSymbolsParams{.path = opts.path});
+    } else if(opts.method == "callGraph") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+        ok =
+            co_await send_and_print(peer, agentic::CallGraphParams{.name = name, .direction = dir});
+    } else if(opts.method == "typeHierarchy") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+        ok = co_await send_and_print(peer,
+                                     agentic::TypeHierarchyParams{.name = name, .direction = dir});
+    } else if(opts.method == "fileDeps") {
+        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+        ok = co_await send_and_print(peer,
+                                     agentic::FileDepsParams{.path = opts.path, .direction = dir});
+    } else if(opts.method == "impactAnalysis") {
+        ok = co_await send_and_print(peer, agentic::ImpactAnalysisParams{.path = opts.path});
     } else {
-        auto json = kota::codec::json::to_string<kota::ipc::lsp_config>(*result);
-        std::println("{}", json ? *json : "null");
-        exit_code = 0;
+        LOG_ERROR("unknown agentic method '{}'", opts.method);
     }
 
+    if(ok)
+        exit_code = 0;
     peer.close();
 }
 
 static kota::task<> agentic_client(int& exit_code,
                                    std::unique_ptr<kota::ipc::JsonPeer>& peer_out,
-                                   std::string host,
-                                   int port,
-                                   std::string path) {
+                                   const AgenticQueryOptions& opts) {
     auto& loop = kota::event_loop::current();
-    auto transport = co_await kota::ipc::StreamTransport::connect_tcp(host, port, loop);
+    auto transport = co_await kota::ipc::StreamTransport::connect_tcp(opts.host, opts.port, loop);
     if(!transport) {
-        LOG_ERROR("failed to connect to {}:{}", host, port);
+        LOG_ERROR("failed to connect to {}:{}", opts.host, opts.port);
         co_return;
     }
 
     peer_out = std::make_unique<kota::ipc::JsonPeer>(loop, std::move(*transport));
-    co_await kota::when_all(peer_out->run(),
-                            agentic_request(*peer_out, exit_code, std::move(path)));
+    co_await kota::when_all(peer_out->run(), agentic_request(*peer_out, exit_code, opts));
 }
 
-int run_agentic_mode(llvm::StringRef host, int port, llvm::StringRef path) {
+int run_agentic_mode(const AgenticQueryOptions& opts) {
     logging::stderr_logger("agentic", logging::options);
 
     kota::event_loop loop;
     int exit_code = 1;
     std::unique_ptr<kota::ipc::JsonPeer> peer;
-    loop.schedule(agentic_client(exit_code, peer, host.str(), port, path.str()));
+    loop.schedule(agentic_client(exit_code, peer, opts));
     loop.run();
     return exit_code;
 }

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -10,6 +10,7 @@
 #include "kota/async/async.h"
 #include "kota/ipc/codec/json.h"
 #include "kota/ipc/transport.h"
+#include "llvm/Support/Path.h"
 
 namespace clice {
 
@@ -54,6 +55,56 @@ int run_agentic_mode(llvm::StringRef host, int port, llvm::StringRef path) {
     loop.schedule(agentic_client(exit_code, peer, host.str(), port, path.str()));
     loop.run();
     return exit_code;
+}
+
+static kota::task<> relay_forward(kota::ipc::Transport& from, kota::ipc::Transport& to) {
+    while(true) {
+        auto msg = co_await from.read_message();
+        if(!msg)
+            break;
+        co_await to.write_message(*msg);
+    }
+    to.close();
+}
+
+static kota::task<> relay_main(kota::event_loop& loop, std::string socket_path) {
+    auto stdio = kota::ipc::StreamTransport::open_stdio(loop);
+    if(!stdio) {
+        LOG_ERROR("failed to open stdio transport");
+        loop.stop();
+        co_return;
+    }
+
+    auto conn = co_await kota::pipe::connect(socket_path, {}, loop);
+    if(!conn) {
+        LOG_ERROR("failed to connect to {}", socket_path);
+        loop.stop();
+        co_return;
+    }
+
+    auto socket = std::make_unique<kota::ipc::StreamTransport>(std::move(*conn));
+
+    co_await kota::when_all(relay_forward(**stdio, *socket), relay_forward(*socket, **stdio));
+    loop.stop();
+}
+
+static std::string default_socket_path() {
+    llvm::SmallString<128> home;
+    if(!llvm::sys::path::home_directory(home))
+        return "/tmp/clice.sock";
+    llvm::sys::path::append(home, ".clice", "clice.sock");
+    return home.str().str();
+}
+
+int run_relay_mode(llvm::StringRef socket_path) {
+    logging::stderr_logger("relay", logging::options);
+
+    auto path = socket_path.empty() ? default_socket_path() : socket_path.str();
+
+    kota::event_loop loop;
+    loop.schedule(relay_main(loop, std::move(path)));
+    loop.run();
+    return 0;
 }
 
 }  // namespace clice

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -69,6 +69,8 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
                                      agentic::FileDepsParams{.path = opts.path, .direction = dir});
     } else if(opts.method == "impactAnalysis") {
         ok = co_await send_and_print(peer, agentic::ImpactAnalysisParams{.path = opts.path});
+    } else if(opts.method == "status") {
+        ok = co_await send_and_print(peer, agentic::StatusParams{});
     } else {
         LOG_ERROR("unknown agentic method '{}'", opts.method);
     }

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -71,6 +71,9 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
         ok = co_await send_and_print(peer, agentic::ImpactAnalysisParams{.path = opts.path});
     } else if(opts.method == "status") {
         ok = co_await send_and_print(peer, agentic::StatusParams{});
+    } else if(opts.method == "shutdown") {
+        peer.send_notification(agentic::ShutdownParams{});
+        ok = true;
     } else {
         LOG_ERROR("unknown agentic method '{}'", opts.method);
     }

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -5,12 +5,12 @@
 #include <string>
 
 #include "server/protocol/agentic.h"
+#include "support/filesystem.h"
 #include "support/logging.h"
 
 #include "kota/async/async.h"
 #include "kota/ipc/codec/json.h"
 #include "kota/ipc/transport.h"
-#include "llvm/Support/Path.h"
 
 namespace clice {
 
@@ -162,18 +162,10 @@ static kota::task<> relay_main(kota::event_loop& loop, int& exit_code, std::stri
     loop.stop();
 }
 
-static std::string default_socket_path() {
-    llvm::SmallString<128> home;
-    if(!llvm::sys::path::home_directory(home))
-        return "/tmp/clice.sock";
-    llvm::sys::path::append(home, ".clice", "clice.sock");
-    return home.str().str();
-}
-
 int run_relay_mode(llvm::StringRef socket_path) {
     logging::stderr_logger("relay", logging::options);
 
-    auto path = socket_path.empty() ? default_socket_path() : socket_path.str();
+    auto path = socket_path.empty() ? path::default_socket_path() : socket_path.str();
 
     kota::event_loop loop;
     int exit_code = 1;

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -47,22 +47,44 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
             agentic::DefinitionParams{.name = name, .path = path, .line = line});
     } else if(opts.method == "references") {
         auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        ok = co_await send_and_print(peer, agentic::ReferencesParams{.name = name});
+        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
+        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+        ok = co_await send_and_print(
+            peer,
+            agentic::ReferencesParams{.name = name, .path = path, .line = line});
     } else if(opts.method == "readSymbol") {
         auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        ok = co_await send_and_print(peer, agentic::ReadSymbolParams{.name = name});
+        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
+        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+        ok = co_await send_and_print(
+            peer,
+            agentic::ReadSymbolParams{.name = name, .path = path, .line = line});
     } else if(opts.method == "documentSymbols") {
         ok = co_await send_and_print(peer, agentic::DocumentSymbolsParams{.path = opts.path});
     } else if(opts.method == "callGraph") {
         auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
-        ok =
-            co_await send_and_print(peer, agentic::CallGraphParams{.name = name, .direction = dir});
-    } else if(opts.method == "typeHierarchy") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
+        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
         auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
         ok = co_await send_and_print(peer,
-                                     agentic::TypeHierarchyParams{.name = name, .direction = dir});
+                                     agentic::CallGraphParams{
+                                         .name = name,
+                                         .path = path,
+                                         .line = line,
+                                         .direction = dir,
+                                     });
+    } else if(opts.method == "typeHierarchy") {
+        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
+        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
+        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+        ok = co_await send_and_print(peer,
+                                     agentic::TypeHierarchyParams{
+                                         .name = name,
+                                         .path = path,
+                                         .line = line,
+                                         .direction = dir,
+                                     });
     } else if(opts.method == "fileDeps") {
         auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
         ok = co_await send_and_print(peer,
@@ -118,7 +140,7 @@ static kota::task<> relay_forward(kota::ipc::Transport& from, kota::ipc::Transpo
     to.close();
 }
 
-static kota::task<> relay_main(kota::event_loop& loop, std::string socket_path) {
+static kota::task<> relay_main(kota::event_loop& loop, int& exit_code, std::string socket_path) {
     auto stdio = kota::ipc::StreamTransport::open_stdio(loop);
     if(!stdio) {
         LOG_ERROR("failed to open stdio transport");
@@ -136,6 +158,7 @@ static kota::task<> relay_main(kota::event_loop& loop, std::string socket_path) 
     auto socket = std::make_unique<kota::ipc::StreamTransport>(std::move(*conn));
 
     co_await kota::when_all(relay_forward(**stdio, *socket), relay_forward(*socket, **stdio));
+    exit_code = 0;
     loop.stop();
 }
 
@@ -153,9 +176,10 @@ int run_relay_mode(llvm::StringRef socket_path) {
     auto path = socket_path.empty() ? default_socket_path() : socket_path.str();
 
     kota::event_loop loop;
-    loop.schedule(relay_main(loop, std::move(path)));
+    int exit_code = 1;
+    loop.schedule(relay_main(loop, exit_code, std::move(path)));
     loop.run();
-    return 0;
+    return exit_code;
 }
 
 }  // namespace clice

--- a/src/server/service/agentic.h
+++ b/src/server/service/agentic.h
@@ -8,4 +8,6 @@ namespace clice {
 
 int run_agentic_mode(llvm::StringRef host, int port, llvm::StringRef path);
 
+int run_relay_mode(llvm::StringRef socket_path);
+
 }  // namespace clice

--- a/src/server/service/agentic.h
+++ b/src/server/service/agentic.h
@@ -6,7 +6,18 @@
 
 namespace clice {
 
-int run_agentic_mode(llvm::StringRef host, int port, llvm::StringRef path);
+struct AgenticQueryOptions {
+    std::string host;
+    int port = 0;
+    std::string method;
+    std::string path;
+    std::string name;
+    std::string query;
+    int line = 0;
+    std::string direction;
+};
+
+int run_agentic_mode(const AgenticQueryOptions& opts);
 
 int run_relay_mode(llvm::StringRef socket_path);
 

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -152,10 +152,8 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         });
 
     peer.on_notification([this]([[maybe_unused]] const protocol::ExitParams& params) {
-        auto& srv = this->server;
-        srv.lifecycle = ServerLifecycle::Exited;
         LOG_INFO("Exit notification received");
-        srv.schedule_shutdown();
+        this->server.schedule_shutdown();
     });
 
     peer.on_notification([this](const protocol::DidOpenTextDocumentParams& params) {

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -196,12 +196,16 @@ void MasterServer::on_file_saved(std::uint32_t path_id) {
 }
 
 void MasterServer::schedule_shutdown() {
+    if(lifecycle == ServerLifecycle::Exited)
+        return;
+    lifecycle = ServerLifecycle::Exited;
+
     indexer.save(workspace.config.project.index_dir);
     workspace.save_cache();
+    shutdown_event.set();
 
     loop.schedule([this]() -> kota::task<> {
-        co_await compiler.stop();
-        co_await pool.stop();
+        co_await kota::when_all(indexer.stop(), compiler.stop(), pool.stop());
         loop.stop();
     }());
 }
@@ -445,32 +449,41 @@ static kota::task<> run_daemon_connection(kota::ipc::JsonPeer* peer,
     connections.erase(pos);
 }
 
-static kota::task<> accept_daemon_connections(MasterServer& server,
-                                              kota::pipe::acceptor acceptor,
-                                              std::list<DaemonConnection>& connections) {
+static kota::task<> daemon_main(MasterServer& server, kota::pipe::acceptor acceptor) {
     auto& loop = kota::event_loop::current();
+    std::list<DaemonConnection> connections;
     kota::task_group<> connection_group(loop);
 
-    while(true) {
-        auto conn = co_await acceptor.accept();
-        if(!conn.has_value())
-            break;
+    co_await kota::when_all(
+        [&]() -> kota::task<> {
+            while(true) {
+                auto conn = co_await acceptor.accept();
+                if(!conn.has_value())
+                    break;
 
-        LOG_INFO("Daemon client connected");
+                LOG_INFO("Daemon client connected");
 
-        auto transport = std::make_unique<kota::ipc::StreamTransport>(std::move(*conn));
-        auto peer = std::make_unique<kota::ipc::JsonPeer>(loop, std::move(transport));
-        auto agent = std::make_unique<AgentClient>(server, *peer);
+                auto transport = std::make_unique<kota::ipc::StreamTransport>(std::move(*conn));
+                auto peer = std::make_unique<kota::ipc::JsonPeer>(loop, std::move(transport));
+                auto agent = std::make_unique<AgentClient>(server, *peer);
 
-        auto* peer_ptr = peer.get();
-        auto it = connections.emplace(connections.end(),
-                                      DaemonConnection{
-                                          .peer = std::move(peer),
-                                          .agent_client = std::move(agent),
-                                      });
+                auto* peer_ptr = peer.get();
+                auto it = connections.emplace(connections.end(),
+                                              DaemonConnection{
+                                                  .peer = std::move(peer),
+                                                  .agent_client = std::move(agent),
+                                              });
 
-        connection_group.spawn(run_daemon_connection(peer_ptr, connections, it));
-    }
+                connection_group.spawn(run_daemon_connection(peer_ptr, connections, it));
+            }
+        }(),
+        [&]() -> kota::task<> {
+            co_await server.shutdown_event.wait();
+            acceptor.stop();
+            for(auto& conn: connections) {
+                conn.peer->close();
+            }
+        }());
 
     co_await connection_group.join();
 }
@@ -500,7 +513,6 @@ int run_daemon_mode(const DaemonOptions& opts) {
 
     kota::event_loop loop;
     MasterServer server(loop, opts.self_path);
-    std::list<DaemonConnection> connections;
 
     if(!opts.workspace.empty()) {
         server.initialize(opts.workspace);
@@ -514,7 +526,7 @@ int run_daemon_mode(const DaemonOptions& opts) {
     }
 
     LOG_INFO("Daemon listening on {}", socket_path);
-    loop.schedule(accept_daemon_connections(server, std::move(*acceptor), connections));
+    loop.schedule(daemon_main(server, std::move(*acceptor)));
     loop.run();
 
     llvm::sys::fs::remove(socket_path);

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -12,6 +12,7 @@
 #include "support/logging.h"
 
 #include "kota/async/async.h"
+#include "kota/async/io/fs_event.h"
 #include "kota/codec/json/json.h"
 #include "kota/ipc/codec/json.h"
 #include "kota/ipc/lsp/protocol.h"
@@ -19,6 +20,7 @@
 #include "kota/ipc/recording_transport.h"
 #include "kota/ipc/transport.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 
 namespace clice {
@@ -89,6 +91,52 @@ void MasterServer::initialize() {
     indexer.set_max_concurrency(cfg.stateless_worker_count.value);
 
     load_workspace();
+}
+
+void MasterServer::initialize(llvm::StringRef root) {
+    workspace_root = root.str();
+    initialize();
+}
+
+void MasterServer::start_file_watcher() {
+    if(workspace_root.empty())
+        return;
+
+    loop.schedule([this]() -> kota::task<> {
+        auto watcher = kota::fs_event::create(workspace_root, {}, loop);
+        if(!watcher) {
+            LOG_WARN("Failed to start file watcher for {}", workspace_root);
+            co_return;
+        }
+
+        LOG_INFO("File watcher started for {}", workspace_root);
+
+        while(true) {
+            auto changes = co_await watcher->next();
+            if(!changes)
+                break;
+
+            for(auto& change: *changes) {
+                if(change.type != kota::fs_event::effect::modify &&
+                   change.type != kota::fs_event::effect::create)
+                    continue;
+
+                llvm::StringRef file(change.path);
+                if(file.ends_with("compile_commands.json")) {
+                    LOG_INFO("CDB changed, reloading workspace");
+                    load_workspace();
+                    continue;
+                }
+
+                if(file.ends_with(".cpp") || file.ends_with(".cc") || file.ends_with(".cxx") ||
+                   file.ends_with(".c") || file.ends_with(".h") || file.ends_with(".hpp") ||
+                   file.ends_with(".hxx") || file.ends_with(".cppm") || file.ends_with(".ixx")) {
+                    auto path_id = workspace.path_pool.intern(file);
+                    on_file_saved(path_id);
+                }
+            }
+        }
+    }());
 }
 
 Session* MasterServer::find_session(std::uint32_t path_id) {
@@ -382,6 +430,95 @@ int run_server_mode(const ServerOptions& opts) {
 
     LOG_ERROR("unknown server mode '{}'", opts.mode);
     return 1;
+}
+
+struct DaemonConnection {
+    std::unique_ptr<kota::ipc::JsonPeer> peer;
+    std::unique_ptr<AgentClient> agent_client;
+};
+
+static kota::task<> run_daemon_connection(kota::ipc::JsonPeer* peer,
+                                          std::list<DaemonConnection>& connections,
+                                          std::list<DaemonConnection>::iterator pos) {
+    co_await peer->run();
+    LOG_INFO("Daemon client disconnected");
+    connections.erase(pos);
+}
+
+static kota::task<> accept_daemon_connections(MasterServer& server,
+                                              kota::pipe::acceptor acceptor,
+                                              std::list<DaemonConnection>& connections) {
+    auto& loop = kota::event_loop::current();
+    kota::task_group<> connection_group(loop);
+
+    while(true) {
+        auto conn = co_await acceptor.accept();
+        if(!conn.has_value())
+            break;
+
+        LOG_INFO("Daemon client connected");
+
+        auto transport = std::make_unique<kota::ipc::StreamTransport>(std::move(*conn));
+        auto peer = std::make_unique<kota::ipc::JsonPeer>(loop, std::move(transport));
+        auto agent = std::make_unique<AgentClient>(server, *peer);
+
+        auto* peer_ptr = peer.get();
+        auto it = connections.emplace(connections.end(),
+                                      DaemonConnection{
+                                          .peer = std::move(peer),
+                                          .agent_client = std::move(agent),
+                                      });
+
+        connection_group.spawn(run_daemon_connection(peer_ptr, connections, it));
+    }
+
+    co_await connection_group.join();
+}
+
+static std::string default_socket_path() {
+    llvm::SmallString<128> home;
+    if(!llvm::sys::path::home_directory(home))
+        return "/tmp/clice.sock";
+    llvm::sys::path::append(home, ".clice", "clice.sock");
+    return home.str().str();
+}
+
+int run_daemon_mode(const DaemonOptions& opts) {
+    logging::stderr_logger("daemon", logging::options);
+
+    auto socket_path = opts.socket_path.empty() ? default_socket_path() : opts.socket_path;
+
+    auto socket_dir = llvm::sys::path::parent_path(socket_path);
+    if(auto ec = llvm::sys::fs::create_directories(socket_dir)) {
+        LOG_ERROR("Failed to create socket directory {}: {}", socket_dir, ec.message());
+        return 1;
+    }
+
+    if(llvm::sys::fs::exists(socket_path)) {
+        llvm::sys::fs::remove(socket_path);
+    }
+
+    kota::event_loop loop;
+    MasterServer server(loop, opts.self_path);
+    std::list<DaemonConnection> connections;
+
+    if(!opts.workspace.empty()) {
+        server.initialize(opts.workspace);
+        server.start_file_watcher();
+    }
+
+    auto acceptor = kota::pipe::listen(socket_path, {}, loop);
+    if(!acceptor) {
+        LOG_ERROR("Failed to listen on {}", socket_path);
+        return 1;
+    }
+
+    LOG_INFO("Daemon listening on {}", socket_path);
+    loop.schedule(accept_daemon_connections(server, std::move(*acceptor), connections));
+    loop.run();
+
+    llvm::sys::fs::remove(socket_path);
+    return 0;
 }
 
 }  // namespace clice

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -486,7 +486,7 @@ static kota::task<> daemon_main(MasterServer& server, kota::pipe::acceptor accep
             }
         }(),
         [&]() -> kota::task<> {
-            co_await server.shutdown_event.wait();
+            co_await server.get_shutdown_event().wait();
             acceptor.stop();
             for(auto& conn: connections) {
                 conn.peer->close();
@@ -496,18 +496,10 @@ static kota::task<> daemon_main(MasterServer& server, kota::pipe::acceptor accep
     co_await connection_group.join();
 }
 
-static std::string default_socket_path() {
-    llvm::SmallString<128> home;
-    if(!llvm::sys::path::home_directory(home))
-        return "/tmp/clice.sock";
-    llvm::sys::path::append(home, ".clice", "clice.sock");
-    return home.str().str();
-}
-
 int run_daemon_mode(const DaemonOptions& opts) {
     logging::stderr_logger("daemon", logging::options);
 
-    auto socket_path = opts.socket_path.empty() ? default_socket_path() : opts.socket_path;
+    auto socket_path = opts.socket_path.empty() ? path::default_socket_path() : opts.socket_path;
 
     auto socket_dir = llvm::sys::path::parent_path(socket_path);
     if(auto ec = llvm::sys::fs::create_directories(socket_dir)) {

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -1,9 +1,17 @@
 #include "server/service/master_server.h"
 
+#include <cerrno>
+#include <cstring>
 #include <list>
 #include <memory>
 #include <string>
 #include <vector>
+
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
 
 #include "server/protocol/worker.h"
 #include "server/service/agent_client.h"
@@ -508,6 +516,21 @@ int run_daemon_mode(const DaemonOptions& opts) {
     }
 
     if(llvm::sys::fs::exists(socket_path)) {
+#ifndef _WIN32
+        int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        if(fd >= 0) {
+            struct sockaddr_un addr{};
+            addr.sun_family = AF_UNIX;
+            auto len = std::min(socket_path.size(), sizeof(addr.sun_path) - 1);
+            std::memcpy(addr.sun_path, socket_path.data(), len);
+            bool live = ::connect(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0;
+            ::close(fd);
+            if(live) {
+                LOG_ERROR("Another daemon is already running on {}", socket_path);
+                return 1;
+            }
+        }
+#endif
         llvm::sys::fs::remove(socket_path);
     }
 

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -37,6 +37,9 @@ public:
     ~MasterServer();
 
     void initialize();
+    void initialize(llvm::StringRef root);
+
+    void start_file_watcher();
 
     Session* find_session(std::uint32_t path_id);
     Session& open_session(std::uint32_t path_id);
@@ -73,5 +76,13 @@ struct ServerOptions {
 };
 
 int run_server_mode(const ServerOptions& opts);
+
+struct DaemonOptions {
+    std::string socket_path;
+    std::string workspace;
+    std::string self_path;
+};
+
+int run_daemon_mode(const DaemonOptions& opts);
 
 }  // namespace clice

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -49,9 +49,12 @@ public:
 
     void schedule_shutdown();
 
-    kota::event shutdown_event;
+    kota::event& get_shutdown_event() {
+        return shutdown_event;
+    }
 
 private:
+    kota::event shutdown_event;
     void load_workspace();
 
     kota::event_loop& loop;

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -49,6 +49,8 @@ public:
 
     void schedule_shutdown();
 
+    kota::event shutdown_event;
+
 private:
     void load_workspace();
 

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -96,9 +96,8 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
                                                                   std::move(spawn.stdin_pipe));
     auto peer = std::make_unique<kota::ipc::BincodePeer>(loop, std::move(transport));
 
-    // Schedule stderr log collection
     std::string prefix = "[" + worker_name + "]";
-    loop.schedule(drain_stderr(std::move(spawn.stderr_pipe), prefix));
+    io_group.spawn(drain_stderr(std::move(spawn.stderr_pipe), prefix));
 
     workers.push_back(WorkerProcess{
         .proc = std::move(spawn.proc),
@@ -108,7 +107,7 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
 
     auto& w = workers.back();
     w.alive = true;
-    loop.schedule(w.peer->run());
+    io_group.spawn(w.peer->run());
 
     return true;
 }
@@ -160,7 +159,7 @@ kota::task<> WorkerPool::stop() {
     for(auto& w: stateful_workers)
         w.proc.kill(SIGTERM);
 
-    co_await monitor_group.join();
+    co_await kota::when_all(monitor_group.join(), io_group.join());
 
     LOG_INFO("WorkerPool stopped");
 }
@@ -320,7 +319,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     auto peer = std::make_unique<kota::ipc::BincodePeer>(loop, std::move(transport));
 
     std::string prefix = "[" + worker_name + "]";
-    loop.schedule(drain_stderr(std::move(spawn.stderr_pipe), prefix));
+    io_group.spawn(drain_stderr(std::move(spawn.stderr_pipe), prefix));
 
     workers[index] = WorkerProcess{
         .proc = std::move(spawn.proc),
@@ -331,7 +330,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     };
 
     auto& w = workers[index];
-    loop.schedule(w.peer->run());
+    io_group.spawn(w.peer->run());
 
     if(stateful) {
         w.peer->on_notification([this](const worker::EvictedParams& params) {

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -84,6 +84,7 @@ private:
 
     bool shutting_down_ = false;
     kota::task_group<> monitor_group{loop};
+    kota::task_group<> io_group{loop};
     WorkerPoolOptions options_;
     std::string log_dir_;
 

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -37,6 +37,14 @@ inline std::string real_path(llvm::StringRef file) {
     return path.str().str();
 }
 
+inline std::string default_socket_path() {
+    llvm::SmallString<128> home;
+    if(!llvm::sys::path::home_directory(home))
+        return "/tmp/clice.sock";
+    llvm::sys::path::append(home, ".clice", "clice.sock");
+    return home.str().str();
+}
+
 }  // namespace path
 
 namespace fs {

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -414,6 +414,18 @@ async def test_rpc_type_hierarchy_subtypes(indexed_agentic, workspace):
 
 
 @pytest.mark.workspace("index_features")
+async def test_rpc_status(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/status", {})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert isinstance(result["idle"], bool)
+    assert result["total"] > 0
+    assert isinstance(result["pending"], int)
+    assert isinstance(result["indexed"], int)
+
+
+@pytest.mark.workspace("index_features")
 async def test_rpc_symbol_not_found(indexed_agentic, workspace):
     rpc, _ = indexed_agentic
     resp = rpc.request("agentic/definition", {"name": "nonexistent_symbol_xyz"})

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -173,6 +173,8 @@ async def indexed_agentic(request, executable, workspace):
         if "result" in resp and resp["result"]["symbols"]:
             break
         await asyncio.sleep(1)
+    else:
+        pytest.fail("agentic/symbolSearch never returned indexed symbols")
 
     yield rpc, workspace
 
@@ -446,7 +448,7 @@ async def test_rpc_shutdown(executable, workspace):
     rpc.sock.settimeout(5)
     try:
         rpc.sock.recv(4096)
-    except Exception:
+    except (socket.timeout, OSError):
         pass
     rpc.sock.close()
 
@@ -532,7 +534,7 @@ async def test_shutdown_during_indexing(executable, tmp_path):
     rpc.sock.settimeout(5)
     try:
         rpc.sock.recv(4096)
-    except Exception:
+    except (socket.timeout, OSError):
         pass
     rpc.sock.close()
 

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -480,3 +480,68 @@ async def test_rpc_symbol_id_roundtrip(indexed_agentic, workspace):
     assert "result" in defn
     assert defn["result"]["name"] == "compute"
     assert defn["result"]["symbolId"] == compute["symbolId"]
+
+
+async def test_shutdown_during_indexing(executable, tmp_path):
+    """Shutdown during active background indexing must exit cleanly."""
+    from tests.integration.utils.client import CliceClient
+    from tests.conftest import _find_free_port
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    entries = []
+    for i in range(20):
+        src = workspace / f"file_{i}.cpp"
+        src.write_text(
+            f"struct Type_{i} {{ int v = {i}; void m() {{}} }};\n"
+            f"int func_{i}(int x) {{ return x + {i}; }}\n"
+            f"int caller_{i}() {{ return func_{i}({i}); }}\n"
+        )
+        entries.append(
+            {
+                "directory": workspace.as_posix(),
+                "file": src.as_posix(),
+                "arguments": ["clang++", "-std=c++17", "-fsyntax-only", src.as_posix()],
+            }
+        )
+
+    (workspace / "compile_commands.json").write_text(json.dumps(entries))
+
+    host = "127.0.0.1"
+    port = _find_free_port()
+    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+
+    c = CliceClient()
+    await c.start_io(*cmd)
+
+    init_options = {
+        "project": {
+            "cache_dir": str(workspace / ".clice"),
+            "idle_timeout_ms": 0,
+        }
+    }
+    await c.initialize(workspace, initialization_options=init_options)
+
+    # Give indexing a moment to start, then send shutdown
+    await asyncio.sleep(0.5)
+
+    rpc = AgenticRpcClient(host, port)
+    body = json.dumps({"jsonrpc": "2.0", "method": "agentic/shutdown", "params": {}})
+    rpc.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode())
+    rpc.sock.settimeout(5)
+    try:
+        rpc.sock.recv(4096)
+    except Exception:
+        pass
+    rpc.sock.close()
+
+    for _ in range(30):
+        if c._server.returncode is not None:
+            break
+        await asyncio.sleep(0.5)
+
+    assert c._server.returncode is not None, "Server did not exit after shutdown"
+    assert c._server.returncode >= 0, (
+        f"Server crashed with signal {-c._server.returncode}"
+    )

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -425,6 +425,40 @@ async def test_rpc_status(indexed_agentic, workspace):
     assert isinstance(result["indexed"], int)
 
 
+@pytest.mark.workspace("hello_world")
+async def test_rpc_shutdown(executable, workspace):
+    """Shutdown notification should cause the server to exit."""
+    from tests.integration.utils.client import CliceClient
+    from tests.conftest import _shutdown_client, _find_free_port
+
+    host = "127.0.0.1"
+    port = _find_free_port()
+    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+
+    c = CliceClient()
+    await c.start_io(*cmd)
+    init_options = {"project": {"cache_dir": str(workspace / ".clice")}}
+    await c.initialize(workspace, initialization_options=init_options)
+
+    rpc = AgenticRpcClient(host, port)
+    body = json.dumps({"jsonrpc": "2.0", "method": "agentic/shutdown", "params": {}})
+    rpc.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode())
+    rpc.sock.settimeout(5)
+    try:
+        rpc.sock.recv(4096)
+    except Exception:
+        pass
+    rpc.sock.close()
+
+    import asyncio
+
+    for _ in range(20):
+        if c._server.returncode is not None:
+            break
+        await asyncio.sleep(0.5)
+    assert c._server.returncode is not None, "Server did not exit after shutdown"
+
+
 @pytest.mark.workspace("index_features")
 async def test_rpc_symbol_not_found(indexed_agentic, workspace):
     rpc, _ = indexed_agentic

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -1,11 +1,66 @@
-"""Tests for the agentic CLI client."""
+"""Tests for the agentic protocol handlers."""
 
+import asyncio
 import json
 import socket
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
+from tests.integration.utils.wait import wait_for_index
+
+
+class AgenticRpcClient:
+    """Minimal JSON-RPC client that speaks Content-Length framing over TCP."""
+
+    def __init__(self, host: str, port: int):
+        self.sock = socket.create_connection((host, port), timeout=10)
+        self.request_id = 0
+        self.buffer = b""
+
+    def request(self, method: str, params: dict):
+        self.request_id += 1
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": self.request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        payload = f"Content-Length: {len(body)}\r\n\r\n{body}".encode("utf-8")
+        self.sock.sendall(payload)
+        return self._read_response()
+
+    def _read_response(self):
+        while b"\r\n\r\n" not in self.buffer:
+            data = self.sock.recv(4096)
+            if not data:
+                raise ConnectionError("connection closed")
+            self.buffer += data
+
+        header_end = self.buffer.index(b"\r\n\r\n")
+        headers = self.buffer[:header_end].decode("utf-8")
+        self.buffer = self.buffer[header_end + 4 :]
+
+        content_length = 0
+        for line in headers.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                content_length = int(line.split(":")[1].strip())
+
+        while len(self.buffer) < content_length:
+            data = self.sock.recv(4096)
+            if not data:
+                raise ConnectionError("connection closed")
+            self.buffer += data
+
+        body = self.buffer[:content_length].decode("utf-8")
+        self.buffer = self.buffer[content_length:]
+        return json.loads(body)
+
+    def close(self):
+        self.sock.close()
 
 
 def run_agentic(executable, host, port, path, timeout=10):
@@ -26,6 +81,9 @@ def run_agentic(executable, host, port, path, timeout=10):
         timeout=timeout,
     )
     return result
+
+
+# ── Existing CLI tests ──────────────────────────────────────────────
 
 
 @pytest.mark.workspace("hello_world")
@@ -61,7 +119,6 @@ async def test_multiple_requests(agentic, workspace):
 
 
 async def test_connection_refused(executable):
-    """Connecting to a port with no server should fail with non-zero exit."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         free_port = s.getsockname()[1]
@@ -71,7 +128,6 @@ async def test_connection_refused(executable):
 
 @pytest.mark.workspace("hello_world")
 async def test_concurrent_connections(agentic, workspace):
-    """Multiple agentic clients connecting simultaneously should all succeed."""
     executable, host, port = agentic
     main_cpp = (workspace / "main.cpp").as_posix()
 
@@ -85,3 +141,243 @@ async def test_concurrent_connections(agentic, workspace):
         assert r.returncode == 0, f"stderr: {r.stderr}"
         data = json.loads(r.stdout)
         assert data["file"] == main_cpp
+
+
+# ── Agentic protocol handler tests ─────────────────────────────────
+# Wire format uses camelCase field names (lsp_config lower_camel rename).
+
+
+@pytest.fixture
+async def indexed_agentic(request, executable, workspace):
+    """Start server with LSP+agentic, compile a file, wait for indexing."""
+    from tests.integration.utils.client import CliceClient
+    from tests.conftest import _shutdown_client, _find_free_port
+
+    host = "127.0.0.1"
+    port = _find_free_port()
+    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+
+    c = CliceClient()
+    await c.start_io(*cmd)
+
+    init_options = {"project": {"cache_dir": str(workspace / ".clice")}}
+    await c.initialize(workspace, initialization_options=init_options)
+
+    uri, _ = await c.open_and_wait(workspace / "main.cpp")
+    assert await wait_for_index(c, uri, "add"), "Index not ready"
+
+    rpc = AgenticRpcClient(host, port)
+
+    for _ in range(30):
+        resp = rpc.request("agentic/symbolSearch", {"query": "add"})
+        if "result" in resp and resp["result"]["symbols"]:
+            break
+        await asyncio.sleep(1)
+
+    yield rpc, workspace
+
+    rpc.close()
+    c.close(uri)
+    await _shutdown_client(c)
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_compile_command(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/compileCommand", {"path": path})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["file"] == path
+    assert len(result["arguments"]) > 0
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_project_files(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/projectFiles", {})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["total"] > 0
+    paths = [f["path"] for f in result["files"]]
+    assert any("main.cpp" in p for p in paths)
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_project_files_filter(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/projectFiles", {"filter": "source"})
+    assert "result" in resp
+    for f in resp["result"]["files"]:
+        assert f["kind"] == "source"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_symbol_search(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/symbolSearch", {"query": "add"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    names = [s["name"] for s in resp["result"]["symbols"]]
+    assert "add" in names
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_symbol_search_kind(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request(
+        "agentic/symbolSearch", {"query": "Animal", "kindFilter": ["Struct"]}
+    )
+    assert "result" in resp
+    for s in resp["result"]["symbols"]:
+        assert s["kind"] == "Struct"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_symbol_search_max(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/symbolSearch", {"query": "", "maxResults": 3})
+    assert "result" in resp
+    assert len(resp["result"]["symbols"]) <= 3
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_read_symbol(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/readSymbol", {"name": "add"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["name"] == "add"
+    assert result["symbolId"] != 0
+    assert "int" in result["text"] or "add" in result["text"]
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_read_symbol_by_id(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp1 = rpc.request("agentic/readSymbol", {"name": "add"})
+    assert "result" in resp1
+    sid = resp1["result"]["symbolId"]
+
+    resp2 = rpc.request("agentic/readSymbol", {"symbolId": sid})
+    assert "result" in resp2
+    assert resp2["result"]["name"] == "add"
+    assert resp2["result"]["symbolId"] == sid
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_document_symbols(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/documentSymbols", {"path": path})
+    assert "result" in resp, f"unexpected response: {resp}"
+    names = [s["name"] for s in resp["result"]["symbols"]]
+    assert any("add" in n for n in names), f"expected 'add' in {names}"
+    assert any("main" in n for n in names), f"expected 'main' in {names}"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_definition(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/definition", {"name": "add"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["name"] == "add"
+    assert result["definition"] is not None
+    assert "main.cpp" in result["definition"]["file"]
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_definition_by_position(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/definition", {"path": path, "line": 19})
+    assert "result" in resp, f"unexpected response: {resp}"
+    assert resp["result"]["name"] == "add"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_references(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/references", {"name": "global_var"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["name"] == "global_var"
+    assert result["total"] >= 2
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_references_include_decl(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request(
+        "agentic/references", {"name": "global_var", "includeDeclaration": True}
+    )
+    assert "result" in resp
+    assert resp["result"]["total"] >= 3
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_call_graph_incoming(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/callGraph", {"name": "add", "direction": "callers"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["root"]["name"] == "add"
+    caller_names = [c["name"] for c in result["callers"]]
+    assert "compute" in caller_names, f"expected 'compute' in {caller_names}"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_call_graph_outgoing(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/callGraph", {"name": "compute", "direction": "callees"})
+    assert "result" in resp, f"unexpected response: {resp}"
+    callee_names = [c["name"] for c in resp["result"]["callees"]]
+    assert "add" in callee_names, f"expected 'add' in {callee_names}"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_type_hierarchy_supertypes(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request(
+        "agentic/typeHierarchy", {"name": "Dog", "direction": "supertypes"}
+    )
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["root"]["name"] == "Dog"
+    supertype_names = [t["name"] for t in result["supertypes"]]
+    assert "Animal" in supertype_names, f"expected 'Animal' in {supertype_names}"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_type_hierarchy_subtypes(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request(
+        "agentic/typeHierarchy", {"name": "Animal", "direction": "subtypes"}
+    )
+    assert "result" in resp, f"unexpected response: {resp}"
+    subtype_names = [t["name"] for t in resp["result"]["subtypes"]]
+    assert "Dog" in subtype_names, f"expected 'Dog' in {subtype_names}"
+    assert "Cat" in subtype_names, f"expected 'Cat' in {subtype_names}"
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_symbol_not_found(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/definition", {"name": "nonexistent_symbol_xyz"})
+    assert "error" in resp
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_symbol_id_roundtrip(indexed_agentic, workspace):
+    """Search -> get symbolId -> definition -> verify consistency."""
+    rpc, _ = indexed_agentic
+    search = rpc.request("agentic/symbolSearch", {"query": "compute"})
+    assert "result" in search
+    symbols = search["result"]["symbols"]
+    compute = next((s for s in symbols if s["name"] == "compute"), None)
+    assert compute is not None, f"'compute' not found in {[s['name'] for s in symbols]}"
+
+    defn = rpc.request("agentic/definition", {"symbolId": compute["symbolId"]})
+    assert "result" in defn
+    assert defn["result"]["name"] == "compute"
+    assert defn["result"]["symbolId"] == compute["symbolId"]

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -83,9 +83,6 @@ def run_agentic(executable, host, port, path, timeout=10):
     return result
 
 
-# ── Existing CLI tests ──────────────────────────────────────────────
-
-
 @pytest.mark.workspace("hello_world")
 async def test_compile_command(agentic, workspace):
     executable, host, port = agentic
@@ -141,10 +138,6 @@ async def test_concurrent_connections(agentic, workspace):
         assert r.returncode == 0, f"stderr: {r.stderr}"
         data = json.loads(r.stdout)
         assert data["file"] == main_cpp
-
-
-# ── Agentic protocol handler tests ─────────────────────────────────
-# Wire format uses camelCase field names (lsp_config lower_camel rename).
 
 
 @pytest.fixture
@@ -482,6 +475,56 @@ async def test_rpc_symbol_id_roundtrip(indexed_agentic, workspace):
     assert "result" in defn
     assert defn["result"]["name"] == "compute"
     assert defn["result"]["symbolId"] == compute["symbolId"]
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_file_deps(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/fileDeps", {"path": path})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert result["file"] == path
+    assert isinstance(result["includes"], list)
+    assert isinstance(result["includers"], list)
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_file_deps_direction(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/fileDeps", {"path": path, "direction": "includes"})
+    assert "result" in resp
+    assert resp["result"]["includers"] == []
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_file_deps_unknown(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/fileDeps", {"path": "/nonexistent/file.cpp"})
+    assert "result" in resp
+    assert resp["result"]["includes"] == []
+    assert resp["result"]["includers"] == []
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_impact_analysis(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    path = (workspace / "main.cpp").as_posix()
+    resp = rpc.request("agentic/impactAnalysis", {"path": path})
+    assert "result" in resp, f"unexpected response: {resp}"
+    result = resp["result"]
+    assert isinstance(result["directDependents"], list)
+    assert isinstance(result["transitiveDependents"], list)
+    assert isinstance(result["affectedModules"], list)
+
+
+@pytest.mark.workspace("index_features")
+async def test_rpc_impact_analysis_unknown(indexed_agentic, workspace):
+    rpc, _ = indexed_agentic
+    resp = rpc.request("agentic/impactAnalysis", {"path": "/nonexistent/file.cpp"})
+    assert "result" in resp
+    assert resp["result"]["directDependents"] == []
 
 
 async def test_shutdown_during_indexing(executable, tmp_path):

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -217,8 +217,13 @@ async def test_rpc_symbol_search(indexed_agentic, workspace):
     rpc, _ = indexed_agentic
     resp = rpc.request("agentic/symbolSearch", {"query": "add"})
     assert "result" in resp, f"unexpected response: {resp}"
-    names = [s["name"] for s in resp["result"]["symbols"]]
-    assert "add" in names
+    symbols = resp["result"]["symbols"]
+    add_sym = next((s for s in symbols if s["name"] == "add"), None)
+    assert add_sym is not None, f"'add' not found in {[s['name'] for s in symbols]}"
+    assert add_sym["kind"] == "Function"
+    assert add_sym["line"] == 19
+    assert add_sym["symbolId"] != 0
+    assert "main.cpp" in add_sym["file"]
 
 
 @pytest.mark.workspace("index_features")
@@ -248,7 +253,10 @@ async def test_rpc_read_symbol(indexed_agentic, workspace):
     result = resp["result"]
     assert result["name"] == "add"
     assert result["symbolId"] != 0
-    assert "int" in result["text"] or "add" in result["text"]
+    assert result["startLine"] == 19
+    assert result["endLine"] == 21
+    assert "int add(int a, int b)" in result["text"]
+    assert "return a + b;" in result["text"]
 
 
 @pytest.mark.workspace("index_features")
@@ -270,9 +278,15 @@ async def test_rpc_document_symbols(indexed_agentic, workspace):
     path = (workspace / "main.cpp").as_posix()
     resp = rpc.request("agentic/documentSymbols", {"path": path})
     assert "result" in resp, f"unexpected response: {resp}"
-    names = [s["name"] for s in resp["result"]["symbols"]]
-    assert any("add" in n for n in names), f"expected 'add' in {names}"
-    assert any("main" in n for n in names), f"expected 'main' in {names}"
+    symbols = resp["result"]["symbols"]
+    names = [s["name"] for s in symbols]
+    kinds = [s["kind"] for s in symbols]
+    assert "add" in names, f"expected 'add' in {names}"
+    assert "main" in names, f"expected 'main' in {names}"
+    assert "global_var" in names, f"expected 'global_var' in {names}"
+    assert "Parameter" not in kinds, (
+        f"Parameters should be filtered: {list(zip(names, kinds))}"
+    )
 
 
 @pytest.mark.workspace("index_features")
@@ -283,7 +297,12 @@ async def test_rpc_definition(indexed_agentic, workspace):
     result = resp["result"]
     assert result["name"] == "add"
     assert result["definition"] is not None
-    assert "main.cpp" in result["definition"]["file"]
+    defn = result["definition"]
+    assert "main.cpp" in defn["file"]
+    assert defn["startLine"] == 19
+    assert defn["endLine"] == 21
+    assert "int add(int a, int b)" in defn["text"]
+    assert "return a + b;" in defn["text"]
 
 
 @pytest.mark.workspace("index_features")
@@ -302,7 +321,12 @@ async def test_rpc_references(indexed_agentic, workspace):
     assert "result" in resp, f"unexpected response: {resp}"
     result = resp["result"]
     assert result["name"] == "global_var"
-    assert result["total"] >= 2
+    assert result["total"] == 2
+    lines = sorted(r["line"] for r in result["references"])
+    assert lines == [34, 38]
+    contexts = [r["context"] for r in result["references"]]
+    assert any("global_var + 1" in c for c in contexts)
+    assert any("global_var * 2" in c for c in contexts)
 
 
 @pytest.mark.workspace("index_features")
@@ -312,7 +336,10 @@ async def test_rpc_references_include_decl(indexed_agentic, workspace):
         "agentic/references", {"name": "global_var", "includeDeclaration": True}
     )
     assert "result" in resp
-    assert resp["result"]["total"] >= 3
+    result = resp["result"]
+    assert result["total"] == 3
+    lines = sorted(r["line"] for r in result["references"])
+    assert 31 in lines, f"expected declaration line 31 in {lines}"
 
 
 @pytest.mark.workspace("index_features")
@@ -322,8 +349,15 @@ async def test_rpc_call_graph_incoming(indexed_agentic, workspace):
     assert "result" in resp, f"unexpected response: {resp}"
     result = resp["result"]
     assert result["root"]["name"] == "add"
-    caller_names = [c["name"] for c in result["callers"]]
+    assert result["root"]["line"] == 19
+    assert result["root"]["symbolId"] != 0
+    callers = result["callers"]
+    caller_names = [c["name"] for c in callers]
     assert "compute" in caller_names, f"expected 'compute' in {caller_names}"
+    compute = next(c for c in callers if c["name"] == "compute")
+    assert compute["line"] == 24
+    assert compute["symbolId"] != 0
+    assert result["callees"] == []
 
 
 @pytest.mark.workspace("index_features")
@@ -331,8 +365,14 @@ async def test_rpc_call_graph_outgoing(indexed_agentic, workspace):
     rpc, _ = indexed_agentic
     resp = rpc.request("agentic/callGraph", {"name": "compute", "direction": "callees"})
     assert "result" in resp, f"unexpected response: {resp}"
-    callee_names = [c["name"] for c in resp["result"]["callees"]]
+    result = resp["result"]
+    assert result["root"]["name"] == "compute"
+    callees = result["callees"]
+    callee_names = [c["name"] for c in callees]
     assert "add" in callee_names, f"expected 'add' in {callee_names}"
+    add_entry = next(c for c in callees if c["name"] == "add")
+    assert add_entry["line"] == 19
+    assert result["callers"] == []
 
 
 @pytest.mark.workspace("index_features")
@@ -344,8 +384,13 @@ async def test_rpc_type_hierarchy_supertypes(indexed_agentic, workspace):
     assert "result" in resp, f"unexpected response: {resp}"
     result = resp["result"]
     assert result["root"]["name"] == "Dog"
-    supertype_names = [t["name"] for t in result["supertypes"]]
+    assert result["root"]["line"] == 9
+    supertypes = result["supertypes"]
+    supertype_names = [t["name"] for t in supertypes]
     assert "Animal" in supertype_names, f"expected 'Animal' in {supertype_names}"
+    animal = next(t for t in supertypes if t["name"] == "Animal")
+    assert animal["line"] == 2
+    assert animal["symbolId"] != 0
 
 
 @pytest.mark.workspace("index_features")
@@ -355,9 +400,17 @@ async def test_rpc_type_hierarchy_subtypes(indexed_agentic, workspace):
         "agentic/typeHierarchy", {"name": "Animal", "direction": "subtypes"}
     )
     assert "result" in resp, f"unexpected response: {resp}"
-    subtype_names = [t["name"] for t in resp["result"]["subtypes"]]
+    result = resp["result"]
+    assert result["root"]["name"] == "Animal"
+    assert result["root"]["line"] == 2
+    subtypes = result["subtypes"]
+    subtype_names = [t["name"] for t in subtypes]
     assert "Dog" in subtype_names, f"expected 'Dog' in {subtype_names}"
     assert "Cat" in subtype_names, f"expected 'Cat' in {subtype_names}"
+    dog = next(t for t in subtypes if t["name"] == "Dog")
+    assert dog["line"] == 9
+    cat = next(t for t in subtypes if t["name"] == "Cat")
+    assert cat["line"] == 14
 
 
 @pytest.mark.workspace("index_features")

--- a/tests/integration/agentic/test_cli.py
+++ b/tests/integration/agentic/test_cli.py
@@ -175,3 +175,15 @@ async def test_cli_project_files(indexed_server, workspace):
     assert data["total"] > 0
     paths = [f["path"] for f in data["files"]]
     assert any("main.cpp" in p for p in paths)
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_status(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "status")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert isinstance(data["idle"], bool)
+    assert data["total"] > 0
+    assert isinstance(data["pending"], int)
+    assert isinstance(data["indexed"], int)

--- a/tests/integration/agentic/test_cli.py
+++ b/tests/integration/agentic/test_cli.py
@@ -1,0 +1,177 @@
+"""CLI-based tests for agentic mode — run clice --mode agentic as a subprocess."""
+
+import json
+import subprocess
+
+import pytest
+
+from tests.integration.utils.wait import wait_for_index
+
+
+def run_cli(executable, host, port, method, **kwargs):
+    cmd = [
+        str(executable),
+        "--mode",
+        "agentic",
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--method",
+        method,
+    ]
+    for k, v in kwargs.items():
+        cmd.extend([f"--{k}", str(v)])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    return result
+
+
+@pytest.fixture
+async def indexed_server(request, executable, workspace):
+    """Start server with LSP+agentic, compile a file, wait for indexing."""
+    import asyncio
+    from tests.integration.utils.client import CliceClient
+    from tests.conftest import _shutdown_client, _find_free_port
+
+    host = "127.0.0.1"
+    port = _find_free_port()
+    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+
+    c = CliceClient()
+    await c.start_io(*cmd)
+
+    init_options = {"project": {"cache_dir": str(workspace / ".clice")}}
+    await c.initialize(workspace, initialization_options=init_options)
+
+    uri, _ = await c.open_and_wait(workspace / "main.cpp")
+    assert await wait_for_index(c, uri, "add"), "Index not ready"
+
+    from tests.integration.agentic.test_agentic import AgenticRpcClient
+
+    rpc = AgenticRpcClient(host, port)
+    for _ in range(30):
+        resp = rpc.request("agentic/symbolSearch", {"query": "add"})
+        if "result" in resp and resp["result"]["symbols"]:
+            break
+        await asyncio.sleep(1)
+    rpc.close()
+
+    yield executable, host, port, workspace
+
+    c.close(uri)
+    await _shutdown_client(c)
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_compile_command(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    path = (workspace / "main.cpp").as_posix()
+    r = run_cli(exe, host, port, "compileCommand", path=path)
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["file"] == path
+    assert len(data["arguments"]) > 0
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_symbol_search(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "symbolSearch", query="add")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    names = [s["name"] for s in data["symbols"]]
+    assert "add" in names
+    add_sym = next(s for s in data["symbols"] if s["name"] == "add")
+    assert add_sym["kind"] == "Function"
+    assert add_sym["line"] == 19
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_definition(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "definition", name="add")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["name"] == "add"
+    defn = data["definition"]
+    assert defn["startLine"] == 19
+    assert defn["endLine"] == 21
+    assert "return a + b;" in defn["text"]
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_definition_by_position(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    path = (workspace / "main.cpp").as_posix()
+    r = run_cli(exe, host, port, "definition", path=path, line=19)
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["name"] == "add"
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_references(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "references", name="global_var")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["name"] == "global_var"
+    assert data["total"] == 2
+    lines = sorted(ref["line"] for ref in data["references"])
+    assert lines == [34, 38]
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_read_symbol(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "readSymbol", name="compute")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["name"] == "compute"
+    assert "add(1, 2)" in data["text"]
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_document_symbols(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    path = (workspace / "main.cpp").as_posix()
+    r = run_cli(exe, host, port, "documentSymbols", path=path)
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    names = [s["name"] for s in data["symbols"]]
+    assert "add" in names
+    assert "main" in names
+    assert "global_var" in names
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_call_graph(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "callGraph", name="add", direction="callers")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["root"]["name"] == "add"
+    caller_names = [c["name"] for c in data["callers"]]
+    assert "compute" in caller_names
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_type_hierarchy(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "typeHierarchy", name="Dog", direction="supertypes")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["root"]["name"] == "Dog"
+    supertype_names = [t["name"] for t in data["supertypes"]]
+    assert "Animal" in supertype_names
+
+
+@pytest.mark.workspace("index_features")
+async def test_cli_project_files(indexed_server, workspace):
+    exe, host, port, _ = indexed_server
+    r = run_cli(exe, host, port, "projectFiles")
+    assert r.returncode == 0, f"stderr: {r.stderr}"
+    data = json.loads(r.stdout)
+    assert data["total"] > 0
+    paths = [f["path"] for f in data["files"]]
+    assert any("main.cpp" in p for p in paths)


### PR DESCRIPTION
## Summary
- **Agentic query API**: 11 JSON-RPC handlers over TCP for AI agent integration — compileCommand, projectFiles, fileDeps, impactAnalysis, symbolSearch, readSymbol, documentSymbols, definition, references, callGraph, typeHierarchy
- **Daemon mode**: MasterServer listens on a unix domain socket, accepting multiple agent connections (`--mode daemon`)
- **Relay mode**: Bidirectional stdin/stdout ↔ unix socket proxy for editor integration (`--mode relay`)
- **Full-body definition text**: readSymbol/definition return complete function/class bodies via brace matching, not just the declaration line
- **24 integration tests** with concrete value assertions covering all handlers

## Test plan
- [x] All 551 unit tests pass
- [x] All 2 smoke tests pass
- [x] All 148 integration tests pass (including 24 new agentic tests)
- [x] Raw JSON responses manually inspected for correctness (line numbers, text content, field names, structural completeness)
- [x] Formatted with `pixi run format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon mode: background service with workspace watching and socket support
  * Relay mode: stdio ↔ Unix-socket message relay
  * Expanded agentic RPC/CLI: project files, deps/impact, symbol search/read, document symbols, definitions, references, call graphs, type hierarchy, status, shutdown; richer query options

* **Behavioral**
  * Improved indexing lifecycle and status reporting; safer shutdown coordination and client handling

* **Tests**
  * New integration tests covering agentic RPC endpoints, CLI status, shutdown, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->