### PR TITLE
refactor(command): subcommand-based CLI with SubCommander

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Debug clice",
       "program": "${workspaceFolder}/build/Debug/bin/clice",
-      "args": ["--mode=socket", "--port=50051"],
+      "args": ["server", "--mode", "socket", "--port", "50051"],
       "cwd": "${workspaceFolder}"
     },
     {
@@ -14,7 +14,7 @@
       "request": "launch",
       "name": "Debug clice (socket, RelWithDebInfo)",
       "program": "${workspaceFolder}/build/RelWithDebInfo/bin/clice",
-      "args": ["--mode=socket", "--port=50051"],
+      "args": ["server", "--mode", "socket", "--port", "50051"],
       "cwd": "${workspaceFolder}"
     },
     {

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -87,7 +87,7 @@ All feature responses use `RawValue` passthrough — the worker serializes the L
 
 ## Worker Pool
 
-The worker pool (`src/server/worker_pool.cpp`) manages spawning and communicating with worker processes. Each worker is a child process of the same `clice` binary, launched with `--mode stateful-worker` or `--mode stateless-worker`.
+The worker pool (`src/server/worker_pool.cpp`) manages spawning and communicating with worker processes. Each worker is a child process of the same `clice` binary, launched with `clice worker` (stateless by default) or `clice worker --memory-limit <bytes>` (stateful).
 
 ### Communication
 

--- a/docs/en/dev/test-and-debug.md
+++ b/docs/en/dev/test-and-debug.md
@@ -23,7 +23,7 @@ $ pytest -s --log-cli-level=INFO tests/integration --executable=./build/bin/clic
 If you want to attach a debugger to clice for debugging, it is recommended to first start clice in socket mode independently, and then connect the client to it.
 
 ```shell
-$ ./build/bin/clice --mode=socket --port=50051
+$ ./build/bin/clice server --mode socket --port 50051
 ```
 
 After the server starts, you can connect a client to the server in the following two ways:

--- a/docs/zh/dev/test-and-debug.md
+++ b/docs/zh/dev/test-and-debug.md
@@ -23,7 +23,7 @@ $ pytest -s --log-cli-level=INFO tests/integration --executable=./build/bin/clic
 如果想在 clice 上附加调试器并进行调试，推荐先单独以 socket 模式启动 clice，然后再将客户端连接到 clice 上
 
 ```shell
-$ ./build/bin/clice --mode=socket --port=50051
+$ ./build/bin/clice server --mode socket --port 50051
 ```
 
 在服务器启动之后，可以通过以下两种方式启动客户端连接到服务器

--- a/editors/nvim/doc/clice.lua
+++ b/editors/nvim/doc/clice.lua
@@ -25,7 +25,7 @@ local clice = {
 
     cmd = {
         'clice',
-        '--mode=pipe',
+        'server',
     },
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -45,7 +45,7 @@ export async function activate(context: ExtensionContext) {
             }
         }
 
-        let args = ["--mode=pipe"];
+        let args = ["server"];
         serverOptions = {
             run: { command: executable, args: args },
             debug: { command: executable, args: args },

--- a/editors/zed/src/clice.rs
+++ b/editors/zed/src/clice.rs
@@ -33,8 +33,7 @@ impl zed::Extension for CliceExtension {
         Ok(zed::Command {
             command: binary.path,
             args: vec![
-                "--mode".to_string(),
-                "pipe".to_string(),
+                "server".to_string(),
             ],
             env: Default::default(),
         })

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -84,7 +84,8 @@ int main(int argc, const char** argv) {
         .matchAll([&](clice::ServerOptions opts) {
             if(opts.help) {
                 clice::print_usage(server_cmd);
-                return exit_code = 0, void();
+                exit_code = 0;
+                return;
             }
             if(!clice::apply_log_level(opts.log_level.value_or("info")))
                 return;
@@ -110,7 +111,8 @@ int main(int argc, const char** argv) {
         .matchAll([&](clice::QueryOptions opts) {
             if(opts.help) {
                 clice::print_usage(query_cmd);
-                return exit_code = 0, void();
+                exit_code = 0;
+                return;
             }
             auto port = opts.port.value_or(0);
             if(port <= 0 || port > 65535) {
@@ -128,7 +130,8 @@ int main(int argc, const char** argv) {
         .matchAll([&](clice::WorkerOptions opts) {
             if(opts.help) {
                 clice::print_usage(worker_cmd);
-                return exit_code = 0, void();
+                exit_code = 0;
+                return;
             }
             auto name = opts.worker_name.value_or("worker");
             auto log_dir = opts.log_dir.value_or("");
@@ -145,7 +148,8 @@ int main(int argc, const char** argv) {
         .matchAll([&](clice::LintOptions opts) {
             if(opts.help) {
                 clice::print_usage(lint_cmd);
-                return exit_code = 0, void();
+                exit_code = 0;
+                return;
             }
             LOG_ERROR("lint is not yet implemented");
         })
@@ -156,7 +160,8 @@ int main(int argc, const char** argv) {
         .matchAll([&](clice::FormatOptions opts) {
             if(opts.help) {
                 clice::print_usage(format_cmd);
-                return exit_code = 0, void();
+                exit_code = 0;
+                return;
             }
             LOG_ERROR("format is not yet implemented");
         })

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -31,9 +31,14 @@ struct WorkerOptions {
     DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
     help;
 
+    DecoFlag(names = {"--stateful"},
+             help = "Run as stateful worker (default: stateless)",
+             required = false)
+    stateful;
+
     DecoKV(style = KVStyle::JoinedOrSeparate,
            names = {"--memory-limit", "--memory-limit="},
-           help = "Memory limit in bytes (presence implies stateful worker)",
+           help = "Memory limit in bytes (stateful worker only)",
            required = false)
     <std::uint64_t> memory_limit;
 
@@ -135,8 +140,9 @@ int main(int argc, const char** argv) {
             }
             auto name = opts.worker_name.value_or("worker");
             auto log_dir = opts.log_dir.value_or("");
-            if(opts.memory_limit.has_value()) {
-                exit_code = clice::run_stateful_worker_mode(*opts.memory_limit, name, log_dir);
+            if(opts.stateful) {
+                auto limit = opts.memory_limit.value_or(4ULL * 1024 * 1024 * 1024);
+                exit_code = clice::run_stateful_worker_mode(limit, name, log_dir);
             } else {
                 exit_code = clice::run_stateless_worker_mode(name, log_dir);
             }

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -1,7 +1,7 @@
 #include <csignal>
 #include <cstdint>
-#include <iostream>
 #include <print>
+#include <sstream>
 #include <string>
 
 #include "server/service/agentic.h"
@@ -14,84 +14,28 @@
 
 namespace clice {
 
-using kota::deco::decl::KVStyle;
+namespace deco = kota::deco;
+using deco::decl::KVStyle;
 
-struct Options {
-    DecoKV(
-        style = KVStyle::JoinedOrSeparate,
-        help =
-            "Running mode: pipe, socket, daemon, relay, agentic, stateless-worker, stateful-worker",
-        required = false)
-    <std::string> mode;
+struct LintOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Socket mode address", required = false)
-    <std::string> host = "127.0.0.1";
+struct FormatOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Agentic TCP port (0 = disabled)",
-           required = false)
-    <int> port = 0;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--log-level", "--log-level="},
-           help = "Log level: trace, debug, info, warn, error, off",
-           required = false)
-    <std::string> log_level = "info";
+struct WorkerOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
 
     DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Record LSP input to file for replay testing",
+           names = {"--memory-limit", "--memory-limit="},
+           help = "Memory limit in bytes (presence implies stateful worker)",
            required = false)
-    <std::string> record;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "File path for agentic queries",
-           required = false)
-    <std::string> path;
-
-    DecoKV(
-        style = KVStyle::JoinedOrSeparate,
-        help =
-            "Agentic method (compileCommand, symbolSearch, definition, references, "
-            "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, "
-            "fileDeps, impactAnalysis, status, shutdown)",
-        required = false)
-    <std::string> method;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Symbol name for agentic queries",
-           required = false)
-    <std::string> name;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Search query for symbolSearch",
-           required = false)
-    <std::string> query;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Line number for position-based lookup",
-           required = false)
-    <int> line;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Direction: callers/callees or supertypes/subtypes",
-           required = false)
-    <std::string> direction;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Unix domain socket path for daemon mode",
-           required = false)
-    <std::string> socket;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           help = "Workspace root directory for daemon mode",
-           required = false)
-    <std::string> workspace;
-
-    // Internal options (passed from master to worker processes)
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--worker-memory-limit", "--worker-memory-limit="},
-           required = false)
-    <std::uint64_t> worker_memory_limit;
+    <std::uint64_t> memory_limit;
 
     DecoKV(style = KVStyle::JoinedOrSeparate,
            names = {"--worker-name", "--worker-name="},
@@ -100,13 +44,26 @@ struct Options {
 
     DecoKV(style = KVStyle::JoinedOrSeparate, names = {"--log-dir", "--log-dir="}, required = false)
     <std::string> log_dir;
-
-    DecoFlag(names = {"-h", "--help"}, help = "Show help message", required = false)
-    help;
-
-    DecoFlag(names = {"-v", "--version"}, help = "Show version", required = false)
-    version;
 };
+
+bool apply_log_level(const std::string& level_str) {
+    auto level = spdlog::level::from_str(level_str);
+    if(level == spdlog::level::off && level_str != "off") {
+        std::println(stderr,
+                     "unknown log level '{}', valid: trace, debug, info, warn, error, off",
+                     level_str);
+        return false;
+    }
+    logging::options.level = level;
+    return true;
+}
+
+template <typename T>
+void print_usage(T& cmd) {
+    std::ostringstream ss;
+    cmd.usage(ss);
+    std::print("{}", ss.str());
+}
 
 }  // namespace clice
 
@@ -115,108 +72,129 @@ int main(int argc, const char** argv) {
     signal(SIGPIPE, SIG_IGN);
 #endif
 
-    auto args = kota::deco::util::argvify(argc, argv);
-    auto result = kota::deco::cli::parse<clice::Options>(args);
+    namespace deco = kota::deco;
 
-    if(!result.has_value()) {
-        LOG_ERROR("{}", result.error().message);
-        return 1;
-    }
+    auto args = deco::util::argvify(argc, argv);
+    const char* self_path = argv[0];
 
-    auto& opts = result->options;
+    int exit_code = 1;
 
-    if(opts.help.value_or(false)) {
-        kota::deco::cli::write_usage_for<clice::Options>(std::cout, "clice [OPTIONS]");
-        return 0;
-    }
+    auto server_cmd = deco::cli::command<clice::ServerOptions>("clice server [OPTIONS]");
+    server_cmd
+        .matchAll([&](clice::ServerOptions opts) {
+            if(opts.help) {
+                clice::print_usage(server_cmd);
+                return exit_code = 0, void();
+            }
+            if(!clice::apply_log_level(opts.log_level.value_or("info")))
+                return;
+            using clice::ServerMode;
+            auto mode = opts.mode.value_or(ServerMode::Pipe);
+            if(mode == ServerMode::Relay) {
+                exit_code = clice::run_relay_mode(opts.socket.value_or(""));
+            } else if(mode == ServerMode::Daemon) {
+                auto workspace = opts.workspace.value_or("");
+                if(workspace.empty()) {
+                    LOG_ERROR("--workspace is required for daemon mode");
+                    return;
+                }
+                exit_code = clice::run_daemon_mode(opts, self_path);
+            } else {
+                exit_code = clice::run_server_mode(opts, self_path);
+            }
+        })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
 
-    if(opts.version.value_or(false)) {
+    auto query_cmd = deco::cli::command<clice::QueryOptions>("clice query [OPTIONS]");
+    query_cmd
+        .matchAll([&](clice::QueryOptions opts) {
+            if(opts.help) {
+                clice::print_usage(query_cmd);
+                return exit_code = 0, void();
+            }
+            auto port = opts.port.value_or(0);
+            if(port <= 0 || port > 65535) {
+                LOG_ERROR("--port must be between 1 and 65535");
+                return;
+            }
+            if(!clice::apply_log_level(opts.log_level.value_or("info")))
+                return;
+            exit_code = clice::run_agentic_mode(opts);
+        })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    auto worker_cmd = deco::cli::command<clice::WorkerOptions>("clice worker [OPTIONS]");
+    worker_cmd
+        .matchAll([&](clice::WorkerOptions opts) {
+            if(opts.help) {
+                clice::print_usage(worker_cmd);
+                return exit_code = 0, void();
+            }
+            auto name = opts.worker_name.value_or("worker");
+            auto log_dir = opts.log_dir.value_or("");
+            if(opts.memory_limit.has_value()) {
+                exit_code = clice::run_stateful_worker_mode(*opts.memory_limit, name, log_dir);
+            } else {
+                exit_code = clice::run_stateless_worker_mode(name, log_dir);
+            }
+        })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    auto lint_cmd = deco::cli::command<clice::LintOptions>("clice lint [OPTIONS]");
+    lint_cmd
+        .matchAll([&](clice::LintOptions opts) {
+            if(opts.help) {
+                clice::print_usage(lint_cmd);
+                return exit_code = 0, void();
+            }
+            LOG_ERROR("lint is not yet implemented");
+        })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    auto format_cmd = deco::cli::command<clice::FormatOptions>("clice format [OPTIONS]");
+    format_cmd
+        .matchAll([&](clice::FormatOptions opts) {
+            if(opts.help) {
+                clice::print_usage(format_cmd);
+                return exit_code = 0, void();
+            }
+            LOG_ERROR("format is not yet implemented");
+        })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    deco::cli::SubCommander clice("clice <command> [<args>]",
+                                  "A C++ development toolkit built on LLVM/Clang");
+
+    auto print_root_usage = [&] {
+        std::println("usage: clice <command> [<args>]\n");
+        clice::print_usage(clice);
+    };
+
+    clice.add({.name = "server", .description = "Start LSP server"}, server_cmd)
+        .add({.name = "query", .description = "Query symbol information from a running server"},
+             query_cmd)
+        .add({.name = "worker"}, worker_cmd)
+        .add({.name = "lint", .description = "Lint C++ source files"}, lint_cmd)
+        .add({.name = "format", .description = "Format C++ source files"}, format_cmd)
+        .when_err([&](auto err) {
+            if(err.type == deco::cli::SubCommandError::Type::MissingSubCommand) {
+                print_root_usage();
+                exit_code = 0;
+            } else {
+                LOG_ERROR("{}", err.message);
+            }
+        });
+
+    if(!args.empty() && (args[0] == "--version" || args[0] == "-v")) {
         std::println("clice version 0.1.0");
         return 0;
     }
 
-    if(opts.log_level.has_value()) {
-        auto level = spdlog::level::from_str(*opts.log_level);
-        if(level == spdlog::level::off && *opts.log_level != "off") {
-            std::println(stderr,
-                         "unknown log level '{}', valid: trace, debug, info, warn, error, off",
-                         *opts.log_level);
-            return 1;
-        }
-        clice::logging::options.level = level;
+    if(!args.empty() && (args[0] == "--help" || args[0] == "-h")) {
+        print_root_usage();
+        return 0;
     }
 
-    if(!opts.mode.has_value()) {
-        LOG_ERROR("--mode is required");
-        return 1;
-    }
-
-    auto& mode = *opts.mode;
-
-    auto worker_name = opts.worker_name.value_or("");
-    auto log_dir = opts.log_dir.value_or("");
-
-    if(mode == "stateless-worker") {
-        return clice::run_stateless_worker_mode(worker_name.empty() ? "stateless-worker"
-                                                                    : worker_name,
-                                                log_dir);
-    }
-
-    if(mode == "stateful-worker") {
-        auto mem_limit = opts.worker_memory_limit.value_or(4ULL * 1024 * 1024 * 1024);
-        return clice::run_stateful_worker_mode(mem_limit,
-                                               worker_name.empty() ? "stateful-worker"
-                                                                   : worker_name,
-                                               log_dir);
-    }
-
-    if(mode == "pipe" || mode == "socket") {
-        clice::ServerOptions server_opts;
-        server_opts.mode = mode;
-        server_opts.host = opts.host.value_or("127.0.0.1");
-        server_opts.port = opts.port.value_or(0);
-        server_opts.self_path = argv[0];
-        server_opts.record = opts.record.value_or("");
-        return clice::run_server_mode(server_opts);
-    }
-
-    if(mode == "daemon") {
-        auto workspace = opts.workspace.value_or("");
-        if(workspace.empty()) {
-            LOG_ERROR("--workspace is required for daemon mode");
-            return 1;
-        }
-
-        clice::DaemonOptions daemon_opts;
-        daemon_opts.socket_path = opts.socket.value_or("");
-        daemon_opts.workspace = std::move(workspace);
-        daemon_opts.self_path = argv[0];
-        return clice::run_daemon_mode(daemon_opts);
-    }
-
-    if(mode == "agentic") {
-        auto port = opts.port.value_or(0);
-        if(port <= 0) {
-            LOG_ERROR("--port is required for agentic mode");
-            return 1;
-        }
-        clice::AgenticQueryOptions aq;
-        aq.host = opts.host.value_or("127.0.0.1");
-        aq.port = port;
-        aq.method = opts.method.value_or("compileCommand");
-        aq.path = opts.path.value_or("");
-        aq.name = opts.name.value_or("");
-        aq.query = opts.query.value_or("");
-        aq.line = opts.line.value_or(0);
-        aq.direction = opts.direction.value_or("");
-        return clice::run_agentic_mode(aq);
-    }
-
-    if(mode == "relay") {
-        auto socket = opts.socket.value_or("");
-        return clice::run_relay_mode(socket);
-    }
-
-    LOG_ERROR("unknown mode '{}'", mode);
-    return 1;
+    clice(args);
+    return exit_code;
 }

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -104,7 +104,7 @@ static kota::task<> agentic_client(int& exit_code,
                                    const QueryOptions& opts) {
     auto& loop = kota::event_loop::current();
     auto host = opts.host.value_or("127.0.0.1");
-    auto port = *opts.port;
+    auto port = opts.port.value_or(0);
     auto transport = co_await kota::ipc::StreamTransport::connect_tcp(host, port, loop);
     if(!transport) {
         LOG_ERROR("failed to connect to {}:{}", host, port);

--- a/src/server/service/agentic.cpp
+++ b/src/server/service/agentic.cpp
@@ -28,76 +28,70 @@ static kota::task<bool> send_and_print(kota::ipc::JsonPeer& peer, Params params)
 
 static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
                                     int& exit_code,
-                                    const AgenticQueryOptions& opts) {
+                                    const QueryOptions& opts) {
+    auto method = opts.method.value_or("compileCommand");
+    auto path = opts.path.value_or("");
+    auto name = opts.name.value_or("");
+    auto query = opts.query.value_or("");
+    auto line = opts.line.value_or(0);
+    auto direction = opts.direction.value_or("");
+
+    auto opt_name = name.empty() ? std::nullopt : std::optional(name);
+    auto opt_path = path.empty() ? std::nullopt : std::optional(path);
+    auto opt_line = line > 0 ? std::optional(line) : std::nullopt;
+    auto opt_dir = direction.empty() ? std::nullopt : std::optional(direction);
+
     bool ok = false;
 
-    if(opts.method == "compileCommand") {
-        ok = co_await send_and_print(peer, agentic::CompileCommandParams{.path = opts.path});
-    } else if(opts.method == "projectFiles") {
-        auto filter = opts.query.empty() ? std::nullopt : std::optional(opts.query);
+    if(method == "compileCommand") {
+        ok = co_await send_and_print(peer, agentic::CompileCommandParams{.path = path});
+    } else if(method == "projectFiles") {
+        auto filter = query.empty() ? std::nullopt : std::optional(query);
         ok = co_await send_and_print(peer, agentic::ProjectFilesParams{.filter = filter});
-    } else if(opts.method == "symbolSearch") {
-        ok = co_await send_and_print(peer, agentic::SymbolSearchParams{.query = opts.query});
-    } else if(opts.method == "definition") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
-        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+    } else if(method == "symbolSearch") {
+        ok = co_await send_and_print(peer, agentic::SymbolSearchParams{.query = query});
+    } else if(method == "definition") {
         ok = co_await send_and_print(
             peer,
-            agentic::DefinitionParams{.name = name, .path = path, .line = line});
-    } else if(opts.method == "references") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
-        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+            agentic::DefinitionParams{.name = opt_name, .path = opt_path, .line = opt_line});
+    } else if(method == "references") {
         ok = co_await send_and_print(
             peer,
-            agentic::ReferencesParams{.name = name, .path = path, .line = line});
-    } else if(opts.method == "readSymbol") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
-        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
+            agentic::ReferencesParams{.name = opt_name, .path = opt_path, .line = opt_line});
+    } else if(method == "readSymbol") {
         ok = co_await send_and_print(
             peer,
-            agentic::ReadSymbolParams{.name = name, .path = path, .line = line});
-    } else if(opts.method == "documentSymbols") {
-        ok = co_await send_and_print(peer, agentic::DocumentSymbolsParams{.path = opts.path});
-    } else if(opts.method == "callGraph") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
-        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
-        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+            agentic::ReadSymbolParams{.name = opt_name, .path = opt_path, .line = opt_line});
+    } else if(method == "documentSymbols") {
+        ok = co_await send_and_print(peer, agentic::DocumentSymbolsParams{.path = path});
+    } else if(method == "callGraph") {
         ok = co_await send_and_print(peer,
                                      agentic::CallGraphParams{
-                                         .name = name,
-                                         .path = path,
-                                         .line = line,
-                                         .direction = dir,
+                                         .name = opt_name,
+                                         .path = opt_path,
+                                         .line = opt_line,
+                                         .direction = opt_dir,
                                      });
-    } else if(opts.method == "typeHierarchy") {
-        auto name = opts.name.empty() ? std::nullopt : std::optional(opts.name);
-        auto path = opts.path.empty() ? std::nullopt : std::optional(opts.path);
-        auto line = opts.line > 0 ? std::optional(opts.line) : std::nullopt;
-        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+    } else if(method == "typeHierarchy") {
         ok = co_await send_and_print(peer,
                                      agentic::TypeHierarchyParams{
-                                         .name = name,
-                                         .path = path,
-                                         .line = line,
-                                         .direction = dir,
+                                         .name = opt_name,
+                                         .path = opt_path,
+                                         .line = opt_line,
+                                         .direction = opt_dir,
                                      });
-    } else if(opts.method == "fileDeps") {
-        auto dir = opts.direction.empty() ? std::nullopt : std::optional(opts.direction);
+    } else if(method == "fileDeps") {
         ok = co_await send_and_print(peer,
-                                     agentic::FileDepsParams{.path = opts.path, .direction = dir});
-    } else if(opts.method == "impactAnalysis") {
-        ok = co_await send_and_print(peer, agentic::ImpactAnalysisParams{.path = opts.path});
-    } else if(opts.method == "status") {
+                                     agentic::FileDepsParams{.path = path, .direction = opt_dir});
+    } else if(method == "impactAnalysis") {
+        ok = co_await send_and_print(peer, agentic::ImpactAnalysisParams{.path = path});
+    } else if(method == "status") {
         ok = co_await send_and_print(peer, agentic::StatusParams{});
-    } else if(opts.method == "shutdown") {
+    } else if(method == "shutdown") {
         peer.send_notification(agentic::ShutdownParams{});
         ok = true;
     } else {
-        LOG_ERROR("unknown agentic method '{}'", opts.method);
+        LOG_ERROR("unknown agentic method '{}'", method);
     }
 
     if(ok)
@@ -107,11 +101,13 @@ static kota::task<> agentic_request(kota::ipc::JsonPeer& peer,
 
 static kota::task<> agentic_client(int& exit_code,
                                    std::unique_ptr<kota::ipc::JsonPeer>& peer_out,
-                                   const AgenticQueryOptions& opts) {
+                                   const QueryOptions& opts) {
     auto& loop = kota::event_loop::current();
-    auto transport = co_await kota::ipc::StreamTransport::connect_tcp(opts.host, opts.port, loop);
+    auto host = opts.host.value_or("127.0.0.1");
+    auto port = *opts.port;
+    auto transport = co_await kota::ipc::StreamTransport::connect_tcp(host, port, loop);
     if(!transport) {
-        LOG_ERROR("failed to connect to {}:{}", opts.host, opts.port);
+        LOG_ERROR("failed to connect to {}:{}", host, port);
         co_return;
     }
 
@@ -119,7 +115,7 @@ static kota::task<> agentic_client(int& exit_code,
     co_await kota::when_all(peer_out->run(), agentic_request(*peer_out, exit_code, opts));
 }
 
-int run_agentic_mode(const AgenticQueryOptions& opts) {
+int run_agentic_mode(const QueryOptions& opts) {
     logging::stderr_logger("agentic", logging::options);
 
     kota::event_loop loop;

--- a/src/server/service/agentic.h
+++ b/src/server/service/agentic.h
@@ -2,22 +2,58 @@
 
 #include <string>
 
+#include "kota/deco/deco.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace clice {
 
-struct AgenticQueryOptions {
-    std::string host;
-    int port = 0;
-    std::string method;
-    std::string path;
-    std::string name;
-    std::string query;
-    int line = 0;
-    std::string direction;
+namespace deco = kota::deco;
+using deco::decl::KVStyle;
+
+struct QueryOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Server host", required = false)
+    <std::string> host = "127.0.0.1";
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Server port (required)", required = false)
+    <int> port;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Query method (compileCommand, symbolSearch, definition, references, "
+                  "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, "
+                  "fileDeps, impactAnalysis, status, shutdown)",
+           required = false)
+    <std::string> method = "compileCommand";
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "File path for queries", required = false)
+    <std::string> path;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Symbol name", required = false)
+    <std::string> name;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Search query string", required = false)
+    <std::string> query;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Line number for position-based lookup",
+           required = false)
+    <int> line;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Direction: callers/callees or supertypes/subtypes",
+           required = false)
+    <std::string> direction;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           names = {"--log-level", "--log-level="},
+           help = "Log level: trace, debug, info, warn, error, off",
+           required = false)
+    <std::string> log_level = "info";
 };
 
-int run_agentic_mode(const AgenticQueryOptions& opts);
+int run_agentic_mode(const QueryOptions& opts);
 
 int run_relay_mode(llvm::StringRef socket_path);
 

--- a/src/server/service/agentic.h
+++ b/src/server/service/agentic.h
@@ -8,45 +8,50 @@
 namespace clice {
 
 namespace deco = kota::deco;
-using deco::decl::KVStyle;
 
 struct QueryOptions {
     DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
     help;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Server host", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate, help = "Server host", required = false)
     <std::string> host = "127.0.0.1";
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Server port (required)", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
+           help = "Server port (required)",
+           required = false)
     <int> port;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Query method (compileCommand, symbolSearch, definition, references, "
                   "documentSymbols, readSymbol, callGraph, typeHierarchy, projectFiles, "
                   "fileDeps, impactAnalysis, status, shutdown)",
            required = false)
     <std::string> method = "compileCommand";
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "File path for queries", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
+           help = "File path for queries",
+           required = false)
     <std::string> path;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Symbol name", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate, help = "Symbol name", required = false)
     <std::string> name;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Search query string", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
+           help = "Search query string",
+           required = false)
     <std::string> query;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Line number for position-based lookup",
            required = false)
     <int> line;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Direction: callers/callees or supertypes/subtypes",
            required = false)
     <std::string> direction;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            names = {"--log-level", "--log-level="},
            help = "Log level: trace, debug, info, warn, error, off",
            required = false)

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -473,6 +473,7 @@ int run_server_mode(const ServerOptions& opts, const char* self_path) {
         return 0;
     }
 
+    LOG_ERROR("unexpected server mode");
     return 1;
 }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -392,14 +392,19 @@ static kota::task<> accept_connections(MasterServer& server,
     co_await group.join();
 }
 
