### PR TITLE
fix(docs): use relative links in index.md hero actions

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -8,13 +8,13 @@ hero:
   actions:
     - theme: brand
       text: What is clice?
-      link: /guide/what-is-clice
+      link: ./guide/what-is-clice
     - theme: alt
       text: Quick Start
-      link: /guide/quick-start
+      link: ./guide/quick-start
     - theme: alt
       text: Contribution
-      link: /dev/contribution
+      link: ./dev/contribution
   image:
     src: /image.png
     alt: clice

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -8,13 +8,13 @@ hero:
   actions:
     - theme: brand
       text: 什么是 clice?
-      link: /zh/guide/what-is-clice
+      link: ./guide/what-is-clice
     - theme: alt
       text: 快速开始
-      link: /zh/guide/quick-start
+      link: ./guide/quick-start
     - theme: alt
       text: 参与贡献
-      link: /zh/dev/contribution
+      link: ./dev/contribution
   image:
     src: /image.png
     alt: clice


### PR DESCRIPTION
## Summary
- Absolute links like `/guide/what-is-clice` in `docs/en/index.md` and `docs/zh/index.md` resolve to the docs site root instead of the `/clice/` subpath when synced to the central docs repo.
- Switch to relative paths (`./guide/...`) so links work correctly.

## Test plan
- [ ] After sync to docs repo, `/clice/` hero links navigate to `/clice/guide/...`
- [ ] `/zh/clice/` hero links navigate to `/zh/clice/guide/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated homepage action links in English and Chinese documentation pages to use relative paths instead of absolute paths for improved navigation consistency across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->