### PR TITLE
refactor(command): replace LLVM OptTable with kotatsu option parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ target_link_libraries(clice-core PUBLIC
     flatbuffers
     kota::ipc::lsp
     kota::codec::toml
+    kota::option
     simdjson::simdjson
 )
 

--- a/src/command/argument_parser.cpp
+++ b/src/command/argument_parser.cpp
@@ -1,94 +1,165 @@
 #include "command/argument_parser.h"
 
-#include <array>
+#include <span>
+#include <string_view>
+#include <utility>
 
-#include "llvm/ADT/SmallString.h"
+#include <kota/deco/option.h>
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringTable.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "clang/Driver/Driver.h"
-#include "clang/Driver/Options.h"
 #include "clang/Driver/Types.h"
 
 namespace clice {
 
-namespace {
+namespace option {
 
-namespace opt = llvm::opt;
-namespace driver = clang::driver;
+namespace eo = kota::option;
 
-/// Access private members of OptTable via the Thief pattern.
-bool enable_dash_dash_parsing(const opt::OptTable& table);
-bool enable_grouped_short_options(const opt::OptTable& table);
+namespace detail {
 
-template <auto MP1, auto MP2>
-struct Thief {
-    friend bool enable_dash_dash_parsing(const opt::OptTable& table) {
-        return table.*MP1;
+#define OPTTABLE_STR_TABLE_CODE
+#include "clang/Driver/Options.inc"
+#undef OPTTABLE_STR_TABLE_CODE
+
+#define OPTTABLE_PREFIXES_TABLE_CODE
+#include "clang/Driver/Options.inc"
+#undef OPTTABLE_PREFIXES_TABLE_CODE
+
+static_assert(OptionPrefixesTable[0].value() == 0, "pfx_none: 0 prefixes");
+static_assert(OptionPrefixesTable[1].value() == 1, "pfx_dash: 1 prefix");
+static_assert(OptionPrefixesTable[3].value() == 2, "pfx_dash_double: 2 prefixes");
+static_assert(OptionPrefixesTable[6].value() == 1, "pfx_double: 1 prefix");
+static_assert(OptionPrefixesTable[8].value() == 3, "pfx_all: 3 prefixes");
+static_assert(OptionPrefixesTable[12].value() == 2, "pfx_slash_dash: 2 prefixes");
+
+constexpr std::span<const std::string_view> prefixes(unsigned offset) {
+    switch(offset) {
+        case 0: return eo::pfx_none;
+        case 1: return eo::pfx_dash;
+        case 3: return eo::pfx_dash_double;
+        case 6: return eo::pfx_double;
+        case 8: return eo::pfx_all;
+        case 12: return eo::pfx_slash_dash;
+        default: std::unreachable();
     }
-
-    friend bool enable_grouped_short_options(const opt::OptTable& table) {
-        return table.*MP2;
-    }
-};
-
-template struct Thief<&opt::OptTable::DashDashParsing, &opt::OptTable::GroupedShortOptions>;
-
-auto& option_table = driver::getDriverOptTable();
-
-}  // namespace
-
-std::unique_ptr<llvm::opt::Arg> ArgumentParser::parse_one(unsigned& index) {
-    assert(!enable_dash_dash_parsing(option_table));
-    assert(!enable_grouped_short_options(option_table));
-    return option_table.ParseOneArg(*this, index, opt::Visibility(visibility_mask));
 }
 
-using ID = clang::driver::options::ID;
+constexpr std::string_view str_at(unsigned offset) {
+    auto ref = OptionStrTable[llvm::StringTable::Offset(offset)];
+    return {ref.data(), ref.size()};
+}
+
+}  // namespace detail
+
+const eo::OptTable& table() {
+    using enum eo::Kind;
+    using detail::prefixes;
+    using detail::str_at;
+
+    enum ClangDriverFlag : unsigned {
+        HelpHidden = eo::HelpHidden,
+        RenderAsInput = eo::RenderAsInput,
+        RenderJoined = eo::RenderJoined,
+        Ignored = 1u << 4,
+        LinkOption = 1u << 5,
+        LinkerInput = 1u << 6,
+        NoArgumentUnused = 1u << 7,
+        NoXarchOption = 1u << 8,
+        TargetSpecific = 1u << 9,
+        Unsupported = 1u << 10,
+    };
+
+    constexpr static eo::Option option_infos[] = {
+#define OPTION(PREFIXES_OFFSET,                                                                    \
+               NAME_OFFSET,                                                                        \
+               ID,                                                                                 \
+               KIND,                                                                               \
+               GROUP,                                                                              \
+               ALIAS,                                                                              \
+               ALIAS_ARGS,                                                                         \
+               FLAGS,                                                                              \
+               VISIBILITY,                                                                         \
+               PARAM,                                                                              \
+               HELP,                                                                               \
+               HELP_TEXTS,                                                                         \
+               META_VAR,                                                                           \
+               VALUES)                                                                             \
+    eo::Option{                                                                                    \
+        .prefixes = prefixes(PREFIXES_OFFSET),                                                     \
+        .prefixed_name = str_at(NAME_OFFSET),                                                      \
+        .id = OPT_##ID,                                                                            \
+        .kind = KIND,                                                                              \
+        .group_id = OPT_##GROUP,                                                                   \
+        .alias_id = OPT_##ALIAS,                                                                   \
+        .alias_args = ALIAS_ARGS,                                                                  \
+        .flags = FLAGS,                                                                            \
+        .visibility = VISIBILITY,                                                                  \
+        .num_args = PARAM,                                                                         \
+        .help_text = HELP,                                                                         \
+        .meta_var = META_VAR,                                                                      \
+    },
+#include "clang/Driver/Options.inc"
+#undef OPTION
+    };
+
+    const static auto opt_table = [] {
+        auto t = eo::OptTable(std::span(option_infos));
+        t.tablegen_mode = true;
+        return t;
+    }();
+    return opt_table;
+}
+
+}  // namespace option
+
+using namespace option;
 
 bool is_discarded_option(unsigned id) {
     switch(id) {
         /// Input file, unknown args, and output — we manage these ourselves.
-        case ID::OPT_INPUT:
-        case ID::OPT_UNKNOWN:
-        case ID::OPT__DASH_DASH:
-        case ID::OPT_c:
-        case ID::OPT_o:
-        case ID::OPT_dxc_Fc:
-        case ID::OPT_dxc_Fo:
-        case ID::OPT__SLASH_Fo:
-        case ID::OPT__SLASH_Fd:
+        case OPT_INPUT:
+        case OPT_UNKNOWN:
+        case OPT__DASH_DASH:
+        case OPT_c:
+        case OPT_o:
+        case OPT_dxc_Fc:
+        case OPT_dxc_Fo:
+        case OPT__SLASH_Fo:
+        case OPT__SLASH_Fd:
 
         /// PCH building.
-        case ID::OPT_emit_pch:
-        case ID::OPT_include_pch:
-        case ID::OPT__SLASH_Yu:
-        case ID::OPT__SLASH_Fp:
+        case OPT_emit_pch:
+        case OPT_include_pch:
+        case OPT__SLASH_Yu:
+        case OPT__SLASH_Fp:
 
         /// Dependency scan.
-        case ID::OPT_E:
-        case ID::OPT_M:
-        case ID::OPT_MM:
-        case ID::OPT_MD:
-        case ID::OPT_MMD:
-        case ID::OPT_MF:
-        case ID::OPT_MT:
-        case ID::OPT_MQ:
-        case ID::OPT_MG:
-        case ID::OPT_MP:
-        case ID::OPT_show_inst:
-        case ID::OPT_show_encoding:
-        case ID::OPT_show_includes:
-        case ID::OPT__SLASH_showFilenames:
-        case ID::OPT__SLASH_showFilenames_:
-        case ID::OPT__SLASH_showIncludes:
-        case ID::OPT__SLASH_showIncludes_user:
+        case OPT_E:
+        case OPT_M:
+        case OPT_MM:
+        case OPT_MD:
+        case OPT_MMD:
+        case OPT_MF:
+        case OPT_MT:
+        case OPT_MQ:
+        case OPT_MG:
+        case OPT_MP:
+        case OPT_show_inst:
+        case OPT_show_encoding:
+        case OPT_show_includes:
+        case OPT__SLASH_showFilenames:
+        case OPT__SLASH_showFilenames_:
+        case OPT__SLASH_showIncludes:
+        case OPT__SLASH_showIncludes_user:
 
         /// C++ modules — we handle these ourselves.
-        case ID::OPT_fmodule_file:
-        case ID::OPT_fmodule_output:
-        case ID::OPT_fprebuilt_module_path: return true;
+        case OPT_fmodule_file:
+        case OPT_fmodule_output:
+        case OPT_fprebuilt_module_path: return true;
 
         default: return false;
     }
@@ -96,70 +167,51 @@ bool is_discarded_option(unsigned id) {
 
 bool is_user_content_option(unsigned id) {
     switch(id) {
-        case ID::OPT_I:
-        case ID::OPT_isystem:
-        case ID::OPT_iquote:
-        case ID::OPT_idirafter:
-        case ID::OPT_D:
-        case ID::OPT_U:
-        case ID::OPT_include: return true;
+        case OPT_I:
+        case OPT_isystem:
+        case OPT_iquote:
+        case OPT_idirafter:
+        case OPT_D:
+        case OPT_U:
+        case OPT_include: return true;
         default: return false;
     }
 }
 
 bool is_include_path_option(unsigned id) {
     switch(id) {
-        case ID::OPT_I:
-        case ID::OPT_isystem:
-        case ID::OPT_iquote:
-        case ID::OPT_idirafter: return true;
+        case OPT_I:
+        case OPT_isystem:
+        case OPT_iquote:
+        case OPT_idirafter: return true;
         default: return false;
     }
 }
 
 bool is_xclang_option(unsigned id) {
-    return id == ID::OPT_Xclang;
+    return id == OPT_Xclang;
 }
 
 bool is_toolchain_option(unsigned id) {
     switch(id) {
-        case ID::OPT_target:
-        case ID::OPT_target_legacy_spelling:
-        case ID::OPT_isysroot:
-        case ID::OPT__sysroot_EQ:
-        case ID::OPT__sysroot:
-        case ID::OPT_stdlib_EQ:
-        case ID::OPT_gcc_toolchain:
-        case ID::OPT_gcc_install_dir_EQ:
-        case ID::OPT_nostdinc:
-        case ID::OPT_nostdincxx:
-        case ID::OPT_std_EQ:
-        case ID::OPT_x: return true;
+        case OPT_target:
+        case OPT_target_legacy_spelling:
+        case OPT_isysroot:
+        case OPT__sysroot_EQ:
+        case OPT__sysroot:
+        case OPT_stdlib_EQ:
+        case OPT_gcc_toolchain:
+        case OPT_gcc_install_dir_EQ:
+        case OPT_nostdinc:
+        case OPT_nostdincxx:
+        case OPT_std_EQ:
+        case OPT_x: return true;
         default: return false;
-    }
-}
-
-std::optional<std::uint32_t> get_option_id(llvm::StringRef argument) {
-    llvm::SmallString<64> buffer = argument;
-
-    if(argument.ends_with("=")) {
-        buffer += "placeholder";
-    }
-
-    unsigned index = 1;
-    std::array arguments = {"clang++", buffer.c_str(), "placeholder"};
-    llvm::opt::InputArgList arg_list(arguments.data(), arguments.data() + arguments.size());
-
-    if(auto arg = option_table.ParseOneArg(arg_list, index)) {
-        return arg->getOption().getID();
-    } else {
-        return {};
     }
 }
 
 llvm::StringRef resource_dir() {
     static std::string dir = [] {
-        // Use address of this lambda to locate our binary via dladdr/proc.
         static int anchor;
         auto exe = llvm::sys::fs::getMainExecutable("", &anchor);
         if(exe.empty()) {
@@ -170,56 +222,56 @@ llvm::StringRef resource_dir() {
     return dir;
 }
 
-bool is_codegen_option(unsigned id, const llvm::opt::Option& opt) {
+bool is_codegen_option(unsigned id) {
     /// Debug info options form a group (-g, -gdwarf-*, -gsplit-dwarf, etc.).
-    if(opt.matches(ID::OPT_DebugInfo_Group)) {
+    if(auto opt = option::table().option(id); opt && opt->matches(OPT_DebugInfo_Group)) {
         return true;
     }
 
     switch(id) {
         /// Position-independent code — pure codegen, no macro or semantic effect.
-        case ID::OPT_fPIC:
-        case ID::OPT_fno_PIC:
-        case ID::OPT_fpic:
-        case ID::OPT_fno_pic:
-        case ID::OPT_fPIE:
-        case ID::OPT_fno_PIE:
-        case ID::OPT_fpie:
-        case ID::OPT_fno_pie:
+        case OPT_fPIC:
+        case OPT_fno_PIC:
+        case OPT_fpic:
+        case OPT_fno_pic:
+        case OPT_fPIE:
+        case OPT_fno_PIE:
+        case OPT_fpie:
+        case OPT_fno_pie:
 
         /// Frame pointer and unwind tables — pure codegen.
-        case ID::OPT_fomit_frame_pointer:
-        case ID::OPT_fno_omit_frame_pointer:
-        case ID::OPT_funwind_tables:
-        case ID::OPT_fno_unwind_tables:
-        case ID::OPT_fasynchronous_unwind_tables:
-        case ID::OPT_fno_asynchronous_unwind_tables:
+        case OPT_fomit_frame_pointer:
+        case OPT_fno_omit_frame_pointer:
+        case OPT_funwind_tables:
+        case OPT_fno_unwind_tables:
+        case OPT_fasynchronous_unwind_tables:
+        case OPT_fno_asynchronous_unwind_tables:
 
         /// Stack protection — pure codegen.
-        case ID::OPT_fstack_protector:
-        case ID::OPT_fstack_protector_strong:
-        case ID::OPT_fstack_protector_all:
-        case ID::OPT_fno_stack_protector:
+        case OPT_fstack_protector:
+        case OPT_fstack_protector_strong:
+        case OPT_fstack_protector_all:
+        case OPT_fno_stack_protector:
 
         /// Section splitting, LTO, semantic interposition — pure codegen/linker.
-        case ID::OPT_fdata_sections:
-        case ID::OPT_fno_data_sections:
-        case ID::OPT_ffunction_sections:
-        case ID::OPT_fno_function_sections:
-        case ID::OPT_flto:
-        case ID::OPT_flto_EQ:
-        case ID::OPT_fno_lto:
-        case ID::OPT_fsemantic_interposition:
-        case ID::OPT_fno_semantic_interposition:
-        case ID::OPT_fvisibility_inlines_hidden:
+        case OPT_fdata_sections:
+        case OPT_fno_data_sections:
+        case OPT_ffunction_sections:
+        case OPT_fno_function_sections:
+        case OPT_flto:
+        case OPT_flto_EQ:
+        case OPT_fno_lto:
+        case OPT_fsemantic_interposition:
+        case OPT_fno_semantic_interposition:
+        case OPT_fvisibility_inlines_hidden:
 
         /// Diagnostics output formatting — doesn't affect analysis.
-        case ID::OPT_fcolor_diagnostics:
-        case ID::OPT_fno_color_diagnostics:
+        case OPT_fcolor_diagnostics:
+        case OPT_fno_color_diagnostics:
 
         /// Floating-point codegen — doesn't define macros (unlike -ffast-math).
-        case ID::OPT_ftrapping_math:
-        case ID::OPT_fno_trapping_math: return true;
+        case OPT_ftrapping_math:
+        case OPT_fno_trapping_math: return true;
 
         default: return false;
     }
@@ -246,7 +298,6 @@ std::string print_argv(llvm::ArrayRef<const char*> args) {
 }
 
 unsigned default_visibility(llvm::StringRef driver) {
-    namespace options = clang::driver::options;
     auto name = llvm::sys::path::filename(driver);
     name.consume_back(".exe");
 
@@ -260,7 +311,7 @@ unsigned default_visibility(llvm::StringRef driver) {
         return ~0u;
     }
     /// Exclude CLOption to prevent /U, /D, /I from matching Unix paths.
-    return ~static_cast<unsigned>(options::CLOption);
+    return ~static_cast<unsigned>(CLOption);
 }
 
 bool is_c_family_file(llvm::StringRef filename) {
@@ -269,7 +320,7 @@ bool is_c_family_file(llvm::StringRef filename) {
     if(ext.empty()) {
         return false;
     }
-    /// Drop the leading dot: ".cpp" → "cpp".
+    /// Drop the leading dot: ".cpp" -> "cpp".
     auto type = types::lookupTypeForExtension(ext.drop_front());
     return type != types::TY_INVALID && types::isAcceptedByClang(type);
 }

--- a/src/command/argument_parser.h
+++ b/src/command/argument_parser.h
@@ -1,89 +1,48 @@
 #pragma once
 
-#include <cassert>
-#include <cstdint>
-#include <memory>
-#include <optional>
-
+#include <kota/deco/option.h>
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Option/ArgList.h"
-#include "llvm/Support/Allocator.h"
 
 namespace clice {
 
-class ArgumentParser final : public llvm::opt::ArgList {
-public:
-    ArgumentParser(llvm::BumpPtrAllocator* allocator) : allocator(allocator) {}
+namespace option {
 
-    ~ArgumentParser() {
-        /// We never use the private `Args` field, so make sure it's empty.
-        if(getArgs().size() != 0) {
-            std::abort();
-        }
-    }
+enum ID : unsigned {
+    OPT_INVALID = 0,
 
-    const char* getArgString(unsigned index) const override {
-        return arguments[index];
-    }
-
-    unsigned getNumInputArgStrings() const override {
-        return arguments.size();
-    }
-
-    const char* MakeArgStringRef(llvm::StringRef s) const override {
-        auto p = allocator->Allocate<char>(s.size() + 1);
-        std::ranges::copy(s, p);
-        p[s.size()] = '\0';
-        return p;
-    }
-
-    /// Set visibility mask for option parsing. The default (~0u) accepts all
-    /// options. Pass a narrower mask to exclude option groups — e.g. exclude
-    /// MSVC cl.exe-style /U, /D, /I options that would otherwise misparse
-    /// Unix absolute paths like /Users/... on macOS.
-    void set_visibility(unsigned mask) {
-        visibility_mask = mask;
-    }
-
-    /// Parse a single argument at the given index. Defined out-of-line in
-    /// argument_parser.cpp to isolate the heavy clang driver option table include.
-    std::unique_ptr<llvm::opt::Arg> parse_one(unsigned& index);
-
-    void parse(llvm::ArrayRef<const char*> arguments, const auto& on_parse, const auto& on_error) {
-        this->arguments = arguments;
-
-        unsigned it = 0;
-        while(it != arguments.size()) {
-            llvm::StringRef s = arguments[it];
-
-            if(s.empty()) [[unlikely]] {
-                it += 1;
-                continue;
-            }
-
-            auto prev = it;
-            auto arg = parse_one(it);
-            assert(it > prev && "parser failed to consume argument");
-
-            if(!arg) [[unlikely]] {
-                assert(it >= arguments.size() && "unexpected parser error!");
-                assert(it - prev - 1 && "no missing arguments!");
-
-                on_error(prev, it - prev - 1);
-                break;
-            }
-
-            on_parse(std::move(arg));
-        }
-    }
-
-private:
-    llvm::BumpPtrAllocator* allocator;
-    unsigned visibility_mask = ~0u;
-
-    llvm::ArrayRef<const char*> arguments;
+#define OPTION(PREFIXES_OFFSET,                                                                    \
+               NAME_OFFSET,                                                                        \
+               ID,                                                                                 \
+               KIND,                                                                               \
+               GROUP,                                                                              \
+               ALIAS,                                                                              \
+               ALIAS_ARGS,                                                                         \
+               FLAGS,                                                                              \
+               VISIBILITY,                                                                         \
+               PARAM,                                                                              \
+               HELP,                                                                               \
+               HELP_TEXTS,                                                                         \
+               META_VAR,                                                                           \
+               VALUES)                                                                             \
+    OPT_##ID,
+#include "clang/Driver/Options.inc"
+#undef OPTION
 };
+
+enum DriverClass : unsigned {
+    DefaultVis = 1u << 0,
+    CLOption = 1u << 1,
+    CC1Option = 1u << 2,
+    CC1AsOption = 1u << 3,
+    FlangOption = 1u << 4,
+    FC1Option = 1u << 5,
+    DXCOption = 1u << 6,
+};
+
+const kota::option::OptTable& table();
+
+}  // namespace option
 
 /// Check if an option is a codegen-only flag that doesn't affect frontend
 /// semantics (parsing, diagnostics, code completion). These are pure
@@ -93,7 +52,7 @@ private:
 ///   -fno-exceptions, -fno-rtti, -std=*, -march=*, -fsanitize=*, -O*, -W*
 ///
 /// Defined out-of-line in argument_parser.cpp (needs clang driver option IDs).
-bool is_codegen_option(unsigned id, const llvm::opt::Option& opt);
+bool is_codegen_option(unsigned id);
 
 /// Options that are completely irrelevant to an LSP and should be discarded
 /// (input/output, PCH building, dependency scan, C++ modules).
@@ -113,9 +72,6 @@ bool is_xclang_option(unsigned id);
 /// Options that affect system path discovery and should be included in the
 /// toolchain cache key. Only these flags are passed to the toolchain query.
 bool is_toolchain_option(unsigned id);
-
-/// Get the option ID for a specific argument string.
-std::optional<std::uint32_t> get_option_id(llvm::StringRef argument);
 
 /// Get the resource directory for clang builtin headers. Computed once
 /// from the current executable path using Driver::GetResourcesPath.

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -72,50 +72,6 @@ llvm::ArrayRef<CompilationEntry> CompilationDatabase::find_entries(std::uint32_t
     return {&*first, static_cast<size_t>(last - first)};
 }
 
-namespace {
-
-/// Shared render logic for a parsed argument. Calls `emit(StringRef)` for each
-/// output token, handling all four render styles.
-template <typename Emit>
-void render_arg_to(Emit&& emit, llvm::opt::Arg& arg) {
-    switch(arg.getOption().getRenderStyle()) {
-        case llvm::opt::Option::RenderValuesStyle:
-            for(auto value: arg.getValues()) {
-                emit(llvm::StringRef(value));
-            }
-            break;
-
-        case llvm::opt::Option::RenderSeparateStyle:
-            emit(arg.getSpelling());
-            for(auto value: arg.getValues()) {
-                emit(llvm::StringRef(value));
-            }
-            break;
-
-        case llvm::opt::Option::RenderJoinedStyle: {
-            llvm::SmallString<256> first = {arg.getSpelling(), arg.getValue(0)};
-            emit(llvm::StringRef(first));
-            for(auto value: llvm::ArrayRef(arg.getValues()).drop_front()) {
-                emit(llvm::StringRef(value));
-            }
-            break;
-        }
-
-        case llvm::opt::Option::RenderCommaJoinedStyle: {
-            llvm::SmallString<256> buffer = arg.getSpelling();
-            for(unsigned i = 0; i < arg.getNumValues(); i++) {
-                if(i)
-                    buffer += ',';
-                buffer += arg.getValue(i);
-            }
-            emit(llvm::StringRef(buffer));
-            break;
-        }
-    }
-}
-
-}  // namespace
-
 llvm::ArrayRef<const char*> CompilationDatabase::persist_args(llvm::ArrayRef<const char*> args) {
     if(args.empty())
         return {};
@@ -130,8 +86,11 @@ object_ptr<CompilationInfo>
                                                llvm::ArrayRef<const char*> arguments) {
     assert(!arguments.empty() && "arguments must contain at least the driver");
 
-    auto render_arg = [&](auto& out, llvm::opt::Arg& arg) {
-        render_arg_to([&](llvm::StringRef s) { out.push_back(strings.save(s).data()); }, arg);
+    auto render_arg = [&](auto& out, const kota::option::ParsedArg& arg) {
+        auto cb = [&](std::string_view s) {
+            out.push_back(strings.save(s).data());
+        };
+        option::table().render(arg, cb);
     };
 
     llvm::SmallVector<const char*, 32> canonical_args;
@@ -142,63 +101,63 @@ object_ptr<CompilationInfo>
 
     bool remove_pch = false;
 
-    parser->set_visibility(default_visibility(arguments[0]));
+    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
+    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
+                                              .visibility = default_visibility(arguments[0])};
+    for(auto& result: option::table().parse(parse_args, options)) {
+        if(!result.has_value()) {
+            auto& err = result.error();
+            LOG_WARN("parse error at index {}: {} when parse: {}", err.index, err.message, file);
+            continue;
+        }
+        auto& arg = *result;
+        auto id = arg.id;
 
-    auto on_error = [&](int index, int count) {
-        LOG_WARN("missing argument index: {}, count: {} when parse: {}", index, count, file);
-    };
+        /// Discard options irrelevant to frontend.
+        if(is_discarded_option(id)) {
+            continue;
+        }
 
-    parser->parse(
-        llvm::ArrayRef(arguments).drop_front(),
-        [&](std::unique_ptr<llvm::opt::Arg> arg) {
-            auto& opt = arg->getOption();
-            auto id = opt.getID();
+        /// Discard codegen-only options.
+        if(is_codegen_option(id)) {
+            continue;
+        }
 
-            /// Discard options irrelevant to frontend.
-            if(is_discarded_option(id)) {
-                return;
+        /// Handle CMake's Xclang PCH workaround:
+        /// -Xclang -include-pch -Xclang <pchfile> → discard both pairs.
+        if(is_xclang_option(id) && arg.values.size() == 1) {
+            if(remove_pch) {
+                remove_pch = false;
+                continue;
             }
-
-            /// Discard codegen-only options.
-            if(is_codegen_option(id, opt)) {
-                return;
+            std::string_view value = arg.values[0];
+            if(value == "-include-pch") {
+                remove_pch = true;
+                continue;
             }
+        }
 
-            /// Handle CMake's Xclang PCH workaround:
-            /// -Xclang -include-pch -Xclang <pchfile> → discard both pairs.
-            if(is_xclang_option(id) && arg->getNumValues() == 1) {
-                if(remove_pch) {
-                    remove_pch = false;
-                    return;
+        /// User-content options go into per-file patch.
+        if(is_user_content_option(id)) {
+            /// Absolutize relative paths for include-path options.
+            if(is_include_path_option(id) && arg.values.size() == 1) {
+                patch_args.push_back(
+                    strings.save(option::table().option(id)->prefixed_name()).data());
+                llvm::StringRef value(arg.values[0]);
+                if(!value.empty() && !path::is_absolute(value)) {
+                    patch_args.push_back(strings.save(path::join(directory, value)).data());
+                } else {
+                    patch_args.push_back(strings.save(value).data());
                 }
-                llvm::StringRef value = arg->getValue(0);
-                if(value == "-include-pch") {
-                    remove_pch = true;
-                    return;
-                }
+                continue;
             }
+            render_arg(patch_args, arg);
+            continue;
+        }
 
-            /// User-content options go into per-file patch.
-            if(is_user_content_option(id)) {
-                /// Absolutize relative paths for include-path options.
-                if(is_include_path_option(id) && arg->getNumValues() == 1) {
-                    patch_args.push_back(strings.save(arg->getSpelling()).data());
-                    llvm::StringRef value = arg->getValue(0);
-                    if(!value.empty() && !path::is_absolute(value)) {
-                        patch_args.push_back(strings.save(path::join(directory, value)).data());
-                    } else {
-                        patch_args.push_back(strings.save(value).data());
-                    }
-                    return;
-                }
-                render_arg(patch_args, *arg);
-                return;
-            }
-
-            /// Everything else goes into canonical.
-            render_arg(canonical_args, *arg);
-        },
-        on_error);
+        /// Everything else goes into canonical.
+        render_arg(canonical_args, arg);
+    }
 
     /// Dedup canonical command.
     auto canonical_id = canonicals.get(CanonicalCommand{canonical_args});
@@ -372,8 +331,11 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
     auto path_id = paths.intern(file);
     auto matched = find_entries(path_id);
 
-    auto render_arg = [&](auto& out, llvm::opt::Arg& arg) {
-        render_arg_to([&](llvm::StringRef s) { out.push_back(strings.save(s).data()); }, arg);
+    auto render_arg = [&](auto& out, const kota::option::ParsedArg& arg) {
+        auto cb = [&](std::string_view s) {
+            out.push_back(strings.save(s).data());
+        };
+        option::table().render(arg, cb);
     };
 
     /// Build one CompileCommand from a single CompilationInfo.
@@ -464,18 +426,18 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
 
         // Apply remove filter.
         if(!options.remove.empty()) {
-            using Arg = std::unique_ptr<llvm::opt::Arg>;
-            llvm::SmallVector<const char*> remove_strs;
+            std::vector<std::string> remove_strs;
             for(auto& s: options.remove) {
-                remove_strs.push_back(strings.save(s).data());
+                remove_strs.push_back(s);
             }
-            llvm::SmallVector<Arg> remove_args;
-            parser->parse(
-                remove_strs,
-                [&remove_args](Arg arg) { remove_args.emplace_back(std::move(arg)); },
-                [](int, int) {});
-            auto get_id = [](const Arg& arg) {
-                return arg->getOption().getID();
+            std::vector<kota::option::ParsedArg> remove_args;
+            for(auto& result: option::table().parse(remove_strs)) {
+                if(result.has_value()) {
+                    remove_args.push_back(*result);
+                }
+            }
+            auto get_id = [](const kota::option::ParsedArg& arg) {
+                return arg.id;
             };
             std::ranges::sort(remove_args, {}, get_id);
 
@@ -483,26 +445,29 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
             flags.clear();
             flags.push_back(saved_flags.front());
 
-            parser->parse(
-                llvm::ArrayRef(saved_flags).drop_front(),
-                [&](Arg arg) {
-                    auto id = arg->getOption().getID();
-                    auto range = std::ranges::equal_range(remove_args, id, {}, get_id);
-                    for(auto& remove: range) {
-                        if(remove->getNumValues() == 1 &&
-                           remove->getValue(0) == llvm::StringRef("*")) {
-                            return;
-                        }
-                        if(std::ranges::equal(
-                               arg->getValues(),
-                               remove->getValues(),
-                               [](llvm::StringRef l, llvm::StringRef r) { return l == r; })) {
-                            return;
-                        }
+            std::vector<std::string> saved_parse_args(saved_flags.begin() + 1, saved_flags.end());
+            for(auto& result: option::table().parse(saved_parse_args)) {
+                if(!result.has_value()) {
+                    continue;
+                }
+                auto& arg = *result;
+                auto id = arg.id;
+                auto range = std::ranges::equal_range(remove_args, id, {}, get_id);
+                bool removed = false;
+                for(auto& remove: range) {
+                    if(remove.values.size() == 1 && remove.values[0] == "*") {
+                        removed = true;
+                        break;
                     }
-                    render_arg(flags, *arg);
-                },
-                [](int, int) {});
+                    if(std::ranges::equal(arg.values, remove.values)) {
+                        removed = true;
+                        break;
+                    }
+                }
+                if(!removed) {
+                    render_arg(flags, arg);
+                }
+            }
         }
 
         for(auto& arg: options.append) {
@@ -589,30 +554,33 @@ CompilationDatabase::ToolchainExtract
 
     result.query_args.push_back(arguments[0]);
 
-    parser->set_visibility(default_visibility(arguments[0]));
+    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
+    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
+                                              .visibility = default_visibility(arguments[0])};
+    for(auto& result_arg: option::table().parse(parse_args, options)) {
+        if(!result_arg.has_value()) {
+            continue;
+        }
+        auto& arg = *result_arg;
+        auto id = arg.id;
+        if(!is_toolchain_option(id)) {
+            continue;
+        }
 
-    parser->parse(
-        llvm::ArrayRef(arguments).drop_front(),
-        [&](std::unique_ptr<llvm::opt::Arg> arg) {
-            auto id = arg->getOption().getID();
-            if(!is_toolchain_option(id)) {
-                return;
-            }
-
-            // Add option ID and all its values to the cache key.
-            result.key += std::to_string(id);
+        // Add option ID and all its values to the cache key.
+        result.key += std::to_string(id);
+        result.key += '\0';
+        for(auto value: arg.values) {
+            result.key += value;
             result.key += '\0';
-            for(auto value: arg->getValues()) {
-                result.key += value;
-                result.key += '\0';
-            }
+        }
 
-            // Render the argument back to query args.
-            render_arg_to(
-                [&](llvm::StringRef s) { result.query_args.push_back(strings.save(s).data()); },
-                *arg);
-        },
-        [](int, int) {});
+        // Render the argument back to query args.
+        auto cb = [&](std::string_view s) {
+            result.query_args.push_back(strings.save(s).data());
+        };
+        option::table().render(arg, cb);
+    }
 
     return result;
 }

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -316,8 +316,6 @@ private:
 
     /// Cache of toolchain query results, keyed by canonical toolchain key.
     llvm::StringMap<std::vector<const char*>> toolchain_cache;
-
-    std::unique_ptr<ArgumentParser> parser = std::make_unique<ArgumentParser>(allocator.get());
 };
 
 }  // namespace clice

--- a/src/command/search_config.cpp
+++ b/src/command/search_config.cpp
@@ -6,11 +6,10 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "clang/Driver/Options.h"
 
 namespace clice {
 
-using ID = clang::driver::options::ID;
+using namespace option;
 
 SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
                                    llvm::StringRef directory) {
@@ -23,7 +22,7 @@ SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
     std::vector<SearchDir> system;
     std::vector<SearchDir> after;
 
-    auto make_absolute = [&](llvm::StringRef path) -> std::string {
+    auto make_absolute = [&](std::string_view path) -> std::string {
         llvm::SmallString<256> abs_path(path);
         if(!llvm::sys::path::is_absolute(abs_path)) {
             llvm::sys::fs::make_absolute(directory, abs_path);
@@ -35,48 +34,46 @@ SearchConfig extract_search_config(llvm::ArrayRef<const char*> arguments,
     // Track -iprefix state for -iwithprefix/-iwithprefixbefore.
     std::string prefix;
 
-    llvm::BumpPtrAllocator allocator;
-    ArgumentParser parser{&allocator};
-    parser.set_visibility(default_visibility(arguments[0]));
+    std::vector<std::string> parse_args(arguments.begin() + 1, arguments.end());
+    auto options = kota::option::ParseOptions{.dash_dash_parsing = true,
+                                              .visibility = default_visibility(arguments[0])};
+    for(auto& result: option::table().parse(parse_args, options)) {
+        if(!result.has_value()) {
+            continue;
+        }
+        auto& arg = *result;
+        auto vals = arg.values;
+        switch(arg.id) {
+            // Quoted group (clang: frontend::Quoted)
+            case OPT_iquote: quoted.push_back({make_absolute(vals[0])}); break;
 
-    parser.parse(
-        llvm::ArrayRef(arguments).drop_front(),
-        [&](std::unique_ptr<llvm::opt::Arg> arg) {
-            auto id = arg->getOption().getID();
-            switch(id) {
-                // Quoted group (clang: frontend::Quoted)
-                case ID::OPT_iquote: quoted.push_back({make_absolute(arg->getValue())}); break;
+            // Angled group (clang: frontend::Angled)
+            case OPT_I: angled.push_back({make_absolute(vals[0])}); break;
 
-                // Angled group (clang: frontend::Angled)
-                case ID::OPT_I: angled.push_back({make_absolute(arg->getValue())}); break;
+            // System group (clang: frontend::System / ExternCSystem)
+            case OPT_isystem:
+            case OPT_internal_isystem:
+            case OPT_internal_externc_isystem: system.push_back({make_absolute(vals[0])}); break;
 
-                // System group (clang: frontend::System / ExternCSystem)
-                case ID::OPT_isystem:
-                case ID::OPT_internal_isystem:
-                case ID::OPT_internal_externc_isystem:
-                    system.push_back({make_absolute(arg->getValue())});
-                    break;
+            // Prefix options: must be processed in argument order.
+            case OPT_iprefix: prefix = vals[0]; break;
+            case OPT_iwithprefix:
+                // clang maps to After group.
+                after.push_back({make_absolute(prefix + std::string(vals[0]))});
+                break;
+            case OPT_iwithprefixbefore:
+                // clang maps to Angled group.
+                angled.push_back({make_absolute(prefix + std::string(vals[0]))});
+                break;
 
-                // Prefix options: must be processed in argument order.
-                case ID::OPT_iprefix: prefix = arg->getValue(); break;
-                case ID::OPT_iwithprefix:
-                    // clang maps to After group.
-                    after.push_back({make_absolute(prefix + arg->getValue())});
-                    break;
-                case ID::OPT_iwithprefixbefore:
-                    // clang maps to Angled group.
-                    angled.push_back({make_absolute(prefix + arg->getValue())});
-                    break;
+            case OPT_idirafter: after.push_back({make_absolute(vals[0])}); break;
 
-                case ID::OPT_idirafter: after.push_back({make_absolute(arg->getValue())}); break;
-
-                // TODO: -cxx-isystem (clang: frontend::CXXSystem, C++-only system dirs)
-                // TODO: -iwithsysroot (prepends sysroot to path, then adds to System)
-                // TODO: HeaderMap support (-I foo.hmap remaps include names)
-                default: break;
-            }
-        },
-        [](int, int) {});
+            // TODO: -cxx-isystem (clang: frontend::CXXSystem, C++-only system dirs)
+            // TODO: -iwithsysroot (prepends sysroot to path, then adds to System)
+            // TODO: HeaderMap support (-I foo.hmap remaps include names)
+            default: break;
+        }
+    }
 
     // Concatenate: Quoted → Angled → System → After
     SearchConfig config;

--- a/tests/unit/command/argument_parser_tests.cpp
+++ b/tests/unit/command/argument_parser_tests.cpp
@@ -1,84 +1,133 @@
 #include "test/test.h"
 #include "command/argument_parser.h"
 
-#include "clang/Driver/Options.h"
-
 namespace clice::testing {
 
 namespace {
 
+using namespace option;
+
 TEST_SUITE(ArgumentParser) {
 
-using option = clang::driver::options::ID;
-
-void EXPECT_ID(llvm::StringRef command, option opt) {
-    auto id = get_option_id(command);
-    ASSERT_TRUE(id.has_value());
-    ASSERT_EQ(*id, int(opt));
+unsigned parse_first(std::vector<std::string> args) {
+    for(auto& result: option::table().parse(args)) {
+        if(result.has_value()) {
+            return result->id;
+        }
+    }
+    return OPT_INVALID;
 }
 
-TEST_CASE(GetOptionID) {
-    /// GroupClass
-    EXPECT_ID("-g", option::OPT_g_Flag);
+TEST_CASE(ParseOptionID) {
+    ASSERT_EQ(parse_first({"-g"}), OPT_g_Flag);
+    ASSERT_EQ(parse_first({"-v"}), OPT_v);
+    ASSERT_EQ(parse_first({"-c"}), OPT_c);
+    ASSERT_EQ(parse_first({"-pedantic"}), OPT_pedantic);
+    ASSERT_EQ(parse_first({"--pedantic"}), OPT_pedantic);
+    ASSERT_EQ(parse_first({"-Wno-unused-variable"}), OPT_W_Joined);
+    ASSERT_EQ(parse_first({"-Xclang", "-ast-dump"}), OPT_Xclang);
+    ASSERT_EQ(parse_first({"-Wl,foo"}), OPT_Wl_COMMA);
+    ASSERT_EQ(parse_first({"-o", "out.o"}), OPT_o);
+    ASSERT_EQ(parse_first({"-omain.o"}), OPT_o);
+    ASSERT_EQ(parse_first({"-I", "/usr/include"}), OPT_I);
+    ASSERT_EQ(parse_first({"-x", "c++"}), OPT_x);
+};
 
-    /// InputClass
-    EXPECT_ID("main.cpp", option::OPT_INPUT);
+TEST_CASE(InputAndUnknown) {
+    ASSERT_EQ(parse_first({"main.cpp"}), OPT_INPUT);
+    ASSERT_EQ(parse_first({"--clice-unknown-flag"}), OPT_UNKNOWN);
+};
 
-    /// UnknownClass
-    EXPECT_ID("--clice", option::OPT_UNKNOWN);
+TEST_CASE(AliasAndDashDash) {
+    ASSERT_EQ(parse_first({"--include-directory=/usr/include"}), OPT_I);
+    ASSERT_EQ(parse_first({"--language=c++"}), OPT_x);
+    ASSERT_EQ(parse_first({"--std=c++20"}), OPT_std_EQ);
 
-    /// FlagClass
-    EXPECT_ID("-v", option::OPT_v);
-    EXPECT_ID("-c", option::OPT_c);
-    EXPECT_ID("-pedantic", option::OPT_pedantic);
-    EXPECT_ID("--pedantic", option::OPT_pedantic);
+    std::vector<std::string> args = {"-I", "/usr/include", "--", "main.cpp"};
+    auto options = kota::option::ParseOptions{.dash_dash_parsing = true};
+    unsigned count = 0;
+    for(auto& result: option::table().parse(args, options)) {
+        if(result.has_value()) {
+            ++count;
+        }
+    }
+    ASSERT_EQ(count, 2u);
+};
 
-    /// JoinedClass
-    EXPECT_ID("-Wno-unused-variable", option::OPT_W_Joined);
-    EXPECT_ID("-W*", option::OPT_W_Joined);
-    EXPECT_ID("-W", option::OPT_W_Joined);
+TEST_CASE(ParseError) {
+    std::vector<std::string> args = {"-o"};
+    bool got_error = false;
+    for(auto& result: option::table().parse(args)) {
+        if(!result.has_value()) {
+            got_error = true;
+        }
+    }
+    EXPECT_TRUE(got_error);
+};
 
-    /// ValuesClass
+TEST_CASE(CLVisibility) {
+    auto cl_vis = default_visibility("clang-cl");
+    auto gcc_vis = default_visibility("clang++");
 
-    /// SeparateClass
-    EXPECT_ID("-Xclang", option::OPT_Xclang);
-    /// EXPECT_ID(GET_ID("-Xclang -ast-dump") , option::OPT_Xclang);
+    auto parse_with_vis = [](std::vector<std::string> args, unsigned vis) -> unsigned {
+        auto options = kota::option::ParseOptions{.dash_dash_parsing = true, .visibility = vis};
+        for(auto& result: option::table().parse(args, options)) {
+            if(result.has_value()) {
+                return result->id;
+            }
+        }
+        return OPT_INVALID;
+    };
 
-    /// RemainingArgsClass
+    ASSERT_EQ(parse_with_vis({"/DFOO"}, cl_vis), OPT_D);
+    ASSERT_EQ(parse_with_vis({"-DFOO"}, gcc_vis), OPT_D);
+    ASSERT_EQ(parse_with_vis({"-DFOO"}, cl_vis), OPT_D);
+};
 
-    /// RemainingArgsJoinedClass
+TEST_CASE(RenderRoundTrip) {
+    auto roundtrip = [](std::vector<std::string> input) -> std::vector<std::string> {
+        std::vector<std::string> rendered;
+        for(auto& result: option::table().parse(input)) {
+            if(!result.has_value())
+                continue;
+            auto cb = [&](std::string_view s) {
+                rendered.emplace_back(s);
+            };
+            option::table().render(*result, cb);
+        }
+        return rendered;
+    };
 
-    /// CommaJoinedClass
-    EXPECT_ID("-Wl,", option::OPT_Wl_COMMA);
+    auto r1 = roundtrip({"-I", "/usr/include"});
+    ASSERT_EQ(r1.size(), 2u);
+    ASSERT_EQ(r1[0], "-I");
+    ASSERT_EQ(r1[1], "/usr/include");
 
-    /// MultiArgClass
+    auto r2 = roundtrip({"-DFOO=bar"});
+    ASSERT_EQ(r2.size(), 2u);
+    ASSERT_EQ(r2[0], "-D");
+    ASSERT_EQ(r2[1], "FOO=bar");
 
-    /// JoinedOrSeparateClass
-    EXPECT_ID("-o", option::OPT_o);
-    EXPECT_ID("-omain.o", option::OPT_o);
-    EXPECT_ID("-I", option::OPT_I);
-    EXPECT_ID("--include-directory=", option::OPT_I);
-    EXPECT_ID("-x", option::OPT_x);
-    EXPECT_ID("--language=", option::OPT_x);
+    auto r3 = roundtrip({"-Wno-unused"});
+    ASSERT_EQ(r3.size(), 1u);
+    ASSERT_EQ(r3[0], "-Wno-unused");
 
-    /// JoinedAndSeparateClass
+    auto r4 = roundtrip({"-std=c++20"});
+    ASSERT_EQ(r4.size(), 1u);
+    ASSERT_EQ(r4[0], "-std=c++20");
 };
 
 TEST_CASE(PrintArgv) {
-    /// Normal args.
     std::vector<const char*> args = {"clang++", "-std=c++20", "main.cpp"};
     ASSERT_EQ(print_argv(args), "clang++ -std=c++20 main.cpp");
 
-    /// Empty args.
     std::vector<const char*> empty = {};
     ASSERT_EQ(print_argv(empty), "");
 
-    /// Args with spaces get quoted.
     std::vector<const char*> spaced = {"clang++", "-DFOO=hello world"};
     auto result = print_argv(spaced);
     EXPECT_TRUE(llvm::StringRef(result).contains("\""));
 
-    /// Args with backslash get quoted/escaped.
     std::vector<const char*> escaped = {"clang++", "-DPATH=C:\\foo"};
     auto result2 = print_argv(escaped);
     EXPECT_TRUE(llvm::StringRef(result2).contains("\""));


### PR DESCRIPTION
## Summary

- **Replace `llvm::opt::OptTable`/`ArgList` with `kota::option::OptTable`** — the old code used LLVM's option parsing infrastructure and a custom `ArgumentParser` class that subclassed `llvm::opt::ArgList` with a "Thief pattern" hack to access private `OptTable` members. Kotatsu provides a cleaner value-type API (`ParsedArg` with `.id`, `.values`, `.spelling`) and a range-based `table().parse()` that returns `expected<ParsedArg, ParseError>`.
- **Build the option table directly from `Options.inc`** — instead of calling `clang::driver::getDriverOptTable()`, we now construct a `kota::option::OptTable` at startup by bridging Clang's TableGen string/prefix tables through a `constexpr` adapter layer (prefix offset → kotatsu prefix span, string table offset → `string_view`).
- **Remove `ArgumentParser` class, `render_arg_to` template, and `get_option_id()` helper** — all replaced by kotatsu's `table().parse()`, `table().render()`, and `table().option()`. The `parser` member is removed from `CompilationDatabase`. `is_codegen_option` no longer needs an `llvm::opt::Option&` parameter.
- **Namespace cleanup** — `clang::driver::options::ID::OPT_xxx` → `option::OPT_xxx`. Option IDs live in an unscoped `enum ID` inside `clice::option`, with a `DriverClass` enum whose bit layout matches LLVM's `ClangVisibility`.
- **Rewrite unit tests** — expanded from 2 test cases (`GetOptionID`, `PrintArgv`) to 7, covering full parse round-trips, alias resolution, `--` stop parsing, parse errors, CL visibility filtering, and render fidelity.

## Details

The kotatsu option library is a standalone reimplementation of LLVM's `opt::OptTable` with a simpler API. The key adapter challenge is bridging Clang's `Options.inc` output (which assumes LLVM's internal table format) to kotatsu's `Option` struct. This is done via:
- `OPTTABLE_STR_TABLE_CODE` / `OPTTABLE_PREFIXES_TABLE_CODE` to pull in raw string and prefix data
- A `constexpr prefixes(offset)` switch that maps LLVM prefix table offsets to kotatsu's named prefix spans (`pfx_dash`, `pfx_all`, `pfx_slash_dash`, etc.)
- `static_assert`s that verify the prefix table layout hasn't changed across LLVM versions

`OPT_` prefix is retained (matching LLVM convention) because bare option names like `static` are C++ keywords.