-int run_server_mode(const ServerOptions& opts) {
+int run_server_mode(const ServerOptions& opts, const char* self_path) {
     logging::stderr_logger("master", logging::options);
 
+    auto mode = opts.mode.value_or(ServerMode::Pipe);
+    auto host = opts.host.value_or("127.0.0.1");
+    auto port = opts.port.value_or(0);
+    auto record = opts.record.value_or("");
+
     kota::event_loop loop;
-    MasterServer server(loop, opts.self_path);
+    MasterServer server(loop, self_path);
     std::list<Connection> connections;
 
-    if(opts.mode == "pipe") {
+    if(mode == ServerMode::Pipe) {
         auto transport = kota::ipc::StreamTransport::open_stdio(loop);
         if(!transport) {
             LOG_ERROR("failed to open stdio transport");
@@ -407,10 +412,9 @@ int run_server_mode(const ServerOptions& opts) {
         }
 
         std::unique_ptr<kota::ipc::Transport> final_transport = std::move(*transport);
-        if(!opts.record.empty()) {
+        if(!record.empty()) {
             final_transport =
-                std::make_unique<kota::ipc::RecordingTransport>(std::move(final_transport),
-                                                                opts.record);
+                std::make_unique<kota::ipc::RecordingTransport>(std::move(final_transport), record);
         }
 
         kota::ipc::JsonPeer lsp_peer(loop, std::move(final_transport));
@@ -419,14 +423,14 @@ int run_server_mode(const ServerOptions& opts) {
         kota::tcp::acceptor agent_acceptor;
         bool has_agent_acceptor = false;
 
-        if(opts.port > 0) {
-            auto acceptor = kota::tcp::listen(opts.host, opts.port, {}, loop);
+        if(port > 0) {
+            auto acceptor = kota::tcp::listen(host, port, {}, loop);
             if(acceptor) {
-                LOG_INFO("Agentic protocol listening on {}:{}", opts.host, opts.port);
+                LOG_INFO("Agentic protocol listening on {}:{}", host, port);
                 agent_acceptor = std::move(*acceptor);
                 has_agent_acceptor = true;
             } else {
-                LOG_WARN("Failed to start agentic listener on {}:{}", opts.host, opts.port);
+                LOG_WARN("Failed to start agentic listener on {}:{}", host, port);
             }
         }
 
@@ -449,14 +453,14 @@ int run_server_mode(const ServerOptions& opts) {
         return 0;
     }
 
-    if(opts.mode == "socket") {
-        auto acceptor = kota::tcp::listen(opts.host, opts.port, {}, loop);
+    if(mode == ServerMode::Socket) {
+        auto acceptor = kota::tcp::listen(host, port, {}, loop);
         if(!acceptor) {
-            LOG_ERROR("failed to listen on {}:{}", opts.host, opts.port);
+            LOG_ERROR("failed to listen on {}:{}", host, port);
             return 1;
         }
 
-        LOG_INFO("Listening on {}:{} ...", opts.host, opts.port);
+        LOG_INFO("Listening on {}:{} ...", host, port);
         loop.schedule([](MasterServer& server,
                          kota::tcp::acceptor acceptor,
                          std::list<Connection>& connections) -> kota::task<> {
@@ -469,7 +473,6 @@ int run_server_mode(const ServerOptions& opts) {
         return 0;
     }
 
-    LOG_ERROR("unknown server mode '{}'", opts.mode);
     return 1;
 }
 
@@ -540,10 +543,12 @@ static kota::task<> daemon_main(MasterServer& server,
     co_await server.shutdown_and_cleanup();
 }
 
-int run_daemon_mode(const DaemonOptions& opts) {
+int run_daemon_mode(const ServerOptions& opts, const char* self_path) {
     logging::stderr_logger("daemon", logging::options);
 
-    auto socket_path = opts.socket_path.empty() ? path::default_socket_path() : opts.socket_path;
+    auto sock = opts.socket.value_or("");
+    auto socket_path = sock.empty() ? path::default_socket_path() : sock;
+    auto ws = opts.workspace.value_or("");
 
     auto socket_dir = llvm::sys::path::parent_path(socket_path);
     if(auto ec = llvm::sys::fs::create_directories(socket_dir)) {
@@ -571,11 +576,11 @@ int run_daemon_mode(const DaemonOptions& opts) {
     }
 
     kota::event_loop loop;
-    MasterServer server(loop, opts.self_path);
+    MasterServer server(loop, self_path);
 
     bool watch_files = false;
-    if(!opts.workspace.empty()) {
-        server.initialize(opts.workspace);
+    if(!ws.empty()) {
+        server.initialize(ws);
         watch_files = true;
     }
 

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -17,7 +17,6 @@
 namespace clice {
 
 namespace deco = kota::deco;
-using deco::decl::KVStyle;
 
 enum class ServerMode : std::uint8_t { Pipe, Socket, Relay, Daemon };
 
@@ -25,35 +24,37 @@ struct ServerOptions {
     DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
     help;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Server mode: pipe (default), socket, relay, or daemon",
            required = false)
     <ServerMode> mode = ServerMode::Pipe;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Socket mode address", required = false)
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
+           help = "Socket mode address",
+           required = false)
     <std::string> host = "127.0.0.1";
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Agentic TCP port (0 = disabled)",
            required = false)
     <int> port = 0;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Record LSP input to file for replay testing",
            required = false)
     <std::string> record;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Unix domain socket path (relay/daemon mode)",
            required = false)
     <std::string> socket;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            help = "Workspace root directory (daemon mode)",
            required = false)
     <std::string> workspace;
 
-    DecoKV(style = KVStyle::JoinedOrSeparate,
+    DecoKV(style = deco::decl::KVStyle::JoinedOrSeparate,
            names = {"--log-level", "--log-level="},
            help = "Log level: trace, debug, info, warn, error, off",
            required = false)

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -10,10 +10,55 @@
 #include "server/workspace/workspace.h"
 
 #include "kota/async/async.h"
+#include "kota/deco/deco.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace clice {
+
+namespace deco = kota::deco;
+using deco::decl::KVStyle;
+
+enum class ServerMode : std::uint8_t { Pipe, Socket, Relay, Daemon };
+
+struct ServerOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Server mode: pipe (default), socket, relay, or daemon",
+           required = false)
+    <ServerMode> mode = ServerMode::Pipe;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, help = "Socket mode address", required = false)
+    <std::string> host = "127.0.0.1";
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Agentic TCP port (0 = disabled)",
+           required = false)
+    <int> port = 0;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Record LSP input to file for replay testing",
+           required = false)
+    <std::string> record;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Unix domain socket path (relay/daemon mode)",
+           required = false)
+    <std::string> socket;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           help = "Workspace root directory (daemon mode)",
+           required = false)
+    <std::string> workspace;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           names = {"--log-level", "--log-level="},
+           help = "Log level: trace, debug, info, warn, error, off",
+           required = false)
+    <std::string> log_level = "info";
+};
 
 enum class ServerLifecycle : std::uint8_t {
     Uninitialized,
@@ -73,22 +118,8 @@ private:
     std::string init_options_json;
 };
 
-struct ServerOptions {
-    std::string mode;
-    std::string host = "127.0.0.1";
-    int port = 0;
-    std::string self_path;
-    std::string record;
-};
+int run_server_mode(const ServerOptions& opts, const char* self_path);
 
-int run_server_mode(const ServerOptions& opts);
-
-struct DaemonOptions {
-    std::string socket_path;
-    std::string workspace;
-    std::string self_path;
-};
-
-int run_daemon_mode(const DaemonOptions& opts);
+int run_daemon_mode(const ServerOptions& opts, const char* self_path);
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -58,6 +58,7 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     opts.file = self_path;
     opts.args = {self_path, "worker"};
     if(stateful) {
+        opts.args.push_back("--stateful");
         opts.args.push_back("--memory-limit");
         opts.args.push_back(std::to_string(memory_limit));
     }
@@ -287,6 +288,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     opts.file = options_.self_path;
     opts.args = {options_.self_path, "worker"};
     if(stateful) {
+        opts.args.push_back("--stateful");
         opts.args.push_back("--memory-limit");
         opts.args.push_back(std::to_string(options_.worker_memory_limit));
     }

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -56,14 +56,10 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
 
     kota::process::options opts;
     opts.file = self_path;
+    opts.args = {self_path, "worker"};
     if(stateful) {
-        opts.args = {self_path,
-                     "--mode",
-                     "stateful-worker",
-                     "--worker-memory-limit",
-                     std::to_string(memory_limit)};
-    } else {
-        opts.args = {self_path, "--mode", "stateless-worker"};
+        opts.args.push_back("--memory-limit");
+        opts.args.push_back(std::to_string(memory_limit));
     }
 
     opts.args.push_back("--worker-name");
@@ -289,14 +285,10 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
 
     kota::process::options opts;
     opts.file = options_.self_path;
+    opts.args = {options_.self_path, "worker"};
     if(stateful) {
-        opts.args = {options_.self_path,
-                     "--mode",
-                     "stateful-worker",
-                     "--worker-memory-limit",
-                     std::to_string(options_.worker_memory_limit)};
-    } else {
-        opts.args = {options_.self_path, "--mode", "stateless-worker"};
+        opts.args.push_back("--memory-limit");
+        opts.args.push_back(std::to_string(options_.worker_memory_limit));
     }
     opts.args.push_back("--worker-name");
     opts.args.push_back(worker_name);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ async def client(
     mode = config.getoption("--mode")
     host = config.getoption("--host")
 
-    cmd = [str(executable), "--mode", mode, "--host", host]
+    cmd = [str(executable), "server", "--mode", mode, "--host", host]
 
     c = CliceClient()
     await c.start_io(*cmd)
@@ -137,7 +137,7 @@ async def agentic(
     """Start a server with agentic TCP port, yield (executable, host, port)."""
     host = "127.0.0.1"
     port = _find_free_port()
-    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+    cmd = [str(executable), "server", "--host", host, "--port", str(port)]
 
     c = CliceClient()
     await c.start_io(*cmd)
@@ -180,7 +180,7 @@ def generate_cdb(workspace: Path) -> None:
 async def make_client(executable: Path, workspace: Path) -> CliceClient:
     """Spawn a fresh clice server and initialize it. For multi-session tests."""
     c = CliceClient()
-    await c.start_io(str(executable), "--mode", "pipe")
+    await c.start_io(str(executable), "server")
     await c.initialize(workspace)
     return c
 

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -67,8 +67,7 @@ def run_agentic(executable, host, port, path, timeout=10):
     result = subprocess.run(
         [
             str(executable),
-            "--mode",
-            "agentic",
+            "query",
             "--host",
             host,
             "--port",
@@ -148,7 +147,7 @@ async def indexed_agentic(request, executable, workspace):
 
     host = "127.0.0.1"
     port = _find_free_port()
-    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+    cmd = [str(executable), "server", "--host", host, "--port", str(port)]
 
     c = CliceClient()
     await c.start_io(*cmd)
@@ -428,7 +427,7 @@ async def test_rpc_shutdown(executable, workspace):
 
     host = "127.0.0.1"
     port = _find_free_port()
-    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+    cmd = [str(executable), "server", "--host", host, "--port", str(port)]
 
     c = CliceClient()
     await c.start_io(*cmd)
@@ -552,7 +551,7 @@ async def test_shutdown_during_indexing(executable, tmp_path):
 
     host = "127.0.0.1"
     port = _find_free_port()
-    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+    cmd = [str(executable), "server", "--host", host, "--port", str(port)]
 
     c = CliceClient()
     await c.start_io(*cmd)

--- a/tests/integration/agentic/test_cli.py
+++ b/tests/integration/agentic/test_cli.py
@@ -1,5 +1,6 @@
-"""CLI-based tests for agentic mode — run clice query as a subprocess."""
+"""CLI-based tests for agentic mode and CLI entry points."""
 
+import asyncio
 import json
 import subprocess
 
@@ -186,3 +187,43 @@ async def test_cli_status(indexed_server, workspace):
     assert data["total"] > 0
     assert isinstance(data["pending"], int)
     assert isinstance(data["indexed"], int)
+
+
+# --- Server mode and CLI entry point tests ---
+
+
+def test_daemon_requires_workspace(executable):
+    r = subprocess.run(
+        [str(executable), "server", "--mode", "daemon"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert r.returncode != 0
+
+
+@pytest.mark.workspace("hello_world")
+async def test_socket_mode_connects(executable, workspace):
+    from tests.conftest import _find_free_port, _shutdown_client
+    from tests.integration.utils.client import CliceClient
+
+    port = _find_free_port()
+    cmd = [str(executable), "server", "--mode", "socket", "--port", str(port)]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await asyncio.sleep(1)
+
+    c = CliceClient()
+    await c.start_tcp("127.0.0.1", port)
+    await c.initialize(workspace)
+    await _shutdown_client(c)
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()

--- a/tests/integration/agentic/test_cli.py
+++ b/tests/integration/agentic/test_cli.py
@@ -1,4 +1,4 @@
-"""CLI-based tests for agentic mode — run clice --mode agentic as a subprocess."""
+"""CLI-based tests for agentic mode — run clice query as a subprocess."""
 
 import json
 import subprocess
@@ -11,8 +11,7 @@ from tests.integration.utils.wait import wait_for_index
 def run_cli(executable, host, port, method, **kwargs):
     cmd = [
         str(executable),
-        "--mode",
-        "agentic",
+        "query",
         "--host",
         host,
         "--port",
@@ -35,7 +34,7 @@ async def indexed_server(request, executable, workspace):
 
     host = "127.0.0.1"
     port = _find_free_port()
-    cmd = [str(executable), "--mode", "pipe", "--host", host, "--port", str(port)]
+    cmd = [str(executable), "server", "--host", host, "--port", str(port)]
 
     c = CliceClient()
     await c.start_io(*cmd)

--- a/tests/replay.py
+++ b/tests/replay.py
@@ -138,8 +138,7 @@ async def replay_one(
 
     proc = await asyncio.create_subprocess_exec(
         str(clice_bin),
-        "--mode",
-        "pipe",
+        "server",
         env=env,
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,

--- a/tests/unit/server/module_worker_tests.cpp
+++ b/tests/unit/server/module_worker_tests.cpp
@@ -30,7 +30,7 @@ TEST_CASE(BuildPCMThenCompileWithImport) {
     auto consumer = tmp.path("consumer.cpp");
 
     WorkerHandle sl;
-    ASSERT_TRUE(sl.spawn("stateless-worker"));
+    ASSERT_TRUE(sl.spawn());
 
     std::string pcm_path;
     bool phase1_done = false;
@@ -63,7 +63,7 @@ TEST_CASE(BuildPCMThenCompileWithImport) {
     ASSERT_FALSE(pcm_path.empty());
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn("stateful-worker"));
+    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool phase2_done = false;
 
@@ -114,7 +114,7 @@ TEST_CASE(BuildPCMChainThenCompile) {
     auto consumer = tmp.path("chain_consumer.cpp");
 
     WorkerHandle sl;
-    ASSERT_TRUE(sl.spawn("stateless-worker"));
+    ASSERT_TRUE(sl.spawn());
 
     std::string pcm_a, pcm_b;
     bool pcm_done = false;
@@ -171,7 +171,7 @@ TEST_CASE(BuildPCMChainThenCompile) {
 
     // Compile consumer with BOTH PCMs via stateful worker.
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn("stateful-worker"));
+    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool compile_done = false;
 
@@ -218,7 +218,7 @@ TEST_CASE(ModuleImplementationUnitWithWorker) {
 
     // Build PCM for interface.
     WorkerHandle sl;
-    ASSERT_TRUE(sl.spawn("stateless-worker"));
+    ASSERT_TRUE(sl.spawn());
 
     std::string pcm_path;
     bool pcm_done = false;
@@ -249,7 +249,7 @@ TEST_CASE(ModuleImplementationUnitWithWorker) {
 
     // Compile implementation unit with the PCM via stateful worker.
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn("stateful-worker"));
+    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool compile_done = false;
 

--- a/tests/unit/server/pch_worker_tests.cpp
+++ b/tests/unit/server/pch_worker_tests.cpp
@@ -31,7 +31,7 @@ TEST_CASE(BuildPCHThenCompile) {
     auto dir = std::string(tmp.root);
 
     WorkerHandle sl;
-    ASSERT_TRUE(sl.spawn("stateless-worker"));
+    ASSERT_TRUE(sl.spawn());
 
     std::string pch_path;
     bool phase1_done = false;
@@ -69,7 +69,7 @@ TEST_CASE(BuildPCHThenCompile) {
     ASSERT_TRUE(llvm::sys::fs::exists(pch_path));
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn("stateful-worker"));
+    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool phase2_done = false;
 
@@ -115,7 +115,7 @@ TEST_CASE(CompileWithoutPCHStillWorks) {
     auto dir = std::string(tmp.root);
 
     WorkerHandle sf;
-    ASSERT_TRUE(sf.spawn("stateful-worker"));
+    ASSERT_TRUE(sf.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool compile_done = false;
 

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -15,7 +15,7 @@ TEST_SUITE(StatefulWorker) {
 
 TEST_CASE(SpawnAndExit) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     w.peer->close_output();
     w.loop.schedule(w.peer->run());
@@ -28,7 +28,7 @@ TEST_CASE(CompileRequest) {
     auto src = tmp.path("compile_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -54,7 +54,7 @@ TEST_CASE(CompileRequest) {
 
 TEST_CASE(HoverWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -83,7 +83,7 @@ TEST_CASE(CompileThenHover) {
     auto src = tmp.path("hover_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -124,7 +124,7 @@ TEST_CASE(DocumentUpdate) {
     auto src = tmp.path("update_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -165,7 +165,7 @@ TEST_CASE(DocumentUpdate) {
 
 TEST_CASE(CodeActionReturnsEmpty) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -187,7 +187,7 @@ TEST_CASE(CodeActionReturnsEmpty) {
 
 TEST_CASE(GoToDefinitionReturnsEmpty) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -210,7 +210,7 @@ TEST_CASE(GoToDefinitionReturnsEmpty) {
 
 TEST_CASE(SemanticTokensWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -231,7 +231,7 @@ TEST_CASE(SemanticTokensWithoutCompile) {
 
 TEST_CASE(FoldingRangeWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -252,7 +252,7 @@ TEST_CASE(FoldingRangeWithoutCompile) {
 
 TEST_CASE(DocumentSymbolWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -273,7 +273,7 @@ TEST_CASE(DocumentSymbolWithoutCompile) {
 
 TEST_CASE(DocumentLinkWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -294,7 +294,7 @@ TEST_CASE(DocumentLinkWithoutCompile) {
 
 TEST_CASE(InlayHintsWithoutCompile) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -325,7 +325,7 @@ TEST_CASE(MultipleSequentialRequests) {
     auto src = tmp.path("seq_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -397,7 +397,7 @@ TEST_CASE(MultipleDocuments) {
     }
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -435,7 +435,7 @@ TEST_CASE(MultipleDocuments) {
 
 TEST_CASE(EvictNotification) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateful-worker"));
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 
@@ -469,7 +469,7 @@ TEST_CASE(SpawnWithMemoryLimit) {
 
     WorkerHandle w;
     // Spawn with a specific memory limit to test the CLI flag is accepted.
-    ASSERT_TRUE(w.spawn("stateful-worker", 2ULL * 1024 * 1024 * 1024));
+    ASSERT_TRUE(w.spawn(2ULL * 1024 * 1024 * 1024));
 
     bool test_done = false;
 

--- a/tests/unit/server/stateless_worker_tests.cpp
+++ b/tests/unit/server/stateless_worker_tests.cpp
@@ -72,7 +72,7 @@ TEST_SUITE(StatelessWorker) {
 
 TEST_CASE(SpawnAndExit) {
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     // Close stdin pipe to signal worker to exit.
     w.peer->close_output();
@@ -86,7 +86,7 @@ TEST_CASE(BuildPCHRequest) {
     auto hdr = tmp.path("test_pch.h");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 
@@ -121,7 +121,7 @@ TEST_CASE(IndexRequest) {
     auto src = tmp.path("test_index.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 
@@ -156,7 +156,7 @@ TEST_CASE(BuildPCMRequest) {
     auto src = tmp.path("test_module.cppm");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 
@@ -190,7 +190,7 @@ TEST_CASE(CompletionRequest) {
     auto src = tmp.path("completion_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 
@@ -220,7 +220,7 @@ TEST_CASE(SignatureHelpRequest) {
     auto src = tmp.path("sighelp_test.cpp");
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 
@@ -255,7 +255,7 @@ TEST_CASE(MultipleStatelessRequests) {
     }
 
     WorkerHandle w;
-    ASSERT_TRUE(w.spawn("stateless-worker"));
+    ASSERT_TRUE(w.spawn());
 
     bool test_done = false;
 

--- a/tests/unit/server/worker_test_helpers.h
+++ b/tests/unit/server/worker_test_helpers.h
@@ -78,6 +78,7 @@ struct WorkerHandle {
         opts.file = binary;
         opts.args = {binary, "worker"};
         if(memory_limit > 0) {
+            opts.args.push_back("--stateful");
             opts.args.push_back("--memory-limit");
             opts.args.push_back(std::to_string(memory_limit));
         }

--- a/tests/unit/server/worker_test_helpers.h
+++ b/tests/unit/server/worker_test_helpers.h
@@ -65,20 +65,20 @@ struct WorkerHandle {
     std::unique_ptr<kota::ipc::BincodePeer> peer;
     int stderr_fd = -1;
 
-    bool spawn(const std::string& mode, std::uint64_t memory_limit = 0) {
+    bool spawn(std::uint64_t memory_limit = 0) {
         auto binary = clice_binary();
+        auto label = memory_limit > 0 ? "stateful" : "stateless";
 
 #ifndef _WIN32
-        // Redirect worker stderr to a temp file for debugging.
-        std::string stderr_path = "/tmp/clice_worker_stderr_" + mode + ".log";
+        std::string stderr_path = std::string("/tmp/clice_worker_stderr_") + label + ".log";
         stderr_fd = ::open(stderr_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 #endif
 
         kota::process::options opts;
         opts.file = binary;
-        opts.args = {binary, "--mode", mode};
+        opts.args = {binary, "worker"};
         if(memory_limit > 0) {
-            opts.args.push_back("--worker-memory-limit");
+            opts.args.push_back("--memory-limit");
             opts.args.push_back(std::to_string(memory_limit));
         }
         opts.streams = {


### PR DESCRIPTION
## Summary

- **Subcommand dispatch**: Replace the flat `--mode` flag with git-style subcommands using kotatsu's `SubCommander` API: `clice server`, `clice query`, `clice worker`, `clice lint`, `clice format`. Each subcommand has its own `--help`.
- **Typed server mode enum**: `ServerMode` enum (`Pipe|Socket|Relay|Daemon`) replaces string comparisons; the deco framework auto-parses enum values and renders them in help text.
- **Explicit `--stateful` worker flag**: Worker type is no longer inferred from the presence of `--memory-limit`. `clice worker --stateful` explicitly selects stateful mode; `--memory-limit` is an optional config (defaults to 4 GB).
- **Dedicated option structs per subcommand**: The monolithic `Options` struct is split into `ServerOptions`, `QueryOptions`, `WorkerOptions`, `LintOptions`, `FormatOptions` — each declares only the flags it needs. Intermediate adapter structs (`ServerOptions`/`DaemonOptions`/`AgenticQueryOptions` in old code) are eliminated; run functions receive the deco option structs directly.
- **Editor/test/doc updates**: All editor plugins (VS Code, Neovim, Zed), integration tests, smoke replay, worker spawn args, and documentation updated to the new `clice server [OPTIONS]` syntax.

## Details

The old CLI used a single `kota::deco::cli::parse<Options>` call with a `--mode` string that dispatched to 7 different code paths (pipe, socket, daemon, relay, agentic, stateless-worker, stateful-worker). This made help output noisy (all flags shown regardless of mode) and made it impossible to validate mode-specific required flags early.

The new design registers each subcommand as an independent `Command<T>` with its own option struct and handler. The `SubCommander` dispatches to the correct handler, and each handler validates only its own flags (e.g. `query` validates `--port` range before calling `run_agentic_mode`).

`lint` and `format` are registered as placeholders — they print "not yet implemented" and exit. They're visible in help intentionally, to establish the public interface early.

## Test plan

- [x] 566 unit tests pass (worker spawn args updated)
- [x] 2 smoke tests pass (replay uses `server` subcommand)
- [x] 172 integration tests pass (2 new: `test_daemon_requires_workspace`, `test_socket_mode_connects`)
- [ ] Manual: `clice --help`, `clice --version`, `clice server --help`, `clice query --help`
- [ ] Manual: `clice server --mode socket --port 50051` accepts connections
- [ ] Manual: `clice server --mode daemon` without `--workspace` exits non-zero