### PR TITLE
refactor(server): interest-counted module compile cancellation

### DIFF
--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -104,10 +104,31 @@ void CompileGraph::release(std::uint32_t path_id) {
     assert(unit.refcount > 0 && "released more interest than acquired");
     unit.refcount -= 1;
 
-    // No interest left in an in-flight round: cancel it. The task unwinds
-    // asynchronously and its guard finishes the bookkeeping, releasing its
-    // own edge references in turn (cascading the cancellation).
+    // No interest left in an in-flight round. The drop is often transient —
+    // a stale round's edges being re-acquired by the retry that re-resolves
+    // it — so don't cancel right away: defer the decision by one event-loop
+    // tick. Synchronous re-acquisition happens within the current drain
+    // cycle, strictly before the check fires, so retained dependencies are
+    // handed over to the new round instead of being killed and restarted;
+    // only a sustained zero cancels.
+    if(unit.refcount == 0 && unit.compiling && !unit.zero_check_pending) {
+        unit.zero_check_pending = true;
+        if(!tasks.spawn(zero_interest_check(path_id))) {
+            // Graph is shutting down; everything gets cancelled anyway.
+            units.find(path_id)->second.zero_check_pending = false;
+        }
+    }
+}
+
+kota::task<> CompileGraph::zero_interest_check(std::uint32_t path_id) {
+    co_await kota::sleep(0);
+
+    auto& unit = units.find(path_id)->second;
+    unit.zero_check_pending = false;
     if(unit.refcount == 0 && unit.compiling) {
+        // The task unwinds asynchronously and its guard finishes the
+        // bookkeeping, releasing its own edge references in turn (cascading
+        // the cancellation).
         cancel_round(unit);
     }
 }

--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -1,15 +1,75 @@
 #include "server/compiler/compile_graph.h"
 
 #include <algorithm>
+#include <cassert>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 
 namespace clice {
 
 namespace ranges = std::ranges;
 
-CompileGraph::CompileGraph(dispatch_fn dispatch, resolve_fn resolve) :
-    dispatch(std::move(dispatch)), resolve(std::move(resolve)) {}
+/// Request scope: holds root references for one compile()/compile_deps()
+/// call. The destructor runs on every exit path, including cancellation
+/// unwind of the requester's frame.
+struct CompileGraph::RefGuard {
+    CompileGraph& graph;
+    llvm::SmallVector<std::uint32_t, 4> held;
+
+    RefGuard(CompileGraph& graph, llvm::ArrayRef<std::uint32_t> ids) :
+        graph(graph), held(ids.begin(), ids.end()) {
+        for(auto id: held) {
+            graph.acquire(id);
+        }
+    }
+
+    RefGuard(const RefGuard&) = delete;
+    RefGuard& operator=(const RefGuard&) = delete;
+
+    ~RefGuard() {
+        for(auto id: held) {
+            graph.release(id);
+        }
+    }
+};
+
+/// Maintains all per-round invariants of a unit task. kotatsu cancellation
+/// destroys a suspended frame without resuming it, so code after a co_await
+/// never runs on the cancel path — only destructors of locals established
+/// before the first suspension are guaranteed to execute. This guard is that
+/// destructor; the body must not maintain unit state any other way.
+struct CompileGraph::UnitGuard {
+    CompileGraph& graph;
+    std::uint32_t path_id;
+    std::shared_ptr<CompileUnit::Round> round;
+    CompileUnit::Outcome outcome = CompileUnit::Outcome::Stale;
+
+    /// Edge references acquired by this task; registration here must stay
+    /// synchronous with the matching refcount increment.
+    llvm::SmallVector<std::uint32_t, 8> acquired;
+
+    ~UnitGuard() {
+        // Publish the outcome, clear the compiling flag, release edge
+        // references, then wake waiters — all synchronous. Resumes triggered
+        // by cancel()/set() are deferred by the event loop, so nothing
+        // re-enters the graph mid-destructor.
+        round->outcome = outcome;
+
+        auto& unit = graph.units.find(path_id)->second;
+        assert(unit.compiling && unit.round == round && "unit round bookkeeping out of sync");
+        unit.compiling = false;
+
+        for(auto dep_id: acquired) {
+            graph.release(dep_id);
+        }
+
+        round->completion.set();
+    }
+};
+
+CompileGraph::CompileGraph(kota::event_loop& loop, dispatch_fn dispatch, resolve_fn resolve) :
+    dispatch(std::move(dispatch)), resolve(std::move(resolve)), tasks(loop) {}
 
 void CompileGraph::ensure_resolved(std::uint32_t path_id) {
     auto& unit = units[path_id];
@@ -33,130 +93,180 @@ void CompileGraph::ensure_resolved(std::uint32_t path_id) {
     }
 }
 
-kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id) {
-    llvm::DenseSet<std::uint32_t> ancestors;
-    co_return co_await compile_impl(path_id, ancestors, false);
+void CompileGraph::acquire(std::uint32_t path_id) {
+    auto& unit = units[path_id];
+    unit.path_id = path_id;
+    unit.refcount += 1;
 }
 
-kota::task<bool> CompileGraph::compile(std::uint32_t path_id) {
-    llvm::DenseSet<std::uint32_t> ancestors;
-    co_return co_await compile_impl(path_id, ancestors);
+void CompileGraph::release(std::uint32_t path_id) {
+    auto& unit = units.find(path_id)->second;
+    assert(unit.refcount > 0 && "released more interest than acquired");
+    unit.refcount -= 1;
+
+    // No interest left in an in-flight round: cancel it. The task unwinds
+    // asynchronously and its guard finishes the bookkeeping, releasing its
+    // own edge references in turn (cascading the cancellation).
+    if(unit.refcount == 0 && unit.compiling) {
+        cancel_round(unit);
+    }
 }
 
-kota::task<bool> CompileGraph::compile_impl(std::uint32_t path_id,
-                                            llvm::DenseSet<std::uint32_t> ancestors,
-                                            bool dispatch_self) {
-    ensure_resolved(path_id);
+void CompileGraph::cancel_round(CompileUnit& unit) {
+    unit.source->cancel();
+    unit.source = std::make_unique<kota::cancellation_source>();
+}
 
-    // Cycle detection: if this unit is already in the compile chain, bail out.
-    if(!ancestors.insert(path_id).second) {
-        co_return false;
+bool CompileGraph::spawn_unit(std::uint32_t path_id) {
+    auto& unit = units.find(path_id)->second;
+    assert(!unit.compiling && "spawn requested while a round is in flight");
+    unit.compiling = true;
+    unit.round = std::make_shared<CompileUnit::Round>();
+    auto round = unit.round;
+    auto token = unit.source->token();
+
+    // spawn resumes the body synchronously up to its first suspension point,
+    // which may insert units and invalidate `unit` — don't touch it below.
+    if(tasks.spawn(unit_task(path_id, round, token))) {
+        return true;
     }
 
-    // Re-lookup after ensure_resolved may have mutated the map.
-    auto it = units.find(path_id);
+    // The graph is shutting down: roll back so concurrent waiters observe a
+    // stale, completed round instead of hanging.
+    units.find(path_id)->second.compiling = false;
+    round->completion.set();
+    return false;
+}
 
-    // For deps-only mode, compile dependencies concurrently and return.
-    if(!dispatch_self) {
-        auto deps = it->second.dependencies;
-        if(deps.empty()) {
+kota::task<> CompileGraph::unit_task(std::uint32_t path_id,
+                                     std::shared_ptr<CompileUnit::Round> round,
+                                     kota::cancellation_token token) {
+    // The cancellation surfaces here as an explicit outcome instead of
+    // unwinding this wrapper, so the task always completes as Finished.
+    co_await kota::with_token(unit_body(path_id, std::move(round)), std::move(token));
+}
+
+kota::task<> CompileGraph::unit_body(std::uint32_t path_id,
+                                     std::shared_ptr<CompileUnit::Round> round) {
+    UnitGuard guard{*this, path_id, std::move(round)};
+
+    ensure_resolved(path_id);
+
+    auto& unit = units.find(path_id)->second;
+    auto gen = unit.generation;
+    // Copy deps — the map may rehash while this frame is suspended.
+    auto deps = unit.dependencies;
+
+    // Trivial cycle: a unit depending on itself can never make progress.
+    if(ranges::contains(deps, path_id)) {
+        guard.outcome = CompileUnit::Outcome::Failed;
+        co_return;
+    }
+
+    // Acquire edge references on all direct dependencies. This must stay
+    // synchronous: no suspension between refcount++ and guard registration.
+    for(auto dep_id: deps) {
+        acquire(dep_id);
+        guard.acquired.push_back(dep_id);
+    }
+
+    if(!deps.empty()) {
+        std::vector<kota::task<bool>> waits;
+        waits.reserve(deps.size());
+        for(auto dep_id: deps) {
+            waits.push_back(await_unit(dep_id, path_id));
+        }
+
+        auto results = co_await kota::when_all(std::move(waits));
+        if(!ranges::all_of(results, [](bool ok) { return ok; })) {
+            guard.outcome = CompileUnit::Outcome::Failed;
+            co_return;
+        }
+    }
+
+    bool ok = co_await dispatch(path_id);
+
+    // Synchronous tail: nothing can interleave between dispatch resuming us
+    // and co_return, so the checks below are atomic.
+    if(!ok) {
+        guard.outcome = CompileUnit::Outcome::Failed;
+        co_return;
+    }
+
+    auto& fresh = units.find(path_id)->second;
+    if(fresh.generation != gen) {
+        // update() raced with dispatch completion: our cancellation was
+        // signalled but this frame resumed first. The result is stale.
+        co_return;
+    }
+
+    fresh.dirty = false;
+    guard.outcome = CompileUnit::Outcome::Success;
+}
+
+kota::task<bool> CompileGraph::await_unit(std::uint32_t path_id,
+                                          std::optional<std::uint32_t> waiter) {
+    while(true) {
+        auto& unit = units.find(path_id)->second;
+        if(!unit.dirty) {
             co_return true;
         }
 
-        std::vector<kota::task<bool>> dep_tasks;
-        dep_tasks.reserve(deps.size());
-        for(auto dep_id: deps) {
-            dep_tasks.push_back(compile_impl(dep_id, ancestors));
+        if(!unit.compiling && !spawn_unit(path_id)) {
+            co_return false;  // graph is shutting down
         }
-        auto results = co_await kota::when_all(std::move(dep_tasks));
-        for(auto ok: results) {
-            if(!ok) {
-                co_return false;
-            }
-        }
-        co_return true;
-    }
 
-    // Already clean.
-    if(!it->second.dirty) {
-        co_return true;
-    }
+        // Re-find: spawn_unit runs the unit body synchronously, which may
+        // rehash the map (and may even complete the round outright).
+        auto round = units.find(path_id)->second.round;
 
-    // Another task is already compiling this unit — wait for it,
-    // but first check that waiting won't deadlock (cross-branch cycle).
-    if(it->second.compiling) {
-        if(has_wait_cycle(path_id, ancestors)) {
+        // Blocking on a unit whose dependency chain reaches back to the
+        // waiting unit would deadlock — fail as a dependency cycle instead.
+        if(!round->completion.is_set() && waiter && has_wait_cycle(path_id, *waiter)) {
             co_return false;
         }
-        auto& completion = *it->second.completion;
-        co_await completion.wait();
-        co_return !units.find(path_id)->second.dirty;
-    }
 
-    // Begin compilation. The finish lambda ensures compiling/completion state
-    // is always cleaned up, regardless of how the function exits.
-    it->second.compiling = true;
-    it->second.completion = std::make_unique<kota::event>();
+        co_await round->completion.wait();
 
-    auto finish = [&, path_id] {
-        auto& u = units.find(path_id)->second;
-        u.compiling = false;
-        u.completion->set();
-    };
-
-    // Copy deps and capture generation before co_await (DenseMap iterator safety).
-    auto deps = it->second.dependencies;
-    auto gen = it->second.generation;
-    auto token = it->second.source->token();
-
-    // Compile all dependencies concurrently.
-    // Deadlocks from cross-branch cycles (e.g. 1->{2,3}, 2->3, 3->2) are
-    // prevented by has_wait_cycle() checking before completion.wait().
-    if(!deps.empty()) {
-        std::vector<kota::task<bool, void, kota::cancellation>> dep_tasks;
-        dep_tasks.reserve(deps.size());
-        for(auto dep_id: deps) {
-            dep_tasks.push_back(kota::with_token(compile_impl(dep_id, ancestors), token));
-        }
-
-        auto results = co_await kota::when_all(std::move(dep_tasks));
-
-        if(results.is_cancelled()) {
-            finish();
-            co_await kota::cancel();
-        }
-
-        for(auto ok: *results) {
-            if(!ok) {
-                finish();
-                co_return false;
-            }
+        switch(round->outcome) {
+            case CompileUnit::Outcome::Success: co_return true;
+            case CompileUnit::Outcome::Failed: co_return false;
+            // The round was cancelled and produced no result; we still hold
+            // interest, so drive a new round. Each retry consumes one
+            // staleness event — without further updates this terminates.
+            case CompileUnit::Outcome::Stale: break;
         }
     }
+}
 
-    // Dispatch the actual compilation, cancellable via the pre-captured token.
-    auto result = co_await kota::with_token(dispatch(path_id), token);
+kota::task<bool> CompileGraph::compile(std::uint32_t path_id) {
+    // Request scope: one root reference, dropped when the requester exits or
+    // its frame is cancelled.
+    RefGuard scope(*this, {path_id});
+    co_return co_await await_unit(path_id, std::nullopt);
+}
 
-    if(!result.has_value()) {
-        finish();
-        co_await kota::cancel();
+kota::task<bool> CompileGraph::compile_deps(std::uint32_t path_id) {
+    ensure_resolved(path_id);
+
+    // Copy deps — the map may rehash while this frame is suspended.
+    auto deps = units.find(path_id)->second.dependencies;
+    if(deps.empty()) {
+        co_return true;
     }
 
-    if(!*result) {
-        finish();
-        co_return false;
+    // Request scope: root references on each direct dependency (path_id
+    // itself is never dispatched here).
+    RefGuard scope(*this, deps);
+
+    std::vector<kota::task<bool>> waits;
+    waits.reserve(deps.size());
+    for(auto dep_id: deps) {
+        waits.push_back(await_unit(dep_id, std::nullopt));
     }
 
-    // Success — only clear dirty if update() hasn't bumped the generation.
-    auto& final_unit = units.find(path_id)->second;
-    if(final_unit.generation != gen) {
-        finish();
-        co_return false;
-    }
-
-    final_unit.dirty = false;
-    finish();
-    co_return true;
+    auto results = co_await kota::when_all(std::move(waits));
+    co_return ranges::all_of(results, [](bool ok) { return ok; });
 }
 
 llvm::SmallVector<std::uint32_t> CompileGraph::update(std::uint32_t path_id) {
@@ -196,11 +306,10 @@ llvm::SmallVector<std::uint32_t> CompileGraph::update(std::uint32_t path_id) {
             unit.dependencies.clear();
         }
 
-        // Cancel in-flight compilation if running.
-        if(unit.compiling) {
-            unit.source->cancel();
-            unit.source = std::make_unique<kota::cancellation_source>();
-        }
+        // The in-flight result (if any) is stale: cancel the round. Interest
+        // counts are untouched — waiters keep their references and drive a
+        // fresh round once the cancelled task unwinds.
+        cancel_round(unit);
         unit.dirty = true;
         unit.generation++;
         dirtied.push_back(current);
@@ -214,10 +323,9 @@ llvm::SmallVector<std::uint32_t> CompileGraph::update(std::uint32_t path_id) {
     return dirtied;
 }
 
-bool CompileGraph::has_wait_cycle(std::uint32_t target,
-                                  const llvm::DenseSet<std::uint32_t>& ancestors) const {
-    // BFS through the target's dependency chain, following only compiling units.
-    // If any dependency is in our ancestor chain, waiting would deadlock.
+bool CompileGraph::has_wait_cycle(std::uint32_t target, std::uint32_t waiter) const {
+    // BFS through the target's dependency chain, following only compiling
+    // units. If any dependency reaches the waiting unit, waiting would deadlock.
     llvm::SmallVector<std::uint32_t> queue;
     llvm::DenseSet<std::uint32_t> visited;
     queue.push_back(target);
@@ -232,7 +340,7 @@ bool CompileGraph::has_wait_cycle(std::uint32_t target,
             continue;
         }
         for(auto dep_id: it->second.dependencies) {
-            if(ancestors.count(dep_id)) {
+            if(dep_id == waiter) {
                 return true;
             }
             auto dep_it = units.find(dep_id);
@@ -246,9 +354,16 @@ bool CompileGraph::has_wait_cycle(std::uint32_t target,
 
 void CompileGraph::cancel_all() {
     for(auto& [_, unit]: units) {
-        unit.source->cancel();
-        unit.source = std::make_unique<kota::cancellation_source>();
+        cancel_round(unit);
     }
+}
+
+kota::task<> CompileGraph::shutdown() {
+    // Structured two-step shutdown: cancel every unit task regardless of
+    // interest, then wait for the frames to unwind. The task group must be
+    // joined before destruction.
+    tasks.cancel();
+    co_await tasks.join();
 }
 
 bool CompileGraph::has_unit(std::uint32_t path_id) const {
@@ -263,6 +378,26 @@ bool CompileGraph::is_dirty(std::uint32_t path_id) const {
 bool CompileGraph::is_compiling(std::uint32_t path_id) const {
     auto it = units.find(path_id);
     return it != units.end() && it->second.compiling;
+}
+
+std::uint32_t CompileGraph::refcount(std::uint32_t path_id) const {
+    auto it = units.find(path_id);
+    return it != units.end() ? it->second.refcount : 0;
+}
+
+bool CompileGraph::idle() const {
+    return ranges::all_of(units, [](const auto& entry) {
+        const auto& unit = entry.second;
+        bool round_done = !unit.round || unit.round->completion.is_set();
+        return !unit.compiling && unit.refcount == 0 && round_done;
+    });
+}
+
+bool CompileGraph::consistent() const {
+    return ranges::all_of(units, [](const auto& entry) {
+        const auto& unit = entry.second;
+        return !unit.compiling || (unit.round && !unit.round->completion.is_set());
+    });
 }
 
 }  // namespace clice

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -182,6 +182,9 @@ private:
     llvm::DenseMap<std::uint32_t, CompileUnit> units;
 
     /// Owns every unit task; structured shutdown via shutdown().
+    /// Note: kota::task_group only reclaims completed child frames on
+    /// destruction, so frames accumulate over the graph's lifetime — one per
+    /// compilation round, same trade-off as Compiler::compile_tasks.
     kota::task_group<> tasks;
 };
 

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -3,15 +3,35 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "kota/async/async.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace clice {
 
 struct CompileUnit {
+    /// Result of one compilation round, observed by waiters after the
+    /// round's completion event fires.
+    enum class Outcome : std::uint8_t {
+        /// The round was cancelled (file update or loss of interest) and its
+        /// result discarded; waiters that still hold interest retry.
+        Stale,
+        Success,
+        /// Dispatch failed or a dependency cycle was detected; waiters
+        /// propagate the failure instead of retrying.
+        Failed,
+    };
+
+    /// State of one compilation round. Waiters capture the shared_ptr before
+    /// suspending so the completion event outlives both map mutations and
+    /// the unit task that publishes the outcome.
+    struct Round {
+        kota::event completion;
+        Outcome outcome = Outcome::Stale;
+    };
+
     std::uint32_t path_id = 0;
 
     /// Dependencies discovered lazily by resolve_fn.
@@ -26,15 +46,47 @@ struct CompileUnit {
     bool dirty = true;
     bool compiling = false;
 
-    /// Monotonic counter bumped by update(); used by compile_impl to detect
-    /// stale completions without ABA risk from raw-pointer comparison.
+    /// In-flight interest count: one per requesting root plus one per edge
+    /// held by a dependent unit's running task. Dropping to zero while
+    /// compiling cancels this unit's round. Not a lifetime count.
+    std::uint32_t refcount = 0;
+
+    /// Monotonic counter bumped by update(); detects results that became
+    /// stale while the cancellation raced with a dispatch completion.
     std::uint64_t generation = 0;
 
+    /// Cancellation scope of the current round; replaced after every cancel
+    /// so the next round always starts with a fresh token.
     std::unique_ptr<kota::cancellation_source> source =
         std::make_unique<kota::cancellation_source>();
-    std::unique_ptr<kota::event> completion;
+
+    /// Current (or most recent) compilation round.
+    std::shared_ptr<Round> round;
 };
 
+/// Module compilation DAG with interest-counted cancellation.
+///
+/// Each dirty unit is compiled by an independent task spawned into the
+/// graph's task group, cancellable only through its own round token —
+/// requesters and dependent units merely wait on the round's completion
+/// event. Lifecycle by phase:
+///
+/// - Request arrival: compile()/compile_deps() takes a root reference on the
+///   requested unit(s) and waits. A dirty unit with no running round gets a
+///   unit task spawned; the task acquires edge references on its direct
+///   dependencies, waits for them, then dispatches its own compilation.
+/// - Request cancel: the requester's frame unwinds and drops its root
+///   reference. A unit whose interest reaches zero mid-compile has its round
+///   cancelled; the exiting task drops its edge references, cascading the
+///   cancellation through no-longer-needed dependencies. Shared dependencies
+///   keep compiling as long as any other consumer holds interest.
+/// - File update: update() marks the unit and its transitive dependents
+///   dirty and cancels their in-flight rounds — the results are stale.
+///   Interest is NOT touched; waiters observe the stale round and drive a
+///   fresh one with the new content.
+/// - Compile finish: the unit task publishes success/failure through its
+///   round and wakes waiters; success clears dirty, failure (compile error,
+///   dependency cycle) propagates to waiters without retry.
 class CompileGraph {
 public:
     /// Performs the actual compilation (e.g. produce PCM file).
@@ -43,7 +95,7 @@ public:
     /// Returns the dependency path_ids for a given path_id (called lazily on first compile).
     using resolve_fn = std::function<llvm::SmallVector<std::uint32_t>(std::uint32_t path_id)>;
 
-    CompileGraph(dispatch_fn dispatch, resolve_fn resolve);
+    CompileGraph(kota::event_loop& loop, dispatch_fn dispatch, resolve_fn resolve);
 
     /// Compile a unit and all its transitive dependencies.
     kota::task<bool> compile(std::uint32_t path_id);
@@ -53,33 +105,84 @@ public:
     kota::task<bool> compile_deps(std::uint32_t path_id);
 
     /// Mark path_id and all transitive dependents as dirty,
-    /// cancelling any in-progress compilations.
+    /// cancelling any in-progress compilations (their results are stale).
     /// Returns the set of all path_ids that were marked dirty.
     llvm::SmallVector<std::uint32_t> update(std::uint32_t path_id);
 
+    /// Cancel every in-flight round regardless of interest. Waiters that
+    /// still hold interest respawn their units afterwards.
     void cancel_all();
+
+    /// Cancel all unit tasks and wait for their frames to unwind. Must be
+    /// awaited exactly once before the graph is destroyed; no compilation
+    /// can be started afterwards.
+    kota::task<> shutdown();
 
     bool has_unit(std::uint32_t path_id) const;
     bool is_dirty(std::uint32_t path_id) const;
     bool is_compiling(std::uint32_t path_id) const;
 
+    /// Current in-flight interest count for a unit (testing/diagnostics).
+    std::uint32_t refcount(std::uint32_t path_id) const;
+
+    /// All bookkeeping is quiesced: nothing compiling, no interest held and
+    /// every round's completion has fired. Holds whenever no request is in
+    /// flight and all unit tasks have unwound (e.g. after shutdown()).
+    bool idle() const;
+
+    /// Structural sanity that holds at every drain boundary: a compiling
+    /// unit has an unfinished round, and a finished round never leaves the
+    /// compiling flag behind.
+    bool consistent() const;
+
 private:
+    struct RefGuard;
+    struct UnitGuard;
+
     /// Get or create a unit, resolving its dependencies if needed.
     void ensure_resolved(std::uint32_t path_id);
 
-    /// Internal compile with ancestor tracking for cycle detection.
-    kota::task<bool> compile_impl(std::uint32_t path_id,
-                                  llvm::DenseSet<std::uint32_t> ancestors,
-                                  bool dispatch_self = true);
+    /// Interest +1; creates the unit if needed.
+    void acquire(std::uint32_t path_id);
 
-    /// Check if waiting on `target` would deadlock given our `ancestors` chain.
-    /// Walks the dependency graph through compiling units to see if any dep
-    /// transitively reaches a unit in our ancestor chain.
-    bool has_wait_cycle(std::uint32_t target, const llvm::DenseSet<std::uint32_t>& ancestors) const;
+    /// Interest -1; cancels the unit's round when it drops to zero mid-compile.
+    void release(std::uint32_t path_id);
+
+    /// Cancel the current round and install a fresh cancellation scope.
+    void cancel_round(CompileUnit& unit);
+
+    /// Start a unit task for path_id in the graph's task group.
+    /// Returns false when the graph is shutting down.
+    bool spawn_unit(std::uint32_t path_id);
+
+    /// One compilation round of a unit, cancelled only through its round token.
+    kota::task<> unit_body(std::uint32_t path_id, std::shared_ptr<CompileUnit::Round> round);
+
+    /// Spawned wrapper: runs unit_body under the round token and absorbs the
+    /// cancellation outcome. The task group treats a cancelled child as a
+    /// reason to abort every sibling (structured fail-fast); a round
+    /// cancelled via its token is a normal event and must not do that.
+    kota::task<> unit_task(std::uint32_t path_id,
+                           std::shared_ptr<CompileUnit::Round> round,
+                           kota::cancellation_token token);
+
+    /// Wait until path_id reaches a terminal outcome, respawning its unit
+    /// task whenever a stale round invalidates the previous attempt.
+    /// `waiter` is the unit doing the waiting (for deadlock detection),
+    /// or nullopt for requests.
+    kota::task<bool> await_unit(std::uint32_t path_id, std::optional<std::uint32_t> waiter);
+
+    /// Check if waiting on `target` would deadlock: walks the dependency
+    /// graph through compiling units to see if any dependency transitively
+    /// reaches the waiting unit.
+    bool has_wait_cycle(std::uint32_t target, std::uint32_t waiter) const;
 
     dispatch_fn dispatch;
     resolve_fn resolve;
     llvm::DenseMap<std::uint32_t, CompileUnit> units;
+
+    /// Owns every unit task; structured shutdown via shutdown().
+    kota::task_group<> tasks;
 };
 
 }  // namespace clice

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -47,9 +47,12 @@ struct CompileUnit {
     bool compiling = false;
 
     /// In-flight interest count: one per requesting root plus one per edge
-    /// held by a dependent unit's running task. Dropping to zero while
+    /// held by a dependent unit's running task. Staying at zero while
     /// compiling cancels this unit's round. Not a lifetime count.
     std::uint32_t refcount = 0;
+
+    /// A zero-interest cancellation check is already queued for this unit.
+    bool zero_check_pending = false;
 
     /// Monotonic counter bumped by update(); detects results that became
     /// stale while the cancellation raced with a dispatch completion.
@@ -76,10 +79,12 @@ struct CompileUnit {
 ///   unit task spawned; the task acquires edge references on its direct
 ///   dependencies, waits for them, then dispatches its own compilation.
 /// - Request cancel: the requester's frame unwinds and drops its root
-///   reference. A unit whose interest reaches zero mid-compile has its round
-///   cancelled; the exiting task drops its edge references, cascading the
-///   cancellation through no-longer-needed dependencies. Shared dependencies
-///   keep compiling as long as any other consumer holds interest.
+///   reference. A unit whose interest stays at zero for an event-loop tick
+///   has its round cancelled; the exiting task drops its edge references,
+///   cascading the cancellation through no-longer-needed dependencies.
+///   Shared dependencies keep compiling as long as any other consumer holds
+///   interest, and a transient drop (a retry re-acquiring a retained
+///   dependency after re-resolve) does not disturb the running compilation.
 /// - File update: update() marks the unit and its transitive dependents
 ///   dirty and cancels their in-flight rounds — the results are stale.
 ///   Interest is NOT touched; waiters observe the stale round and drive a
@@ -145,8 +150,16 @@ private:
     /// Interest +1; creates the unit if needed.
     void acquire(std::uint32_t path_id);
 
-    /// Interest -1; cancels the unit's round when it drops to zero mid-compile.
+    /// Interest -1; schedules a zero-interest cancellation check when it
+    /// drops to zero mid-compile.
     void release(std::uint32_t path_id);
+
+    /// Cancels path_id's round if its interest is still zero one event-loop
+    /// tick after release() saw it drop. The delay lets transient drops
+    /// survive: a retry respawning the unit after update() re-acquires its
+    /// retained dependencies within the same drain cycle, so their in-flight
+    /// compilations are handed over instead of being killed and restarted.
+    kota::task<> zero_interest_check(std::uint32_t path_id);
 
     /// Cancel the current round and install a fresh cancellation scope.
     void cancel_round(CompileUnit& unit);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -615,6 +615,12 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
         }
     }
 
+    // The buffer-scan waits above tolerate failed PCM builds, but a cancelled
+    // scope means this round was superseded — abandon it before the PCH step.
+    if(scope && scope->cancelled()) {
+        co_return false;
+    }
+
     // Build or reuse PCH.
     auto pch_ok = co_await ensure_pch(session, directory, arguments);
     if(pch_ok) {
@@ -705,6 +711,18 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
     sess = find_session();
     if(!sess) {
         pc->done.set();
+        co_return;
+    }
+
+    // Superseded while preparing dependencies — don't send the stale text:
+    // the replacement compile may already have sent newer text, and the
+    // worker applies compiles in arrival order without a version check.
+    if(sess->generation != gen) {
+        LOG_INFO("ensure_compiled: superseded before send ({} vs {}) for {}",
+                 sess->generation,
+                 gen,
+                 uri_str);
+        finish_compile();
         co_return;
     }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -40,6 +40,12 @@ Compiler::~Compiler() {
 kota::task<> Compiler::stop() {
     compile_tasks.cancel();
     co_await compile_tasks.join();
+
+    // Requests have unwound and released their interest; now tear down the
+    // module compile graph's own unit tasks.
+    if(workspace.compile_graph) {
+        co_await workspace.compile_graph->shutdown();
+    }
 }
 
 void Compiler::init_compile_graph() {
@@ -147,7 +153,7 @@ void Compiler::init_compile_graph() {
     };
 
     workspace.compile_graph =
-        std::make_unique<CompileGraph>(std::move(dispatch), std::move(resolve));
+        std::make_unique<CompileGraph>(loop, std::move(dispatch), std::move(resolve));
     LOG_INFO("CompileGraph initialized with {} module(s)", workspace.path_to_module.size());
 }
 
@@ -562,11 +568,23 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
                                        const std::string& directory,
                                        const std::vector<std::string>& arguments,
                                        std::pair<std::string, uint32_t>& pch,
-                                       std::unordered_map<std::string, std::string>& pcms) {
+                                       std::unordered_map<std::string, std::string>& pcms,
+                                       std::optional<kota::cancellation_token> scope) {
     auto path_id = session.path_id;
 
+    // Compile module dependencies within the request scope: cancelling the
+    // scope unwinds the wait and releases this request's interest in the
+    // dependency graph, without touching the shared compilations themselves.
+    auto compile_deps = [&](std::uint32_t pid) -> kota::task<bool> {
+        if(!scope) {
+            co_return co_await workspace.compile_graph->compile_deps(pid);
+        }
+        auto result = co_await kota::with_token(workspace.compile_graph->compile_deps(pid), *scope);
+        co_return result.has_value() && *result;
+    };
+
     // Compile C++20 module dependencies (PCMs).
-    if(workspace.compile_graph && !co_await workspace.compile_graph->compile_deps(path_id)) {
+    if(workspace.compile_graph && !co_await compile_deps(path_id)) {
         co_return false;
     }
 
@@ -584,7 +602,7 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
                     // If PCM not already built, try to build it.
                     if(workspace.pcm_paths.find(pid) == workspace.pcm_paths.end()) {
                         if(workspace.compile_graph && workspace.compile_graph->has_unit(pid)) {
-                            co_await workspace.compile_graph->compile_deps(pid);
+                            co_await compile_deps(pid);
                         }
                     }
                     found = true;
@@ -673,7 +691,12 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
         co_return;
     }
 
-    if(!co_await ensure_deps(*sess, params.directory, params.arguments, params.pch, params.pcms)) {
+    if(!co_await ensure_deps(*sess,
+                             params.directory,
+                             params.arguments,
+                             params.pch,
+                             params.pcms,
+                             pc->deps_scope.token())) {
         LOG_WARN("Dependency preparation failed for {}, skipping compile", uri_str);
         finish_compile();
         co_return;
@@ -770,23 +793,37 @@ kota::task<bool> Compiler::ensure_compiled(Session& session) {
         session.ast_dirty = true;
     }
 
-    // If another compile is already in flight, wait for it.
+    // If an up-to-date compile is already in flight, wait for it.
     // This co_await may be cancelled by LSP $/cancelRequest — that's fine,
     // it just means this particular feature request is abandoned.  The
     // detached compile task keeps running independently.
     while(session.compiling) {
         auto pending = session.compiling;
+        if(pending->generation != session.generation) {
+            // The in-flight compile is stale (user edited since it started);
+            // supersede it instead of waiting for it to finish.
+            break;
+        }
         co_await pending->done.wait();
         if(!session.ast_dirty)
             co_return true;
     }
 
+    auto superseded = session.compiling;
     auto pending_compile = std::make_shared<Session::PendingCompile>();
+    pending_compile->generation = session.generation;
     session.compiling = pending_compile;
 
     LOG_INFO("ensure_compiled: launching compile path_id={} gen={}", path_id, session.generation);
 
+    // Spawn the replacement before cancelling the superseded compile: the new
+    // round acquires its module-dependency interest synchronously, so shared
+    // dependencies never see their interest drop to zero across the swap.
     compile_tasks.spawn(run_compile(path_id, pending_compile));
+
+    if(superseded) {
+        superseded->deps_scope.cancel();
+    }
 
     // Wait for the detached compile to finish.  If this wait is cancelled
     // by LSP $/cancelRequest, the detached task continues unaffected.

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -697,12 +697,14 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
         co_return;
     }
 
-    if(!co_await ensure_deps(*sess,
-                             params.directory,
-                             params.arguments,
-                             params.pch,
-                             params.pcms,
-                             pc->deps_scope.token())) {
+    bool deps_ok = co_await ensure_deps(*sess,
+                                        params.directory,
+                                        params.arguments,
+                                        params.pch,
+                                        params.pcms,
+                                        pc->deps_scope.token());
+    pc->deps_done = true;
+    if(!deps_ok) {
         LOG_WARN("Dependency preparation failed for {}, skipping compile", uri_str);
         finish_compile();
         co_return;
@@ -817,9 +819,13 @@ kota::task<bool> Compiler::ensure_compiled(Session& session) {
     // detached compile task keeps running independently.
     while(session.compiling) {
         auto pending = session.compiling;
-        if(pending->generation != session.generation) {
-            // The in-flight compile is stale (user edited since it started);
-            // supersede it instead of waiting for it to finish.
+        if(pending->generation != session.generation && !pending->deps_done) {
+            // The in-flight compile is stale (user edited since it started)
+            // and still holds interest in the module graph — supersede it.
+            // A stale compile already past its dependency phase is left to
+            // finish instead: superseding it gains nothing (the worker send
+            // is not cancellable), and waiting coalesces rapid edits into a
+            // single follow-up compile at the latest generation.
             break;
         }
         co_await pending->done.wait();

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -109,11 +109,14 @@ public:
 private:
     kota::task<> run_compile(std::uint32_t path_id, std::shared_ptr<Session::PendingCompile> pc);
 
+    /// @param scope  When set, cancels the module-dependency wait if this
+    ///               compile round is superseded by a newer one.
     kota::task<bool> ensure_deps(Session& session,
                                  const std::string& directory,
                                  const std::vector<std::string>& arguments,
                                  std::pair<std::string, uint32_t>& pch,
-                                 std::unordered_map<std::string, std::string>& pcms);
+                                 std::unordered_map<std::string, std::string>& pcms,
+                                 std::optional<kota::cancellation_token> scope = {});
 
     kota::task<bool> ensure_pch(Session& session,
                                 const std::string& directory,

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -16,6 +16,7 @@
 #include "kota/ipc/lsp/position.h"
 #include "kota/ipc/lsp/protocol.h"
 #include "kota/ipc/lsp/uri.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"

--- a/src/server/service/session.h
+++ b/src/server/service/session.h
@@ -45,6 +45,13 @@ struct Session {
     struct PendingCompile {
         kota::event done;
         bool succeeded = false;
+
+        /// Generation snapshot at spawn; a later didChange supersedes this compile.
+        std::uint64_t generation = 0;
+
+        /// Cancels the module-dependency wait when this compile is superseded,
+        /// releasing its interest in the old dependency set.
+        kota::cancellation_source deps_scope;
     };
 
     std::shared_ptr<PendingCompile> compiling;

--- a/src/server/service/session.h
+++ b/src/server/service/session.h
@@ -49,6 +49,12 @@ struct Session {
         /// Generation snapshot at spawn; a later didChange supersedes this compile.
         std::uint64_t generation = 0;
 
+        /// True once module dependencies are settled and the compile has moved
+        /// on to the worker phase. Past this point the compile holds no
+        /// interest in the module graph and superseding it gains nothing —
+        /// stale waiters coalesce on its completion instead.
+        bool deps_done = false;
+
         /// Cancels the module-dependency wait when this compile is superseded,
         /// releasing its interest in the old dependency set.
         kota::cancellation_source deps_scope;

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -1246,7 +1246,7 @@ TEST_CASE(SharedDepImportSwitch) {
 // Shared dependency failure propagates to every consumer of the same round
 // ============================================================================
 
-TEST_CASE(SharedDepFailureFailsBoth) {
+TEST_CASE(SharedDepFailsBoth) {
     ModuleTestEnv env;
     env.tmp.touch(
         "shared.cppm",

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -152,11 +152,9 @@ void execute(F&& fn) {
     loop->run();
 }
 
-// ============================================================================
 // Basic module interface units
-// ============================================================================
 
-TEST_CASE(SingleModuleNoDeps) {
+TEST_CASE(single_module) {
     env.tmp.touch("mod_a.cppm", "export module A;\n" "export int foo() { return 42; }\n");
 
     auto json = build_cdb_json({
@@ -176,7 +174,7 @@ TEST_CASE(SingleModuleNoDeps) {
     });
 }
 
-TEST_CASE(ChainedModules) {
+TEST_CASE(chained_modules) {
     env.tmp.touch("mod_a.cppm", "export module A;\n" "export int foo() { return 42; }\n");
     env.tmp.touch("mod_b.cppm",
                   "export module B;\n"
@@ -204,7 +202,7 @@ TEST_CASE(ChainedModules) {
     });
 }
 
-TEST_CASE(DiamondModules) {
+TEST_CASE(diamond_modules) {
     env.tmp.touch("mod_base.cppm",
                   "export module Base;\n" "export int base_val() { return 10; }\n");
     env.tmp.touch("mod_left.cppm",
@@ -241,11 +239,9 @@ TEST_CASE(DiamondModules) {
     });
 }
 
-// ============================================================================
 // Dotted module names
-// ============================================================================
 
-TEST_CASE(DottedModuleName) {
+TEST_CASE(dotted_module_name) {
     env.tmp.touch("io.cppm", "export module my.io;\n" "export void print() {}\n");
     env.tmp.touch("app.cppm",
                   "export module my.app;\n"
@@ -270,11 +266,9 @@ TEST_CASE(DottedModuleName) {
     });
 }
 
-// ============================================================================
 // Re-export (export import)
-// ============================================================================
 
-TEST_CASE(ReExport) {
+TEST_CASE(re_export) {
     env.tmp.touch("core.cppm", "export module Core;\n" "export int core_fn() { return 1; }\n");
     env.tmp.touch("wrapper.cppm",
                   "export module Wrapper;\n"
@@ -305,11 +299,9 @@ TEST_CASE(ReExport) {
     });
 }
 
-// ============================================================================
 // Export block syntax
-// ============================================================================
 
-TEST_CASE(ExportBlock) {
+TEST_CASE(export_block) {
     env.tmp.touch("block.cppm",
                   "export module Block;\n"
                   "export {\n"
@@ -342,11 +334,9 @@ TEST_CASE(ExportBlock) {
     });
 }
 
-// ============================================================================
 // Global module fragment
-// ============================================================================
 
-TEST_CASE(GlobalModuleFragment) {
+TEST_CASE(global_module_fragment) {
     env.tmp.touch("legacy.h", "inline int legacy_fn() { return 99; }\n");
     env.tmp.touch("gmf.cppm",
                   "module;\n"
@@ -371,11 +361,9 @@ TEST_CASE(GlobalModuleFragment) {
     });
 }
 
-// ============================================================================
 // Private module fragment
-// ============================================================================
 
-TEST_CASE(PrivateModuleFragment) {
+TEST_CASE(private_module_fragment) {
     env.tmp.touch("priv.cppm",
                   "export module Priv;\n"
                   "export int public_fn();\n"
@@ -400,11 +388,9 @@ TEST_CASE(PrivateModuleFragment) {
     });
 }
 
-// ============================================================================
 // Module partitions — interface partition
-// ============================================================================
 
-TEST_CASE(PartitionInterface) {
+TEST_CASE(partition_interface) {
     // Partition interface unit.
     env.tmp.touch("part.cppm", "export module M:Part;\n" "export int part_fn() { return 5; }\n");
     // Primary module interface re-exports the partition.
@@ -434,11 +420,9 @@ TEST_CASE(PartitionInterface) {
     });
 }
 
-// ============================================================================
 // Multiple partitions
-// ============================================================================
 
-TEST_CASE(MultiplePartitions) {
+TEST_CASE(multiple_partitions) {
     env.tmp.touch("part_a.cppm", "export module Lib:A;\n" "export int a_fn() { return 1; }\n");
     env.tmp.touch("part_b.cppm", "export module Lib:B;\n" "export int b_fn() { return 2; }\n");
     env.tmp.touch("lib.cppm",
@@ -467,11 +451,9 @@ TEST_CASE(MultiplePartitions) {
     });
 }
 
-// ============================================================================
 // Partition importing another partition (within same module)
-// ============================================================================
 
-TEST_CASE(PartitionChain) {
+TEST_CASE(partition_chain) {
     env.tmp.touch("types.cppm",
                   "export module Sys:Types;\n" "export struct Config { int value = 0; };\n");
     env.tmp.touch("core.cppm",
@@ -503,11 +485,9 @@ TEST_CASE(PartitionChain) {
     });
 }
 
-// ============================================================================
 // Module with exported namespace
-// ============================================================================
 
-TEST_CASE(ExportNamespace) {
+TEST_CASE(export_namespace) {
     env.tmp.touch("ns.cppm",
                   "export module NS;\n"
                   "export namespace math {\n"
@@ -537,11 +517,9 @@ TEST_CASE(ExportNamespace) {
     });
 }
 
-// ============================================================================
 // GMF with include + module import
-// ============================================================================
 
-TEST_CASE(GMFWithImport) {
+TEST_CASE(gmf_with_import) {
     env.tmp.touch("util.h", "inline int util_helper() { return 7; }\n");
     env.tmp.touch("base.cppm", "export module Base;\n" "export int base() { return 100; }\n");
     env.tmp.touch("combined.cppm",
@@ -569,11 +547,9 @@ TEST_CASE(GMFWithImport) {
     });
 }
 
-// ============================================================================
 // Deep chain (5 modules)
-// ============================================================================
 
-TEST_CASE(DeepChain) {
+TEST_CASE(deep_chain) {
     env.tmp.touch("m1.cppm", "export module M1;\n" "export int f1() { return 1; }\n");
     env.tmp.touch("m2.cppm",
                   "export module M2;\n"
@@ -613,11 +589,9 @@ TEST_CASE(DeepChain) {
     });
 }
 
-// ============================================================================
 // Multiple independent modules (no shared deps)
-// ============================================================================
 
-TEST_CASE(IndependentModules) {
+TEST_CASE(independent_modules) {
     env.tmp.touch("x.cppm", "export module X;\n" "export int x() { return 1; }\n");
     env.tmp.touch("y.cppm", "export module Y;\n" "export int y() { return 2; }\n");
 
@@ -642,11 +616,9 @@ TEST_CASE(IndependentModules) {
     });
 }
 
-// ============================================================================
 // Module with template exports
-// ============================================================================
 
-TEST_CASE(TemplateExport) {
+TEST_CASE(template_export) {
     env.tmp.touch("tmpl.cppm",
                   "export module Tmpl;\n"
                   "export template<typename T>\n"
@@ -676,11 +648,9 @@ TEST_CASE(TemplateExport) {
     });
 }
 
-// ============================================================================
 // Module with class export and inheritance across modules
-// ============================================================================
 
-TEST_CASE(ClassExportAndInheritance) {
+TEST_CASE(class_export_inheritance) {
     env.tmp.touch("shape.cppm",
                   "export module Shape;\n"
                   "export class Shape {\n"
@@ -716,11 +686,9 @@ TEST_CASE(ClassExportAndInheritance) {
     });
 }
 
-// ============================================================================
 // Recompile after update (invalidation + recompile)
-// ============================================================================
 
-TEST_CASE(RecompileAfterUpdate) {
+TEST_CASE(recompile_after_update) {
     env.tmp.touch("leaf.cppm", "export module Leaf;\n" "export int leaf() { return 1; }\n");
     env.tmp.touch("mid.cppm",
                   "export module Mid;\n"
@@ -760,11 +728,9 @@ TEST_CASE(RecompileAfterUpdate) {
     });
 }
 
-// ============================================================================
 // Partition with GMF (#include inside global module fragment of partition)
-// ============================================================================
 
-TEST_CASE(PartitionWithGMF) {
+TEST_CASE(partition_with_gmf) {
     env.tmp.touch("config.h", "#define MAX_SIZE 100\n");
     env.tmp.touch("part_cfg.cppm",
                   "module;\n"
@@ -791,11 +757,9 @@ TEST_CASE(PartitionWithGMF) {
     });
 }
 
-// ============================================================================
 // Cross-module partition + external import
-// ============================================================================
 
-TEST_CASE(PartitionWithExternalImport) {
+TEST_CASE(partition_external_import) {
     // External module.
     env.tmp.touch("ext.cppm", "export module Ext;\n" "export int ext_val() { return 99; }\n");
     // Partition that imports the external module.
@@ -826,11 +790,9 @@ TEST_CASE(PartitionWithExternalImport) {
     });
 }
 
-// ============================================================================
 // Diamond update cascade + recompile
-// ============================================================================
 
-TEST_CASE(DiamondUpdateCascade) {
+TEST_CASE(diamond_update_cascade) {
     env.tmp.touch("mod_base.cppm",
                   "export module Base;\n" "export int base_val() { return 10; }\n");
     env.tmp.touch("mod_left.cppm",
@@ -894,11 +856,9 @@ TEST_CASE(DiamondUpdateCascade) {
     });
 }
 
-// ============================================================================
 // Verify resolve_fn is re-invoked after update (resolved=false)
-// ============================================================================
 
-TEST_CASE(ReResolveAfterUpdate) {
+TEST_CASE(re_resolve_after_update) {
     // Start with Mid importing Leaf.
     env.tmp.touch("leaf.cppm", "export module Leaf;\n" "export int leaf() { return 1; }\n");
     env.tmp.touch("extra.cppm", "export module Extra;\n" "export int extra() { return 99; }\n");
@@ -946,11 +906,9 @@ TEST_CASE(ReResolveAfterUpdate) {
     });
 }
 
-// ============================================================================
 // Compilation failure propagation (real clang error)
-// ============================================================================
 
-TEST_CASE(CompileFailurePropagation) {
+TEST_CASE(compile_failure_propagation) {
     // Good module.
     env.tmp.touch("good.cppm", "export module Good;\n" "export int good() { return 1; }\n");
     // Bad module with syntax error.
@@ -982,11 +940,9 @@ TEST_CASE(CompileFailurePropagation) {
     });
 }
 
-// ============================================================================
 // Module implementation unit (consumes PCM, doesn't produce one)
-// ============================================================================
 
-TEST_CASE(ModuleImplementationUnit) {
+TEST_CASE(module_implementation_unit) {
     // Module interface unit — produces PCM.
     env.tmp.touch("iface.cppm", "export module Greeter;\n" "export const char* greet();\n");
     // Module implementation unit — consumes PCM, no export.
@@ -1034,11 +990,9 @@ TEST_CASE(ModuleImplementationUnit) {
     });
 }
 
-// ============================================================================
 // Shared dependency: switching import target must not kill or restart it
-// ============================================================================
 
-TEST_CASE(SharedDepImportSwitch) {
+TEST_CASE(shared_dep_import_switch) {
     env.tmp.touch("shared.cppm",
                   "export module Shared;\n" "export int shared_val() { return 1; }\n");
     env.tmp.touch("a.cppm",
@@ -1134,11 +1088,9 @@ TEST_CASE(SharedDepImportSwitch) {
     });
 }
 
-// ============================================================================
 // Shared dependency failure propagates to every consumer of the same round
-// ============================================================================
 
-TEST_CASE(SharedDepFailsBoth) {
+TEST_CASE(shared_dep_fails_both) {
     env.tmp.touch(
         "shared.cppm",
         "export module Shared;\n" "export int shared_val() { return UNDEFINED_SYMBOL; }\n");

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -86,19 +86,6 @@ CompileGraph::resolve_fn make_resolver(CompilationDatabase& cdb,
     };
 }
 
-/// Run the test body, then verify the shutdown protocol leaves the graph idle.
-template <typename F>
-void run_and_shutdown(kota::event_loop& loop, CompileGraph& cg, F& test) {
-    auto wrapper = [&]() -> kota::task<> {
-        co_await test();
-        co_await cg.shutdown();
-        EXPECT_TRUE(cg.idle());
-    };
-    auto t = wrapper();
-    loop.schedule(t);
-    loop.run();
-}
-
 /// Helper to set up infra, compile a module, and verify all PCMs are produced.
 struct ModuleTestEnv {
     TempDir tmp;
@@ -121,12 +108,45 @@ struct ModuleTestEnv {
 
 TEST_SUITE(CompileGraphIntegration) {
 
+ModuleTestEnv env;
+std::optional<kota::event_loop> loop;
+std::optional<CompileGraph> cg;
+
+CompileGraph::dispatch_fn default_dispatch() {
+    return make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+}
+
+CompileGraph::resolve_fn default_resolver() {
+    return make_resolver(env.cdb, env.toolchain, env.pool, env.graph);
+}
+
+void make_graph(CompileGraph::dispatch_fn dispatch, CompileGraph::resolve_fn resolve) {
+    loop.emplace();
+    cg.emplace(*loop, std::move(dispatch), std::move(resolve));
+}
+
+void make_graph() {
+    make_graph(default_dispatch(), default_resolver());
+}
+
+/// Run the test body, then verify the shutdown protocol leaves the graph idle.
+template <typename F>
+void execute(F&& fn) {
+    auto wrapper = [&]() -> kota::task<> {
+        co_await fn();
+        co_await cg->shutdown();
+        EXPECT_TRUE(cg->idle());
+    };
+    auto t = wrapper();
+    loop->schedule(t);
+    loop->run();
+}
+
 // ============================================================================
 // Basic module interface units
 // ============================================================================
 
 TEST_CASE(SingleModuleNoDeps) {
-    ModuleTestEnv env;
     env.tmp.touch("mod_a.cppm", "export module A;\n" "export int foo() { return 42; }\n");
 
     auto json = build_cdb_json({
@@ -137,21 +157,16 @@ TEST_CASE(SingleModuleNoDeps) {
     ASSERT_FALSE(env.graph.lookup_module("A").empty());
     auto pid_a = env.lookup("A");
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_a]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_a).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_a).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid_a));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 TEST_CASE(ChainedModules) {
-    ModuleTestEnv env;
     env.tmp.touch("mod_a.cppm", "export module A;\n" "export int foo() { return 42; }\n");
     env.tmp.touch("mod_b.cppm",
                   "export module B;\n"
@@ -169,22 +184,17 @@ TEST_CASE(ChainedModules) {
     ASSERT_NE(pid_a, UINT32_MAX);
     ASSERT_NE(pid_b, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_a, pid_b]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_b).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_b).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid_a));
         EXPECT_TRUE(env.pcm_paths.contains(pid_b));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 TEST_CASE(DiamondModules) {
-    ModuleTestEnv env;
     env.tmp.touch("mod_base.cppm",
                   "export module Base;\n" "export int base_val() { return 10; }\n");
     env.tmp.touch("mod_left.cppm",
@@ -212,17 +222,13 @@ TEST_CASE(DiamondModules) {
     auto pid_top = env.lookup("Top");
     ASSERT_NE(pid_top, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_top]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_top).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_top).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 4u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -230,7 +236,6 @@ TEST_CASE(DiamondModules) {
 // ============================================================================
 
 TEST_CASE(DottedModuleName) {
-    ModuleTestEnv env;
     env.tmp.touch("io.cppm", "export module my.io;\n" "export void print() {}\n");
     env.tmp.touch("app.cppm",
                   "export module my.app;\n"
@@ -246,17 +251,13 @@ TEST_CASE(DottedModuleName) {
     auto pid_app = env.lookup("my.app");
     ASSERT_NE(pid_app, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_app]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_app).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_app).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -264,7 +265,6 @@ TEST_CASE(DottedModuleName) {
 // ============================================================================
 
 TEST_CASE(ReExport) {
-    ModuleTestEnv env;
     env.tmp.touch("core.cppm", "export module Core;\n" "export int core_fn() { return 1; }\n");
     env.tmp.touch("wrapper.cppm",
                   "export module Wrapper;\n"
@@ -286,17 +286,13 @@ TEST_CASE(ReExport) {
     auto pid_user = env.lookup("User");
     ASSERT_NE(pid_user, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_user]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_user).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_user).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 3u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -304,7 +300,6 @@ TEST_CASE(ReExport) {
 // ============================================================================
 
 TEST_CASE(ExportBlock) {
-    ModuleTestEnv env;
     env.tmp.touch("block.cppm",
                   "export module Block;\n"
                   "export {\n"
@@ -328,17 +323,13 @@ TEST_CASE(ExportBlock) {
     auto pid = env.lookup("Consumer");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -346,7 +337,6 @@ TEST_CASE(ExportBlock) {
 // ============================================================================
 
 TEST_CASE(GlobalModuleFragment) {
-    ModuleTestEnv env;
     env.tmp.touch("legacy.h", "inline int legacy_fn() { return 99; }\n");
     env.tmp.touch("gmf.cppm",
                   "module;\n"
@@ -362,17 +352,13 @@ TEST_CASE(GlobalModuleFragment) {
     auto pid = env.lookup("GMF");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -380,7 +366,6 @@ TEST_CASE(GlobalModuleFragment) {
 // ============================================================================
 
 TEST_CASE(PrivateModuleFragment) {
-    ModuleTestEnv env;
     env.tmp.touch("priv.cppm",
                   "export module Priv;\n"
                   "export int public_fn();\n"
@@ -396,17 +381,13 @@ TEST_CASE(PrivateModuleFragment) {
     auto pid = env.lookup("Priv");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -414,7 +395,6 @@ TEST_CASE(PrivateModuleFragment) {
 // ============================================================================
 
 TEST_CASE(PartitionInterface) {
-    ModuleTestEnv env;
     // Partition interface unit.
     env.tmp.touch("part.cppm", "export module M:Part;\n" "export int part_fn() { return 5; }\n");
     // Primary module interface re-exports the partition.
@@ -434,18 +414,14 @@ TEST_CASE(PartitionInterface) {
     ASSERT_NE(pid_m, UINT32_MAX);
     ASSERT_NE(env.lookup("M:Part"), UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_m]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_m).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_m).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         // Both partition and primary should be compiled.
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -453,7 +429,6 @@ TEST_CASE(PartitionInterface) {
 // ============================================================================
 
 TEST_CASE(MultiplePartitions) {
-    ModuleTestEnv env;
     env.tmp.touch("part_a.cppm", "export module Lib:A;\n" "export int a_fn() { return 1; }\n");
     env.tmp.touch("part_b.cppm", "export module Lib:B;\n" "export int b_fn() { return 2; }\n");
     env.tmp.touch("lib.cppm",
@@ -472,18 +447,14 @@ TEST_CASE(MultiplePartitions) {
     auto pid_lib = env.lookup("Lib");
     ASSERT_NE(pid_lib, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_lib]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_lib).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_lib).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         // Lib:A, Lib:B, and Lib.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -491,7 +462,6 @@ TEST_CASE(MultiplePartitions) {
 // ============================================================================
 
 TEST_CASE(PartitionChain) {
-    ModuleTestEnv env;
     env.tmp.touch("types.cppm",
                   "export module Sys:Types;\n" "export struct Config { int value = 0; };\n");
     env.tmp.touch("core.cppm",
@@ -513,18 +483,14 @@ TEST_CASE(PartitionChain) {
     auto pid_sys = env.lookup("Sys");
     ASSERT_NE(pid_sys, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_sys]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_sys).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_sys).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         // Sys:Types, Sys:Core, Sys.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -532,7 +498,6 @@ TEST_CASE(PartitionChain) {
 // ============================================================================
 
 TEST_CASE(ExportNamespace) {
-    ModuleTestEnv env;
     env.tmp.touch("ns.cppm",
                   "export module NS;\n"
                   "export namespace math {\n"
@@ -553,17 +518,13 @@ TEST_CASE(ExportNamespace) {
     auto pid = env.lookup("Calc");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -571,7 +532,6 @@ TEST_CASE(ExportNamespace) {
 // ============================================================================
 
 TEST_CASE(GMFWithImport) {
-    ModuleTestEnv env;
     env.tmp.touch("util.h", "inline int util_helper() { return 7; }\n");
     env.tmp.touch("base.cppm", "export module Base;\n" "export int base() { return 100; }\n");
     env.tmp.touch("combined.cppm",
@@ -590,17 +550,13 @@ TEST_CASE(GMFWithImport) {
     auto pid = env.lookup("Combined");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -608,7 +564,6 @@ TEST_CASE(GMFWithImport) {
 // ============================================================================
 
 TEST_CASE(DeepChain) {
-    ModuleTestEnv env;
     env.tmp.touch("m1.cppm", "export module M1;\n" "export int f1() { return 1; }\n");
     env.tmp.touch("m2.cppm",
                   "export module M2;\n"
@@ -639,17 +594,13 @@ TEST_CASE(DeepChain) {
     auto pid = env.lookup("M5");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 5u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -657,7 +608,6 @@ TEST_CASE(DeepChain) {
 // ============================================================================
 
 TEST_CASE(IndependentModules) {
-    ModuleTestEnv env;
     env.tmp.touch("x.cppm", "export module X;\n" "export int x() { return 1; }\n");
     env.tmp.touch("y.cppm", "export module Y;\n" "export int y() { return 2; }\n");
 
@@ -672,18 +622,14 @@ TEST_CASE(IndependentModules) {
     ASSERT_NE(pid_x, UINT32_MAX);
     ASSERT_NE(pid_y, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_x, pid_y]() -> kota::task<> {
-        auto r1 = co_await cg.compile(pid_x).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await cg->compile(pid_x).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
-        auto r2 = co_await cg.compile(pid_y).catch_cancel();
+        auto r2 = co_await cg->compile(pid_y).catch_cancel();
         EXPECT_TRUE(r2.has_value() && *r2);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -691,7 +637,6 @@ TEST_CASE(IndependentModules) {
 // ============================================================================
 
 TEST_CASE(TemplateExport) {
-    ModuleTestEnv env;
     env.tmp.touch("tmpl.cppm",
                   "export module Tmpl;\n"
                   "export template<typename T>\n"
@@ -712,17 +657,13 @@ TEST_CASE(TemplateExport) {
     auto pid = env.lookup("UseTmpl");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -730,7 +671,6 @@ TEST_CASE(TemplateExport) {
 // ============================================================================
 
 TEST_CASE(ClassExportAndInheritance) {
-    ModuleTestEnv env;
     env.tmp.touch("shape.cppm",
                   "export module Shape;\n"
                   "export class Shape {\n"
@@ -757,17 +697,13 @@ TEST_CASE(ClassExportAndInheritance) {
     auto pid = env.lookup("Circle");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -775,7 +711,6 @@ TEST_CASE(ClassExportAndInheritance) {
 // ============================================================================
 
 TEST_CASE(RecompileAfterUpdate) {
-    ModuleTestEnv env;
     env.tmp.touch("leaf.cppm", "export module Leaf;\n" "export int leaf() { return 1; }\n");
     env.tmp.touch("mid.cppm",
                   "export module Mid;\n"
@@ -793,30 +728,26 @@ TEST_CASE(RecompileAfterUpdate) {
     ASSERT_NE(pid_leaf, UINT32_MAX);
     ASSERT_NE(pid_mid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_leaf, pid_mid]() -> kota::task<> {
+    make_graph();
+    execute([&]() -> kota::task<> {
         // First compile.
-        auto r1 = co_await cg.compile(pid_mid).catch_cancel();
+        auto r1 = co_await cg->compile(pid_mid).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-        EXPECT_FALSE(cg.is_dirty(pid_leaf));
-        EXPECT_FALSE(cg.is_dirty(pid_mid));
+        EXPECT_FALSE(cg->is_dirty(pid_leaf));
+        EXPECT_FALSE(cg->is_dirty(pid_mid));
 
         // Simulate editing Leaf — should cascade to Mid.
-        cg.update(pid_leaf);
-        EXPECT_TRUE(cg.is_dirty(pid_leaf));
-        EXPECT_TRUE(cg.is_dirty(pid_mid));
+        cg->update(pid_leaf);
+        EXPECT_TRUE(cg->is_dirty(pid_leaf));
+        EXPECT_TRUE(cg->is_dirty(pid_mid));
 
         // Recompile.
-        auto r2 = co_await cg.compile(pid_mid).catch_cancel();
+        auto r2 = co_await cg->compile(pid_mid).catch_cancel();
         EXPECT_TRUE(r2.has_value() && *r2);
-        EXPECT_FALSE(cg.is_dirty(pid_leaf));
-        EXPECT_FALSE(cg.is_dirty(pid_mid));
-    };
-    run_and_shutdown(loop, cg, test);
+        EXPECT_FALSE(cg->is_dirty(pid_leaf));
+        EXPECT_FALSE(cg->is_dirty(pid_mid));
+    });
 }
 
 // ============================================================================
@@ -824,7 +755,6 @@ TEST_CASE(RecompileAfterUpdate) {
 // ============================================================================
 
 TEST_CASE(PartitionWithGMF) {
-    ModuleTestEnv env;
     env.tmp.touch("config.h", "#define MAX_SIZE 100\n");
     env.tmp.touch("part_cfg.cppm",
                   "module;\n"
@@ -842,17 +772,13 @@ TEST_CASE(PartitionWithGMF) {
     auto pid = env.lookup("Cfg");
     ASSERT_NE(pid, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid]() -> kota::task<> {
-        auto result = co_await cg.compile(pid).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -860,7 +786,6 @@ TEST_CASE(PartitionWithGMF) {
 // ============================================================================
 
 TEST_CASE(PartitionWithExternalImport) {
-    ModuleTestEnv env;
     // External module.
     env.tmp.touch("ext.cppm", "export module Ext;\n" "export int ext_val() { return 99; }\n");
     // Partition that imports the external module.
@@ -881,18 +806,14 @@ TEST_CASE(PartitionWithExternalImport) {
     auto pid_app = env.lookup("App");
     ASSERT_NE(pid_app, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_app]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_app).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_app).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         // Ext, App:Core, App.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -900,7 +821,6 @@ TEST_CASE(PartitionWithExternalImport) {
 // ============================================================================
 
 TEST_CASE(DiamondUpdateCascade) {
-    ModuleTestEnv env;
     env.tmp.touch("mod_base.cppm",
                   "export module Base;\n" "export int base_val() { return 10; }\n");
     env.tmp.touch("mod_left.cppm",
@@ -932,13 +852,10 @@ TEST_CASE(DiamondUpdateCascade) {
     ASSERT_NE(pid_base, UINT32_MAX);
     ASSERT_NE(pid_top, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_base, pid_left, pid_right, pid_top]() -> kota::task<> {
+    make_graph();
+    execute([&]() -> kota::task<> {
         // Initial compile.
-        auto r1 = co_await cg.compile(pid_top).catch_cancel();
+        auto r1 = co_await cg->compile(pid_top).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
         EXPECT_EQ(env.pcm_paths.size(), 4u);
 
@@ -946,11 +863,11 @@ TEST_CASE(DiamondUpdateCascade) {
         auto old_base_pcm = env.pcm_paths[pid_base];
 
         // Update base: should cascade to Left, Right, Top.
-        auto dirtied = cg.update(pid_base);
-        EXPECT_TRUE(cg.is_dirty(pid_base));
-        EXPECT_TRUE(cg.is_dirty(pid_left));
-        EXPECT_TRUE(cg.is_dirty(pid_right));
-        EXPECT_TRUE(cg.is_dirty(pid_top));
+        auto dirtied = cg->update(pid_base);
+        EXPECT_TRUE(cg->is_dirty(pid_base));
+        EXPECT_TRUE(cg->is_dirty(pid_left));
+        EXPECT_TRUE(cg->is_dirty(pid_right));
+        EXPECT_TRUE(cg->is_dirty(pid_top));
 
         // Simulate MasterServer: erase stale PCMs for all dirtied nodes.
         for(auto id: dirtied) {
@@ -959,13 +876,12 @@ TEST_CASE(DiamondUpdateCascade) {
         EXPECT_EQ(env.pcm_paths.size(), 0u);
 
         // Recompile.
-        auto r2 = co_await cg.compile(pid_top).catch_cancel();
+        auto r2 = co_await cg->compile(pid_top).catch_cancel();
         EXPECT_TRUE(r2.has_value() && *r2);
         EXPECT_EQ(env.pcm_paths.size(), 4u);
         // PCM path should have changed (new temp file).
         EXPECT_NE(env.pcm_paths[pid_base], old_base_pcm);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -973,7 +889,6 @@ TEST_CASE(DiamondUpdateCascade) {
 // ============================================================================
 
 TEST_CASE(ReResolveAfterUpdate) {
-    ModuleTestEnv env;
     // Start with Mid importing Leaf.
     env.tmp.touch("leaf.cppm", "export module Leaf;\n" "export int leaf() { return 1; }\n");
     env.tmp.touch("extra.cppm", "export module Extra;\n" "export int extra() { return 99; }\n");
@@ -996,47 +911,29 @@ TEST_CASE(ReResolveAfterUpdate) {
     ASSERT_NE(pid_extra, UINT32_MAX);
 
     int resolve_count = 0;
-    auto counting_resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+    auto counting_resolver =
+        [&, inner = default_resolver()](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
         if(path_id == pid_mid) {
             resolve_count++;
         }
-        // Delegate to the standard resolver.
-        auto file_path = env.pool.resolve(path_id);
-        auto results = env.cdb.lookup(file_path);
-        if(results.empty()) {
-            return {};
-        }
-        env.toolchain.resolve_or_warn(results[0]);
-        auto scan_result = scan_precise(results[0].to_argv(), results[0].resolved.directory);
-        llvm::SmallVector<std::uint32_t> deps;
-        for(auto& mod_name: scan_result.modules) {
-            auto mod_ids = env.graph.lookup_module(mod_name);
-            if(!mod_ids.empty()) {
-                deps.push_back(mod_ids[0]);
-            }
-        }
-        return deps;
+        return inner(path_id);
     };
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    std::move(counting_resolver));
-    auto test = [this, &cg, &env, &resolve_count, pid_mid]() -> kota::task<> {
+    make_graph(default_dispatch(), std::move(counting_resolver));
+    execute([&]() -> kota::task<> {
         // First compile: resolve_fn called once for Mid.
-        auto r1 = co_await cg.compile(pid_mid).catch_cancel();
+        auto r1 = co_await cg->compile(pid_mid).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
         EXPECT_EQ(resolve_count, 1);
 
         // Update Mid: resets resolved.
-        cg.update(pid_mid);
+        cg->update(pid_mid);
 
         // Recompile: resolve_fn should be called again.
-        auto r2 = co_await cg.compile(pid_mid).catch_cancel();
+        auto r2 = co_await cg->compile(pid_mid).catch_cancel();
         EXPECT_TRUE(r2.has_value() && *r2);
         EXPECT_EQ(resolve_count, 2);
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -1044,7 +941,6 @@ TEST_CASE(ReResolveAfterUpdate) {
 // ============================================================================
 
 TEST_CASE(CompileFailurePropagation) {
-    ModuleTestEnv env;
     // Good module.
     env.tmp.touch("good.cppm", "export module Good;\n" "export int good() { return 1; }\n");
     // Bad module with syntax error.
@@ -1062,12 +958,9 @@ TEST_CASE(CompileFailurePropagation) {
     auto pid_bad = env.lookup("Bad");
     ASSERT_NE(pid_bad, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_bad]() -> kota::task<> {
-        auto result = co_await cg.compile(pid_bad).catch_cancel();
+    make_graph();
+    execute([&]() -> kota::task<> {
+        auto result = co_await cg->compile(pid_bad).catch_cancel();
         EXPECT_TRUE(result.has_value());
         // Compilation should fail due to undefined symbol.
         EXPECT_FALSE(*result);
@@ -1076,8 +969,7 @@ TEST_CASE(CompileFailurePropagation) {
         EXPECT_TRUE(env.pcm_paths.contains(pid_good));
         // Bad module should NOT have a PCM.
         EXPECT_FALSE(env.pcm_paths.contains(pid_bad));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -1085,7 +977,6 @@ TEST_CASE(CompileFailurePropagation) {
 // ============================================================================
 
 TEST_CASE(ModuleImplementationUnit) {
-    ModuleTestEnv env;
     // Module interface unit — produces PCM.
     env.tmp.touch("iface.cppm", "export module Greeter;\n" "export const char* greet();\n");
     // Module implementation unit — consumes PCM, no export.
@@ -1101,13 +992,10 @@ TEST_CASE(ModuleImplementationUnit) {
     auto pid_iface = env.lookup("Greeter");
     ASSERT_NE(pid_iface, UINT32_MAX);
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-    auto test = [this, &cg, &env, pid_iface]() -> kota::task<> {
+    make_graph();
+    execute([&]() -> kota::task<> {
         // Build the interface PCM via CompileGraph.
-        auto r1 = co_await cg.compile(pid_iface).catch_cancel();
+        auto r1 = co_await cg->compile(pid_iface).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
         EXPECT_TRUE(env.pcm_paths.contains(pid_iface));
 
@@ -1133,8 +1021,7 @@ TEST_CASE(ModuleImplementationUnit) {
 
         auto unit = compile(cp);
         EXPECT_TRUE(unit.completed());
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -1142,7 +1029,6 @@ TEST_CASE(ModuleImplementationUnit) {
 // ============================================================================
 
 TEST_CASE(SharedDepImportSwitch) {
-    ModuleTestEnv env;
     env.tmp.touch("shared.cppm",
                   "export module Shared;\n" "export int shared_val() { return 1; }\n");
     env.tmp.touch("a.cppm",
@@ -1173,7 +1059,7 @@ TEST_CASE(SharedDepImportSwitch) {
     kota::event shared_started;
     kota::event shared_proceed;
     int shared_calls = 0;
-    auto inner = make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+    auto inner = default_dispatch();
     auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
         if(pid == pid_shared) {
             shared_calls += 1;
@@ -1183,17 +1069,14 @@ TEST_CASE(SharedDepImportSwitch) {
         co_return co_await inner(pid);
     };
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    std::move(dispatch),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
+    make_graph(std::move(dispatch), default_resolver());
 
     kota::cancellation_source req_a;
     kota::event start_c;
     std::optional<bool> result_a, result_c;
 
     auto request_a = [&]() -> kota::task<> {
-        auto r = co_await kota::with_token(cg.compile(pid_a), req_a.token());
+        auto r = co_await kota::with_token(cg->compile(pid_a), req_a.token());
         if(r.has_value()) {
             result_a = *r;
         }
@@ -1201,16 +1084,16 @@ TEST_CASE(SharedDepImportSwitch) {
 
     auto request_c = [&]() -> kota::task<> {
         co_await start_c.wait();
-        auto r = co_await cg.compile(pid_c).catch_cancel();
+        auto r = co_await cg->compile(pid_c).catch_cancel();
         if(r.has_value()) {
             result_c = *r;
         }
     };
 
-    auto test = [&]() -> kota::task<> {
+    execute([&]() -> kota::task<> {
         auto driver = [&]() -> kota::task<> {
             co_await shared_started.wait();
-            EXPECT_EQ(cg.refcount(pid_shared), 1u);
+            EXPECT_EQ(cg->refcount(pid_shared), 1u);
             EXPECT_EQ(shared_calls, 1);
 
             // Simulate switching `import A` to `import C`: start the new
@@ -1221,8 +1104,8 @@ TEST_CASE(SharedDepImportSwitch) {
             req_a.cancel();
             co_await kota::sleep(1);
 
-            EXPECT_TRUE(cg.is_compiling(pid_shared));
-            EXPECT_EQ(cg.refcount(pid_shared), 1u);
+            EXPECT_TRUE(cg->is_compiling(pid_shared));
+            EXPECT_EQ(cg->refcount(pid_shared), 1u);
             EXPECT_EQ(shared_calls, 1);
 
             shared_proceed.set();
@@ -1238,8 +1121,7 @@ TEST_CASE(SharedDepImportSwitch) {
         EXPECT_TRUE(env.pcm_paths.contains(pid_shared));
         EXPECT_TRUE(env.pcm_paths.contains(pid_c));
         EXPECT_FALSE(env.pcm_paths.contains(pid_a));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 // ============================================================================
@@ -1247,7 +1129,6 @@ TEST_CASE(SharedDepImportSwitch) {
 // ============================================================================
 
 TEST_CASE(SharedDepFailsBoth) {
-    ModuleTestEnv env;
     env.tmp.touch(
         "shared.cppm",
         "export module Shared;\n" "export int shared_val() { return UNDEFINED_SYMBOL; }\n");
@@ -1276,7 +1157,7 @@ TEST_CASE(SharedDepFailsBoth) {
     kota::event shared_started;
     kota::event shared_proceed;
     int shared_calls = 0;
-    auto inner = make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+    auto inner = default_dispatch();
     auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
         if(pid == pid_shared) {
             shared_calls += 1;
@@ -1286,31 +1167,28 @@ TEST_CASE(SharedDepFailsBoth) {
         co_return co_await inner(pid);
     };
 
-    kota::event_loop loop;
-    CompileGraph cg(loop,
-                    std::move(dispatch),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
+    make_graph(std::move(dispatch), default_resolver());
 
     std::optional<bool> result_a, result_c;
     auto request_a = [&]() -> kota::task<> {
-        auto r = co_await cg.compile(pid_a).catch_cancel();
+        auto r = co_await cg->compile(pid_a).catch_cancel();
         if(r.has_value()) {
             result_a = *r;
         }
     };
     auto request_c = [&]() -> kota::task<> {
-        auto r = co_await cg.compile(pid_c).catch_cancel();
+        auto r = co_await cg->compile(pid_c).catch_cancel();
         if(r.has_value()) {
             result_c = *r;
         }
     };
 
-    auto test = [&]() -> kota::task<> {
+    execute([&]() -> kota::task<> {
         auto driver = [&]() -> kota::task<> {
             co_await shared_started.wait();
             co_await kota::sleep(1);
             // Both chains hold interest in the same round.
-            EXPECT_EQ(cg.refcount(pid_shared), 2u);
+            EXPECT_EQ(cg->refcount(pid_shared), 2u);
             shared_proceed.set();
             co_return;
         };
@@ -1324,8 +1202,7 @@ TEST_CASE(SharedDepFailsBoth) {
         EXPECT_FALSE(env.pcm_paths.contains(pid_shared));
         EXPECT_FALSE(env.pcm_paths.contains(pid_a));
         EXPECT_FALSE(env.pcm_paths.contains(pid_c));
-    };
-    run_and_shutdown(loop, cg, test);
+    });
 }
 
 };  // TEST_SUITE(CompileGraphIntegration)

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -152,7 +152,9 @@ void execute(F&& fn) {
     loop->run();
 }
 
-// Basic module interface units
+/// ============================================================================
+///                         Basic module interface units
+/// ============================================================================
 
 TEST_CASE(single_module) {
     env.tmp.touch("mod_a.cppm", "export module A;\n" "export int foo() { return 42; }\n");
@@ -239,7 +241,9 @@ TEST_CASE(diamond_modules) {
     });
 }
 
-// Dotted module names
+/// ============================================================================
+///                             Dotted module names
+/// ============================================================================
 
 TEST_CASE(dotted_module_name) {
     env.tmp.touch("io.cppm", "export module my.io;\n" "export void print() {}\n");
@@ -266,7 +270,9 @@ TEST_CASE(dotted_module_name) {
     });
 }
 
-// Re-export (export import)
+/// ============================================================================
+///                          Re-export (export import)
+/// ============================================================================
 
 TEST_CASE(re_export) {
     env.tmp.touch("core.cppm", "export module Core;\n" "export int core_fn() { return 1; }\n");
@@ -299,7 +305,9 @@ TEST_CASE(re_export) {
     });
 }
 
-// Export block syntax
+/// ============================================================================
+///                             Export block syntax
+/// ============================================================================
 
 TEST_CASE(export_block) {
     env.tmp.touch("block.cppm",
@@ -334,7 +342,9 @@ TEST_CASE(export_block) {
     });
 }
 
-// Global module fragment
+/// ============================================================================
+///                            Global module fragment
+/// ============================================================================
 
 TEST_CASE(global_module_fragment) {
     env.tmp.touch("legacy.h", "inline int legacy_fn() { return 99; }\n");
@@ -361,7 +371,9 @@ TEST_CASE(global_module_fragment) {
     });
 }
 
-// Private module fragment
+/// ============================================================================
+///                           Private module fragment
+/// ============================================================================
 
 TEST_CASE(private_module_fragment) {
     env.tmp.touch("priv.cppm",
@@ -388,7 +400,9 @@ TEST_CASE(private_module_fragment) {
     });
 }
 
-// Module partitions — interface partition
+/// ============================================================================
+///                   Module partitions — interface partition
+/// ============================================================================
 
 TEST_CASE(partition_interface) {
     // Partition interface unit.
@@ -420,7 +434,9 @@ TEST_CASE(partition_interface) {
     });
 }
 
-// Multiple partitions
+/// ============================================================================
+///                             Multiple partitions
+/// ============================================================================
 
 TEST_CASE(multiple_partitions) {
     env.tmp.touch("part_a.cppm", "export module Lib:A;\n" "export int a_fn() { return 1; }\n");
@@ -451,7 +467,9 @@ TEST_CASE(multiple_partitions) {
     });
 }
 
-// Partition importing another partition (within same module)
+/// ============================================================================
+///          Partition importing another partition (within same module)
+/// ============================================================================
 
 TEST_CASE(partition_chain) {
     env.tmp.touch("types.cppm",
@@ -485,7 +503,9 @@ TEST_CASE(partition_chain) {
     });
 }
 
-// Module with exported namespace
+/// ============================================================================
+///                        Module with exported namespace
+/// ============================================================================
 
 TEST_CASE(export_namespace) {
     env.tmp.touch("ns.cppm",
@@ -517,7 +537,9 @@ TEST_CASE(export_namespace) {
     });
 }
 
-// GMF with include + module import
+/// ============================================================================
+///                       GMF with include + module import
+/// ============================================================================
 
 TEST_CASE(gmf_with_import) {
     env.tmp.touch("util.h", "inline int util_helper() { return 7; }\n");
@@ -547,7 +569,9 @@ TEST_CASE(gmf_with_import) {
     });
 }
 
-// Deep chain (5 modules)
+/// ============================================================================
+///                            Deep chain (5 modules)
+/// ============================================================================
 
 TEST_CASE(deep_chain) {
     env.tmp.touch("m1.cppm", "export module M1;\n" "export int f1() { return 1; }\n");
@@ -589,7 +613,9 @@ TEST_CASE(deep_chain) {
     });
 }
 
-// Multiple independent modules (no shared deps)
+/// ============================================================================
+///                Multiple independent modules (no shared deps)
+/// ============================================================================
 
 TEST_CASE(independent_modules) {
     env.tmp.touch("x.cppm", "export module X;\n" "export int x() { return 1; }\n");
@@ -616,7 +642,9 @@ TEST_CASE(independent_modules) {
     });
 }
 
-// Module with template exports
+/// ============================================================================
+///                         Module with template exports
+/// ============================================================================
 
 TEST_CASE(template_export) {
     env.tmp.touch("tmpl.cppm",
@@ -648,7 +676,9 @@ TEST_CASE(template_export) {
     });
 }
 
-// Module with class export and inheritance across modules
+/// ============================================================================
+///           Module with class export and inheritance across modules
+/// ============================================================================
 
 TEST_CASE(class_export_inheritance) {
     env.tmp.touch("shape.cppm",
@@ -686,7 +716,9 @@ TEST_CASE(class_export_inheritance) {
     });
 }
 
-// Recompile after update (invalidation + recompile)
+/// ============================================================================
+///              Recompile after update (invalidation + recompile)
+/// ============================================================================
 
 TEST_CASE(recompile_after_update) {
     env.tmp.touch("leaf.cppm", "export module Leaf;\n" "export int leaf() { return 1; }\n");
@@ -728,7 +760,9 @@ TEST_CASE(recompile_after_update) {
     });
 }
 
-// Partition with GMF (#include inside global module fragment of partition)
+/// ============================================================================
+///   Partition with GMF (#include inside global module fragment of partition)
+/// ============================================================================
 
 TEST_CASE(partition_with_gmf) {
     env.tmp.touch("config.h", "#define MAX_SIZE 100\n");
@@ -757,7 +791,9 @@ TEST_CASE(partition_with_gmf) {
     });
 }
 
-// Cross-module partition + external import
+/// ============================================================================
+///                   Cross-module partition + external import
+/// ============================================================================
 
 TEST_CASE(partition_external_import) {
     // External module.
@@ -790,7 +826,9 @@ TEST_CASE(partition_external_import) {
     });
 }
 
-// Diamond update cascade + recompile
+/// ============================================================================
+///                      Diamond update cascade + recompile
+/// ============================================================================
 
 TEST_CASE(diamond_update_cascade) {
     env.tmp.touch("mod_base.cppm",
@@ -856,7 +894,9 @@ TEST_CASE(diamond_update_cascade) {
     });
 }
 
-// Verify resolve_fn is re-invoked after update (resolved=false)
+/// ============================================================================
+///        Verify resolve_fn is re-invoked after update (resolved=false)
+/// ============================================================================
 
 TEST_CASE(re_resolve_after_update) {
     // Start with Mid importing Leaf.
@@ -906,7 +946,9 @@ TEST_CASE(re_resolve_after_update) {
     });
 }
 
-// Compilation failure propagation (real clang error)
+/// ============================================================================
+///              Compilation failure propagation (real clang error)
+/// ============================================================================
 
 TEST_CASE(compile_failure_propagation) {
     // Good module.
@@ -940,7 +982,9 @@ TEST_CASE(compile_failure_propagation) {
     });
 }
 
-// Module implementation unit (consumes PCM, doesn't produce one)
+/// ============================================================================
+///        Module implementation unit (consumes PCM, doesn't produce one)
+/// ============================================================================
 
 TEST_CASE(module_implementation_unit) {
     // Module interface unit — produces PCM.
@@ -990,7 +1034,9 @@ TEST_CASE(module_implementation_unit) {
     });
 }
 
-// Shared dependency: switching import target must not kill or restart it
+/// ============================================================================
+///    Shared dependency: switching import target must not kill or restart it
+/// ============================================================================
 
 TEST_CASE(shared_dep_import_switch) {
     env.tmp.touch("shared.cppm",
@@ -1088,7 +1134,9 @@ TEST_CASE(shared_dep_import_switch) {
     });
 }
 
-// Shared dependency failure propagates to every consumer of the same round
+/// ============================================================================
+///   Shared dependency failure propagates to every consumer of the same round
+/// ============================================================================
 
 TEST_CASE(shared_dep_fails_both) {
     env.tmp.touch(

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -86,6 +86,19 @@ CompileGraph::resolve_fn make_resolver(CompilationDatabase& cdb,
     };
 }
 
+/// Run the test body, then verify the shutdown protocol leaves the graph idle.
+template <typename F>
+void run_and_shutdown(kota::event_loop& loop, CompileGraph& cg, F& test) {
+    auto wrapper = [&]() -> kota::task<> {
+        co_await test();
+        co_await cg.shutdown();
+        EXPECT_TRUE(cg.idle());
+    };
+    auto t = wrapper();
+    loop.schedule(t);
+    loop.run();
+}
+
 /// Helper to set up infra, compile a module, and verify all PCMs are produced.
 struct ModuleTestEnv {
     TempDir tmp;
@@ -124,19 +137,17 @@ TEST_CASE(SingleModuleNoDeps) {
     ASSERT_FALSE(env.graph.lookup_module("A").empty());
     auto pid_a = env.lookup("A");
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_a]() -> kota::task<> {
         auto result = co_await cg.compile(pid_a).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid_a));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 TEST_CASE(ChainedModules) {
@@ -158,10 +169,10 @@ TEST_CASE(ChainedModules) {
     ASSERT_NE(pid_a, UINT32_MAX);
     ASSERT_NE(pid_b, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_a, pid_b]() -> kota::task<> {
         auto result = co_await cg.compile(pid_b).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -169,9 +180,7 @@ TEST_CASE(ChainedModules) {
         EXPECT_TRUE(env.pcm_paths.contains(pid_a));
         EXPECT_TRUE(env.pcm_paths.contains(pid_b));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 TEST_CASE(DiamondModules) {
@@ -203,19 +212,17 @@ TEST_CASE(DiamondModules) {
     auto pid_top = env.lookup("Top");
     ASSERT_NE(pid_top, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_top]() -> kota::task<> {
         auto result = co_await cg.compile(pid_top).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 4u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -239,19 +246,17 @@ TEST_CASE(DottedModuleName) {
     auto pid_app = env.lookup("my.app");
     ASSERT_NE(pid_app, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_app]() -> kota::task<> {
         auto result = co_await cg.compile(pid_app).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -281,19 +286,17 @@ TEST_CASE(ReExport) {
     auto pid_user = env.lookup("User");
     ASSERT_NE(pid_user, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_user]() -> kota::task<> {
         auto result = co_await cg.compile(pid_user).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 3u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -325,19 +328,17 @@ TEST_CASE(ExportBlock) {
     auto pid = env.lookup("Consumer");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -361,19 +362,17 @@ TEST_CASE(GlobalModuleFragment) {
     auto pid = env.lookup("GMF");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -397,19 +396,17 @@ TEST_CASE(PrivateModuleFragment) {
     auto pid = env.lookup("Priv");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_TRUE(env.pcm_paths.contains(pid));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -437,10 +434,10 @@ TEST_CASE(PartitionInterface) {
     ASSERT_NE(pid_m, UINT32_MAX);
     ASSERT_NE(env.lookup("M:Part"), UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_m]() -> kota::task<> {
         auto result = co_await cg.compile(pid_m).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -448,9 +445,7 @@ TEST_CASE(PartitionInterface) {
         // Both partition and primary should be compiled.
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -477,10 +472,10 @@ TEST_CASE(MultiplePartitions) {
     auto pid_lib = env.lookup("Lib");
     ASSERT_NE(pid_lib, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_lib]() -> kota::task<> {
         auto result = co_await cg.compile(pid_lib).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -488,9 +483,7 @@ TEST_CASE(MultiplePartitions) {
         // Lib:A, Lib:B, and Lib.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -520,10 +513,10 @@ TEST_CASE(PartitionChain) {
     auto pid_sys = env.lookup("Sys");
     ASSERT_NE(pid_sys, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_sys]() -> kota::task<> {
         auto result = co_await cg.compile(pid_sys).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -531,9 +524,7 @@ TEST_CASE(PartitionChain) {
         // Sys:Types, Sys:Core, Sys.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -562,19 +553,17 @@ TEST_CASE(ExportNamespace) {
     auto pid = env.lookup("Calc");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -601,19 +590,17 @@ TEST_CASE(GMFWithImport) {
     auto pid = env.lookup("Combined");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -652,19 +639,17 @@ TEST_CASE(DeepChain) {
     auto pid = env.lookup("M5");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 5u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -687,10 +672,10 @@ TEST_CASE(IndependentModules) {
     ASSERT_NE(pid_x, UINT32_MAX);
     ASSERT_NE(pid_y, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_x, pid_y]() -> kota::task<> {
         auto r1 = co_await cg.compile(pid_x).catch_cancel();
         EXPECT_TRUE(r1.has_value() && *r1);
@@ -698,9 +683,7 @@ TEST_CASE(IndependentModules) {
         EXPECT_TRUE(r2.has_value() && *r2);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -729,19 +712,17 @@ TEST_CASE(TemplateExport) {
     auto pid = env.lookup("UseTmpl");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -776,19 +757,17 @@ TEST_CASE(ClassExportAndInheritance) {
     auto pid = env.lookup("Circle");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -814,10 +793,10 @@ TEST_CASE(RecompileAfterUpdate) {
     ASSERT_NE(pid_leaf, UINT32_MAX);
     ASSERT_NE(pid_mid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_leaf, pid_mid]() -> kota::task<> {
         // First compile.
         auto r1 = co_await cg.compile(pid_mid).catch_cancel();
@@ -837,9 +816,7 @@ TEST_CASE(RecompileAfterUpdate) {
         EXPECT_FALSE(cg.is_dirty(pid_leaf));
         EXPECT_FALSE(cg.is_dirty(pid_mid));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -865,19 +842,17 @@ TEST_CASE(PartitionWithGMF) {
     auto pid = env.lookup("Cfg");
     ASSERT_NE(pid, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid]() -> kota::task<> {
         auto result = co_await cg.compile(pid).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(env.pcm_paths.size(), 2u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -906,10 +881,10 @@ TEST_CASE(PartitionWithExternalImport) {
     auto pid_app = env.lookup("App");
     ASSERT_NE(pid_app, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_app]() -> kota::task<> {
         auto result = co_await cg.compile(pid_app).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -917,9 +892,7 @@ TEST_CASE(PartitionWithExternalImport) {
         // Ext, App:Core, App.
         EXPECT_EQ(env.pcm_paths.size(), 3u);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -959,10 +932,10 @@ TEST_CASE(DiamondUpdateCascade) {
     ASSERT_NE(pid_base, UINT32_MAX);
     ASSERT_NE(pid_top, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_base, pid_left, pid_right, pid_top]() -> kota::task<> {
         // Initial compile.
         auto r1 = co_await cg.compile(pid_top).catch_cancel();
@@ -992,9 +965,7 @@ TEST_CASE(DiamondUpdateCascade) {
         // PCM path should have changed (new temp file).
         EXPECT_NE(env.pcm_paths[pid_base], old_base_pcm);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -1047,10 +1018,10 @@ TEST_CASE(ReResolveAfterUpdate) {
         return deps;
     };
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    std::move(counting_resolver));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    std::move(counting_resolver));
     auto test = [this, &cg, &env, &resolve_count, pid_mid]() -> kota::task<> {
         // First compile: resolve_fn called once for Mid.
         auto r1 = co_await cg.compile(pid_mid).catch_cancel();
@@ -1065,9 +1036,7 @@ TEST_CASE(ReResolveAfterUpdate) {
         EXPECT_TRUE(r2.has_value() && *r2);
         EXPECT_EQ(resolve_count, 2);
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -1093,10 +1062,10 @@ TEST_CASE(CompileFailurePropagation) {
     auto pid_bad = env.lookup("Bad");
     ASSERT_NE(pid_bad, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_bad]() -> kota::task<> {
         auto result = co_await cg.compile(pid_bad).catch_cancel();
         EXPECT_TRUE(result.has_value());
@@ -1108,9 +1077,7 @@ TEST_CASE(CompileFailurePropagation) {
         // Bad module should NOT have a PCM.
         EXPECT_FALSE(env.pcm_paths.contains(pid_bad));
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
 }
 
 // ============================================================================
@@ -1134,10 +1101,10 @@ TEST_CASE(ModuleImplementationUnit) {
     auto pid_iface = env.lookup("Greeter");
     ASSERT_NE(pid_iface, UINT32_MAX);
 
-    CompileGraph cg(make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
-                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
-
     kota::event_loop loop;
+    CompileGraph cg(loop,
+                    make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
     auto test = [this, &cg, &env, pid_iface]() -> kota::task<> {
         // Build the interface PCM via CompileGraph.
         auto r1 = co_await cg.compile(pid_iface).catch_cancel();
@@ -1167,9 +1134,198 @@ TEST_CASE(ModuleImplementationUnit) {
         auto unit = compile(cp);
         EXPECT_TRUE(unit.completed());
     };
-    auto t = test();
-    loop.schedule(t);
-    loop.run();
+    run_and_shutdown(loop, cg, test);
+}
+
+// ============================================================================
+// Shared dependency: switching import target must not kill or restart it
+// ============================================================================
+
+TEST_CASE(SharedDepImportSwitch) {
+    ModuleTestEnv env;
+    env.tmp.touch("shared.cppm",
+                  "export module Shared;\n" "export int shared_val() { return 1; }\n");
+    env.tmp.touch("a.cppm",
+                  "export module A;\n"
+                  "import Shared;\n"
+                  "export int a_val() { return shared_val(); }\n");
+    env.tmp.touch("c.cppm",
+                  "export module C;\n"
+                  "import Shared;\n"
+                  "export int c_val() { return shared_val(); }\n");
+
+    auto json = build_cdb_json({
+        {env.tmp.root, env.tmp.path("shared.cppm"), {}},
+        {env.tmp.root, env.tmp.path("a.cppm"),      {}},
+        {env.tmp.root, env.tmp.path("c.cppm"),      {}},
+    });
+    env.setup({}, json);
+
+    auto pid_shared = env.lookup("Shared");
+    auto pid_a = env.lookup("A");
+    auto pid_c = env.lookup("C");
+    ASSERT_NE(pid_shared, UINT32_MAX);
+    ASSERT_NE(pid_a, UINT32_MAX);
+    ASSERT_NE(pid_c, UINT32_MAX);
+
+    // Gate the shared module's dispatch so the import switch can be injected
+    // while it is still compiling.
+    kota::event shared_started;
+    kota::event shared_proceed;
+    int shared_calls = 0;
+    auto inner = make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+    auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
+        if(pid == pid_shared) {
+            shared_calls += 1;
+            shared_started.set();
+            co_await shared_proceed.wait();
+        }
+        co_return co_await inner(pid);
+    };
+
+    kota::event_loop loop;
+    CompileGraph cg(loop,
+                    std::move(dispatch),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
+
+    kota::cancellation_source req_a;
+    kota::event start_c;
+    std::optional<bool> result_a, result_c;
+
+    auto request_a = [&]() -> kota::task<> {
+        auto r = co_await kota::with_token(cg.compile(pid_a), req_a.token());
+        if(r.has_value()) {
+            result_a = *r;
+        }
+    };
+
+    auto request_c = [&]() -> kota::task<> {
+        co_await start_c.wait();
+        auto r = co_await cg.compile(pid_c).catch_cancel();
+        if(r.has_value()) {
+            result_c = *r;
+        }
+    };
+
+    auto test = [&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await shared_started.wait();
+            EXPECT_EQ(cg.refcount(pid_shared), 1u);
+            EXPECT_EQ(shared_calls, 1);
+
+            // Simulate switching `import A` to `import C`: start the new
+            // request first, then cancel the old one — the same order the
+            // supersede path in Compiler::ensure_compiled uses, so the
+            // shared module's interest never drops to zero.
+            start_c.set();
+            req_a.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(cg.is_compiling(pid_shared));
+            EXPECT_EQ(cg.refcount(pid_shared), 1u);
+            EXPECT_EQ(shared_calls, 1);
+
+            shared_proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(request_a(), request_c(), driver());
+
+        // A was cancelled; C completed using the surviving shared build.
+        EXPECT_FALSE(result_a.has_value());
+        EXPECT_TRUE(result_c == true);
+        EXPECT_EQ(shared_calls, 1);
+        EXPECT_TRUE(env.pcm_paths.contains(pid_shared));
+        EXPECT_TRUE(env.pcm_paths.contains(pid_c));
+        EXPECT_FALSE(env.pcm_paths.contains(pid_a));
+    };
+    run_and_shutdown(loop, cg, test);
+}
+
+// ============================================================================
+// Shared dependency failure propagates to every consumer of the same round
+// ============================================================================
+
+TEST_CASE(SharedDepFailureFailsBoth) {
+    ModuleTestEnv env;
+    env.tmp.touch(
+        "shared.cppm",
+        "export module Shared;\n" "export int shared_val() { return UNDEFINED_SYMBOL; }\n");
+    env.tmp.touch("a.cppm",
+                  "export module A;\n"
+                  "import Shared;\n"
+                  "export int a_val() { return shared_val(); }\n");
+    env.tmp.touch("c.cppm",
+                  "export module C;\n"
+                  "import Shared;\n"
+                  "export int c_val() { return shared_val(); }\n");
+
+    auto json = build_cdb_json({
+        {env.tmp.root, env.tmp.path("shared.cppm"), {}},
+        {env.tmp.root, env.tmp.path("a.cppm"),      {}},
+        {env.tmp.root, env.tmp.path("c.cppm"),      {}},
+    });
+    env.setup({}, json);
+
+    auto pid_shared = env.lookup("Shared");
+    auto pid_a = env.lookup("A");
+    auto pid_c = env.lookup("C");
+    ASSERT_NE(pid_shared, UINT32_MAX);
+
+    // Gate the shared module so both consumers join the same failing round.
+    kota::event shared_started;
+    kota::event shared_proceed;
+    int shared_calls = 0;
+    auto inner = make_dispatch(env.cdb, env.toolchain, env.pool, env.graph, env.pcm_paths);
+    auto dispatch = [&](std::uint32_t pid) -> kota::task<bool> {
+        if(pid == pid_shared) {
+            shared_calls += 1;
+            shared_started.set();
+            co_await shared_proceed.wait();
+        }
+        co_return co_await inner(pid);
+    };
+
+    kota::event_loop loop;
+    CompileGraph cg(loop,
+                    std::move(dispatch),
+                    make_resolver(env.cdb, env.toolchain, env.pool, env.graph));
+
+    std::optional<bool> result_a, result_c;
+    auto request_a = [&]() -> kota::task<> {
+        auto r = co_await cg.compile(pid_a).catch_cancel();
+        if(r.has_value()) {
+            result_a = *r;
+        }
+    };
+    auto request_c = [&]() -> kota::task<> {
+        auto r = co_await cg.compile(pid_c).catch_cancel();
+        if(r.has_value()) {
+            result_c = *r;
+        }
+    };
+
+    auto test = [&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await shared_started.wait();
+            co_await kota::sleep(1);
+            // Both chains hold interest in the same round.
+            EXPECT_EQ(cg.refcount(pid_shared), 2u);
+            shared_proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(request_a(), request_c(), driver());
+
+        // One failing round, both consumers fail without retry.
+        EXPECT_TRUE(result_a == false);
+        EXPECT_TRUE(result_c == false);
+        EXPECT_EQ(shared_calls, 1);
+        EXPECT_FALSE(env.pcm_paths.contains(pid_shared));
+        EXPECT_FALSE(env.pcm_paths.contains(pid_a));
+        EXPECT_FALSE(env.pcm_paths.contains(pid_c));
+    };
+    run_and_shutdown(loop, cg, test);
 }
 
 };  // TEST_SUITE(CompileGraphIntegration)

--- a/tests/unit/server/compile_graph_integration_tests.cpp
+++ b/tests/unit/server/compile_graph_integration_tests.cpp
@@ -129,6 +129,16 @@ void make_graph() {
     make_graph(default_dispatch(), default_resolver());
 }
 
+/// Zero-interest cancellation is deferred by one event-loop tick per cascade
+/// level; wait (bounded) until `pred` holds before asserting settled state.
+template <typename Pred>
+kota::task<> settle(Pred pred) {
+    for(int i = 0; i < 100 && !pred(); i++) {
+        co_await kota::sleep(1);
+    }
+    EXPECT_TRUE(pred());
+}
+
 /// Run the test body, then verify the shutdown protocol leaves the graph idle.
 template <typename F>
 void execute(F&& fn) {
@@ -1102,7 +1112,7 @@ TEST_CASE(SharedDepImportSwitch) {
             // shared module's interest never drops to zero.
             start_c.set();
             req_a.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !cg->is_compiling(pid_a); });
 
             EXPECT_TRUE(cg->is_compiling(pid_shared));
             EXPECT_EQ(cg->refcount(pid_shared), 1u);

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -115,7 +115,8 @@ void make_graph(CompileGraph::dispatch_fn dispatch, CompileGraph::resolve_fn res
 }
 
 /// Run the test body, then verify the shutdown protocol: cancel + join must
-/// exit cleanly and leave the graph fully quiesced.
+/// exit cleanly and leave the graph fully quiesced (no compiling residue, no
+/// held interest, every completion fired).
 template <typename F>
 void execute(F&& fn) {
     auto wrapper = [&]() -> kota::task<> {
@@ -136,6 +137,14 @@ kota::task<> run_request(std::uint32_t path_id, Request& req) {
     }
 }
 
+kota::task<> run_deps_request(std::uint32_t path_id, Request& req) {
+    auto result = co_await kota::with_token(graph->compile_deps(path_id), req.source.token());
+    req.done = true;
+    if(result.has_value()) {
+        req.result = *result;
+    }
+}
+
 /// Zero-interest cancellation is deferred by one event-loop tick per cascade
 /// level; wait (bounded) until `pred` holds before asserting settled state.
 template <typename Pred>
@@ -146,15 +155,11 @@ kota::task<> settle(Pred pred) {
     EXPECT_TRUE(pred());
 }
 
-kota::task<> run_deps_request(std::uint32_t path_id, Request& req) {
-    auto result = co_await kota::with_token(graph->compile_deps(path_id), req.source.token());
-    req.done = true;
-    if(result.has_value()) {
-        req.result = *result;
-    }
-}
+// Basic compilation: a request compiles the unit and its transitive
+// dependencies, dependencies first, each dirty unit exactly once.
 
-TEST_CASE(CompileNoDeps) {
+TEST_CASE(compile_no_deps) {
+    // A unit without dependencies is dispatched once and becomes clean.
     make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
@@ -167,8 +172,8 @@ TEST_CASE(CompileNoDeps) {
     });
 }
 
-TEST_CASE(CompileWithDependency) {
-    // Unit 1 depends on unit 2.
+TEST_CASE(compile_single_dep) {
+    // 1 -> 2: the dependency is dispatched before the dependent.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2}}
@@ -178,7 +183,6 @@ TEST_CASE(CompileWithDependency) {
         auto result = co_await graph->compile(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Both 2 (dep) and 1 (self) should be compiled, in that order.
         EXPECT_EQ(compiled.size(), 2u);
         auto pos2 = ranges::find(compiled, 2u);
         auto pos1 = ranges::find(compiled, 1u);
@@ -188,8 +192,8 @@ TEST_CASE(CompileWithDependency) {
     });
 }
 
-TEST_CASE(CompileChain) {
-    // Chain: 1 -> 2 -> 3.
+TEST_CASE(compile_chain) {
+    // 1 -> 2 -> 3: dispatch order follows the dependency chain bottom-up.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2}},
@@ -201,7 +205,6 @@ TEST_CASE(CompileChain) {
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
         EXPECT_EQ(compiled.size(), 3u);
-        // 3 before 2 before 1.
         auto pos3 = ranges::find(compiled, 3u);
         auto pos2 = ranges::find(compiled, 2u);
         auto pos1 = ranges::find(compiled, 1u);
@@ -210,8 +213,9 @@ TEST_CASE(CompileChain) {
     });
 }
 
-TEST_CASE(DiamondDependency) {
-    // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
+TEST_CASE(compile_diamond_dedup) {
+    // Diamond 1 -> {2, 3}, 2 -> 4, 3 -> 4: the shared dependency 4 is
+    // reached through two branches but dispatched exactly once.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2, 3}},
@@ -223,7 +227,6 @@ TEST_CASE(DiamondDependency) {
         auto result = co_await graph->compile(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Unit 4 should be compiled exactly once (dedup).
         auto count4 = ranges::count(compiled, 4u);
         EXPECT_EQ(count4, 1);
         EXPECT_FALSE(graph->is_dirty(2));
@@ -232,276 +235,21 @@ TEST_CASE(DiamondDependency) {
     });
 }
 
-TEST_CASE(UpdateInvalidates) {
-    // 1 -> 2.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_FALSE(graph->is_dirty(2));
-        EXPECT_FALSE(graph->is_dirty(1));
-
-        graph->update(2);
-        EXPECT_TRUE(graph->is_dirty(2));
-        // Cascade: 1 depends on 2, so 1 should also be dirty.
-        EXPECT_TRUE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(UpdateCascade) {
-    // Chain: 1 -> 2 -> 3.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {3}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_FALSE(graph->is_dirty(2));
-        EXPECT_FALSE(graph->is_dirty(3));
-
-        // Update leaf (3) — should cascade to 2 and 1.
-        graph->update(3);
-        EXPECT_TRUE(graph->is_dirty(3));
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_TRUE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(CompileAfterUpdate) {
-    // 1 -> 2.
-    make_graph(tracking_dispatch(compiled),
-               static_resolver({
-                   {1, {2}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_EQ(compiled.size(), 2u);
-
-        graph->update(2);
-        co_await graph->compile(1).catch_cancel();
-        // 2 and 1 should be recompiled.
-        EXPECT_EQ(compiled.size(), 4u);
-    });
-}
-
-TEST_CASE(DispatchFailure) {
-    // 1 -> 2. Dispatch always fails.
-    make_graph(failing_dispatch(),
-               static_resolver({
-                   {1, {2}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-        // Dep 2 failed, so it stays dirty.
-        EXPECT_TRUE(graph->is_dirty(2));
-    });
-}
-
-TEST_CASE(CancelAll) {
-    make_graph(instant_dispatch(), no_deps());
-    // Just verify it doesn't crash.
-    graph->cancel_all();
-}
-
-TEST_CASE(SecondCompileSkips) {
+TEST_CASE(second_compile_skips) {
+    // A clean unit is not redispatched by a later request.
     make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
         co_await graph->compile(1).catch_cancel();
         EXPECT_EQ(compiled.size(), 1u);
-        // Second compile should skip (already clean).
         co_await graph->compile(1).catch_cancel();
         EXPECT_EQ(compiled.size(), 1u);
     });
 }
 
-TEST_CASE(CascadeThroughAlreadyDirty) {
-    // Chain: 1 -> 2 -> 3.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {3}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-
-        // Update node 2: marks 2 and 1 dirty.
-        graph->update(2);
-        EXPECT_TRUE(graph->is_dirty(1));
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_FALSE(graph->is_dirty(3));
-
-        // Now update node 3: must cascade through already-dirty 2 to reach 1.
-        graph->update(3);
-        EXPECT_TRUE(graph->is_dirty(3));
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_TRUE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(CircularDependencyDetection) {
-    // Cycle: 1 -> 2 -> 1.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {1}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        // Should return false (cycle detected), not deadlock.
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-    });
-}
-
-TEST_CASE(CrossBranchCycleDetection) {
-    // Cross-branch cycle: 1 -> {2, 3}, 2 -> 3, 3 -> 2.
-    // Sibling unit tasks could deadlock on each other's completion
-    // without proper wait-cycle detection.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2, 3}},
-                   {2, {3}   },
-                   {3, {2}   }
-    }));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        // Should return false (cycle detected), not deadlock.
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-    });
-}
-
-TEST_CASE(UpdateResetsResolved) {
-    int resolve_count = 0;
-    // 1 depends on {2} initially; after update, depends on {3}.
-    bool updated = false;
-    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
-        if(path_id == 1) {
-            resolve_count++;
-            return updated ? llvm::SmallVector<std::uint32_t>{3}
-                           : llvm::SmallVector<std::uint32_t>{2};
-        }
-        return {};
-    };
-
-    make_graph(tracking_dispatch(compiled), std::move(resolver));
-
-    execute([&]() -> kota::task<> {
-        // First compile: resolves 1 -> {2}.
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_EQ(resolve_count, 1);
-        EXPECT_EQ(compiled.size(), 2u);  // 2, then 1
-
-        // Update node 1: resets resolved, changes deps.
-        updated = true;
-        graph->update(1);
-
-        // Recompile: should re-resolve 1 -> {3}.
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_EQ(resolve_count, 2);
-        // New dep 3 should be compiled, then 1 recompiled.
-        auto tail = compiled | std::views::drop(2);
-        EXPECT_TRUE(ranges::find(tail, 3u) != tail.end());
-    });
-}
-
-TEST_CASE(UpdateCleansBackEdges) {
-    bool updated = false;
-    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
-        if(path_id == 1) {
-            // Initially depends on 2; after update, no deps.
-            return updated ? llvm::SmallVector<std::uint32_t>{}
-                           : llvm::SmallVector<std::uint32_t>{2};
-        }
-        return {};
-    };
-
-    make_graph(tracking_dispatch(compiled), std::move(resolver));
-
-    execute([&]() -> kota::task<> {
-        // First compile: 1 -> {2}.
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_FALSE(graph->is_dirty(1));
-
-        // Update 1: resets resolved, removes dep on 2.
-        updated = true;
-        graph->update(1);
-
-        // Recompile: 1 has no deps now.
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_FALSE(graph->is_dirty(1));
-
-        // Now update 2: should NOT cascade to 1 (back-edge was removed).
-        graph->update(2);
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_FALSE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(DiamondUpdateCascade) {
-    // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
-    make_graph(tracking_dispatch(compiled),
-               static_resolver({
-                   {1, {2, 3}},
-                   {2, {4}   },
-                   {3, {4}   }
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_FALSE(graph->is_dirty(4));
-
-        // Update leaf 4: should cascade to 2, 3, and 1.
-        graph->update(4);
-        EXPECT_TRUE(graph->is_dirty(4));
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_TRUE(graph->is_dirty(3));
-        EXPECT_TRUE(graph->is_dirty(1));
-
-        compiled.clear();
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value() && *result);
-        // Unit 4 should still be compiled exactly once (dedup on recompile).
-        auto count4 = ranges::count(compiled, 4u);
-        EXPECT_EQ(count4, 1);
-    });
-}
-
-TEST_CASE(UpdateReturnsAllDirtied) {
-    // Chain: 1 -> 2 -> 3.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {3}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-
-        auto dirtied = graph->update(3);
-        // Should return 3, 2, 1 (all dirtied nodes).
-        EXPECT_EQ(dirtied.size(), 3u);
-        EXPECT_TRUE(llvm::find(dirtied, 1u) != dirtied.end());
-        EXPECT_TRUE(llvm::find(dirtied, 2u) != dirtied.end());
-        EXPECT_TRUE(llvm::find(dirtied, 3u) != dirtied.end());
-    });
-}
-
-TEST_CASE(HasUnitAndIsCompiling) {
+TEST_CASE(state_queries) {
+    // has_unit/is_compiling reflect the unit's lifecycle: absent before the
+    // first request, present and not compiling after completion.
     make_graph(instant_dispatch(), no_deps());
 
     execute([&]() -> kota::task<> {
@@ -514,154 +262,23 @@ TEST_CASE(HasUnitAndIsCompiling) {
     });
 }
 
-TEST_CASE(FailureLeavesDepsDirty) {
-    // 1 -> 2. Dispatch always fails.
-    make_graph(failing_dispatch(),
-               static_resolver({
-                   {1, {2}}
-    }));
+// compile_deps: compiles a unit's transitive dependencies but never the
+// unit itself — used for plain .cpp files that import modules.
 
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-        // Both dep and self should stay dirty.
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_TRUE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(SelfLoop) {
-    // Unit 1 depends on itself.
-    make_graph(instant_dispatch(),
-               static_resolver({
-                   {1, {1}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        // Should detect cycle and return false, not deadlock.
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-    });
-}
-
-TEST_CASE(CancelAllAndRecompile) {
-    make_graph(tracking_dispatch(compiled),
-               static_resolver({
-                   {1, {2}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        co_await graph->compile(1).catch_cancel();
-        EXPECT_EQ(compiled.size(), 2u);
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_FALSE(graph->is_dirty(2));
-
-        // cancel_all + update to mark dirty again.
-        graph->cancel_all();
-        graph->update(2);
-        EXPECT_TRUE(graph->is_dirty(2));
-        EXPECT_TRUE(graph->is_dirty(1));
-
-        // Recompile should succeed normally.
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_TRUE(*result);
-        EXPECT_EQ(compiled.size(), 4u);
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_FALSE(graph->is_dirty(2));
-    });
-}
-
-TEST_CASE(UpdateDuringCompile) {
-    ManualDispatch md;
-    make_graph(md.fn(), no_deps());
-
-    execute([&]() -> kota::task<> {
-        bool done = false;
-        std::optional<bool> result;
-
-        auto compiler = [&]() -> kota::task<> {
-            auto r = co_await graph->compile(1).catch_cancel();
-            done = true;
-            if(r.has_value()) {
-                result = *r;
-            }
-        };
-
-        // Update while dispatch is in flight: the round is cancelled, the
-        // waiter retries with the new content, and — with no further
-        // updates — exactly one retry happens.
-        auto driver = [&]() -> kota::task<> {
-            co_await md.gate(1).started.wait();
-            md.gate(1).started.reset();
-            graph->update(1);
-            co_await md.gate(1).started.wait();
-            EXPECT_EQ(md.gate(1).calls, 2);
-            md.gate(1).proceed.set();
-            co_return;
-        };
-
-        co_await kota::when_all(compiler(), driver());
-
-        EXPECT_TRUE(done);
-        EXPECT_TRUE(result == true);
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_EQ(md.gate(1).calls, 2);
-    });
-}
-
-TEST_CASE(WhenAllPartialFailure) {
-    // 1 -> {2, 3}. Only unit 3 fails.
-    make_graph(selective_dispatch({
-                   3
-    }),
-               static_resolver({{1, {2, 3}}}));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-        // Unit 2 succeeded — should be clean.
-        EXPECT_FALSE(graph->is_dirty(2));
-        // Unit 3 failed — stays dirty.
-        EXPECT_TRUE(graph->is_dirty(3));
-        // Unit 1 was not dispatched — stays dirty.
-        EXPECT_TRUE(graph->is_dirty(1));
-    });
-}
-
-TEST_CASE(UpdateUnknownPathId) {
-    make_graph(instant_dispatch(), no_deps());
-
-    // update on a path_id that was never compiled should not crash.
-    auto dirtied = graph->update(999);
-    EXPECT_EQ(dirtied.size(), 0u);
-    EXPECT_FALSE(graph->has_unit(999));
-}
-
-TEST_CASE(EmptyGraphNoCompile) {
-    // Construct and destroy without any compile calls.
-    make_graph(instant_dispatch(), no_deps());
-    EXPECT_FALSE(graph->has_unit(1));
-    graph->cancel_all();  // Should not crash on empty graph.
-}
-
-TEST_CASE(CompileDepsNoDeps) {
+TEST_CASE(compile_deps_empty) {
+    // No dependencies: nothing is dispatched, the request succeeds.
     make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
         auto result = co_await graph->compile_deps(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // No dependencies, so nothing should be dispatched.
         EXPECT_EQ(compiled.size(), 0u);
     });
 }
 
-TEST_CASE(CompileDepsWithDependency) {
-    // Unit 1 depends on unit 2.
+TEST_CASE(compile_deps_single) {
+    // 1 -> 2: only the dependency is dispatched, never unit 1 itself.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2}}
@@ -671,16 +288,14 @@ TEST_CASE(CompileDepsWithDependency) {
         auto result = co_await graph->compile_deps(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Only dep 2 should be compiled, NOT unit 1 itself.
         EXPECT_EQ(compiled.size(), 1u);
         EXPECT_EQ(compiled[0], 2u);
-        auto pos1 = ranges::find(compiled, 1u);
-        EXPECT_TRUE(pos1 == compiled.end());
+        EXPECT_TRUE(ranges::find(compiled, 1u) == compiled.end());
     });
 }
 
-TEST_CASE(CompileDepsChain) {
-    // Chain: 1 -> 2 -> 3.
+TEST_CASE(compile_deps_chain) {
+    // 1 -> 2 -> 3: transitive dependencies are compiled, the root is not.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2}},
@@ -691,7 +306,6 @@ TEST_CASE(CompileDepsChain) {
         auto result = co_await graph->compile_deps(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Deps 2 and 3 should be compiled, but NOT unit 1.
         EXPECT_EQ(compiled.size(), 2u);
         EXPECT_TRUE(ranges::find(compiled, 3u) != compiled.end());
         EXPECT_TRUE(ranges::find(compiled, 2u) != compiled.end());
@@ -699,8 +313,8 @@ TEST_CASE(CompileDepsChain) {
     });
 }
 
-TEST_CASE(CompileDepsDiamond) {
-    // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
+TEST_CASE(compile_deps_diamond) {
+    // Diamond below the root: every dependency once, the root never.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {2, 3}},
@@ -712,40 +326,18 @@ TEST_CASE(CompileDepsDiamond) {
         auto result = co_await graph->compile_deps(1).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Deps 2, 3, 4 should be compiled, but NOT unit 1.
         EXPECT_TRUE(ranges::find(compiled, 1u) == compiled.end());
         EXPECT_TRUE(ranges::find(compiled, 2u) != compiled.end());
         EXPECT_TRUE(ranges::find(compiled, 3u) != compiled.end());
         EXPECT_TRUE(ranges::find(compiled, 4u) != compiled.end());
-        // Unit 4 should be compiled exactly once (dedup).
         auto count4 = ranges::count(compiled, 4u);
         EXPECT_EQ(count4, 1);
     });
 }
 
-TEST_CASE(CompileDepsFailure) {
-    // 1 -> 2. Dispatch fails for unit 2.
-    auto fail_and_track = [&](std::uint32_t path_id) -> kota::task<bool> {
-        compiled.push_back(path_id);
-        co_return false;
-    };
-
-    make_graph(std::move(fail_and_track),
-               static_resolver({
-                   {1, {2}}
-    }));
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile_deps(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-        // Unit 1 should NOT be dispatched at all.
-        EXPECT_TRUE(ranges::find(compiled, 1u) == compiled.end());
-    });
-}
-
-TEST_CASE(CompileDepsPlainCpp) {
-    // Simulates a plain .cpp file (unit 10) that imports a module (unit 20).
+TEST_CASE(compile_deps_plain_cpp) {
+    // The .cpp file (10) importing a module (20) gets its module built
+    // without ever being treated as a module unit itself.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {10, {20}}
@@ -755,18 +347,14 @@ TEST_CASE(CompileDepsPlainCpp) {
         auto result = co_await graph->compile_deps(10).catch_cancel();
         EXPECT_TRUE(result.has_value());
         EXPECT_TRUE(*result);
-        // Only dep 20 should be compiled, NOT the .cpp file itself.
         EXPECT_EQ(compiled.size(), 1u);
         EXPECT_EQ(compiled[0], 20u);
-        EXPECT_TRUE(ranges::find(compiled, 10u) == compiled.end());
     });
 }
 
-TEST_CASE(CompileDepsConcurrentDedup) {
-    // Two concurrent compile_deps calls with overlapping dependencies.
-    // Each dep should be dispatched exactly once (no duplicate compilation).
-    // Unit 1 depends on {3, 4}, unit 2 depends on {3, 5}.
-    // Dep 3 is shared — must be compiled only once.
+TEST_CASE(compile_deps_concurrent_dedup) {
+    // Two concurrent requests with overlapping dependency sets ({3,4} and
+    // {3,5}): the shared dependency 3 is dispatched exactly once.
     make_graph(tracking_dispatch(compiled),
                static_resolver({
                    {1, {3, 4}},
@@ -774,7 +362,6 @@ TEST_CASE(CompileDepsConcurrentDedup) {
     }));
 
     execute([&]() -> kota::task<> {
-        // Launch both compile_deps concurrently.
         auto t1 = graph->compile_deps(1);
         auto t2 = graph->compile_deps(2);
         auto results = co_await kota::when_all(std::move(t1), std::move(t2));
@@ -783,8 +370,6 @@ TEST_CASE(CompileDepsConcurrentDedup) {
         EXPECT_TRUE(r1);
         EXPECT_TRUE(r2);
 
-        // Deps 3, 4, 5 should each be compiled exactly once.
-        // Unit 1 and 2 should NOT be compiled.
         ranges::sort(compiled);
         EXPECT_EQ(compiled.size(), 3u);
         EXPECT_EQ(compiled[0], 3u);
@@ -793,9 +378,9 @@ TEST_CASE(CompileDepsConcurrentDedup) {
     });
 }
 
-TEST_CASE(CompileDepsResolveOnce) {
-    // Verify that resolve_fn is called at most once per unit,
-    // even when multiple compile_deps requests touch the same dependency.
+TEST_CASE(compile_deps_resolve_once) {
+    // resolve_fn is expensive (full module scan): it runs at most once per
+    // unit even when concurrent requests touch the same dependency.
     int resolve_count = 0;
 
     auto resolve = [&resolve_count](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
@@ -816,254 +401,281 @@ TEST_CASE(CompileDepsResolveOnce) {
         EXPECT_TRUE(r1);
         EXPECT_TRUE(r2);
 
-        // Dep 3 compiled exactly once.
         EXPECT_EQ(compiled.size(), 1u);
         EXPECT_EQ(compiled[0], 3u);
-
-        // resolve_fn called for units 1, 2, 3 — each at most once (3 total).
         EXPECT_EQ(resolve_count, 3);
     });
 }
 
-// Shared dependency matrix: A(1) -> B(2) -> E(5), C(3) -> D(4) -> E(5).
+TEST_CASE(compile_deps_failure) {
+    // A failing dependency fails the request; the root unit is never
+    // dispatched on a failed preparation.
+    auto fail_and_track = [&](std::uint32_t path_id) -> kota::task<bool> {
+        compiled.push_back(path_id);
+        co_return false;
+    };
 
-TEST_CASE(SharedDepSurvivesCancel) {
-    ManualDispatch md;
-    make_graph(md.fn(),
+    make_graph(std::move(fail_and_track),
                static_resolver({
-                   {1, {2}},
-                   {2, {5}},
-                   {3, {4}},
-                   {4, {5}}
+                   {1, {2}}
     }));
-    md.open({1, 2, 3, 4});
 
-    Request ra, rc;
     execute([&]() -> kota::task<> {
-        auto driver = [&]() -> kota::task<> {
-            // E is dispatching, with interest from both chains.
-            co_await md.gate(5).started.wait();
-            EXPECT_EQ(graph->refcount(5), 2u);
-            EXPECT_EQ(md.gate(5).calls, 1);
+        auto result = co_await graph->compile_deps(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+        EXPECT_TRUE(ranges::find(compiled, 1u) == compiled.end());
+    });
+}
 
-            // Cancel request A: B's task exits and drops its edge on E,
-            // but D's task still holds interest — E must keep compiling.
-            ra.source.cancel();
-            co_await settle([&] { return !graph->is_compiling(2); });
+// update() marks a changed file and everything that (transitively) depends
+// on it dirty, following reverse edges. Marking alone never recompiles —
+// the next request does.
 
-            EXPECT_TRUE(ra.done);
-            EXPECT_TRUE(graph->is_compiling(5));
-            EXPECT_EQ(graph->refcount(5), 1u);
-            EXPECT_EQ(md.gate(5).calls, 1);
+TEST_CASE(update_invalidates) {
+    // Updating a dependency dirties it and its dependent.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}}
+    }));
 
-            md.gate(5).proceed.set();
-            co_return;
-        };
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(1));
 
-        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
-
-        EXPECT_FALSE(ra.result.has_value());
-        EXPECT_TRUE(rc.result == true);
-        EXPECT_FALSE(graph->is_dirty(5));
-        EXPECT_FALSE(graph->is_dirty(3));
+        graph->update(2);
+        EXPECT_TRUE(graph->is_dirty(2));
         EXPECT_TRUE(graph->is_dirty(1));
     });
 }
 
-TEST_CASE(SharedDepBothCancelled) {
-    // E is shared at different depths: depth 2 from A, depth 1 from C.
-    ManualDispatch md;
-    make_graph(md.fn(),
+TEST_CASE(update_cascade) {
+    // 1 -> 2 -> 3: updating the leaf dirties the whole dependent chain.
+    make_graph(instant_dispatch(),
                static_resolver({
                    {1, {2}},
-                   {2, {5}},
-                   {3, {5}}
+                   {2, {3}}
     }));
-    md.open({1, 2, 3});
 
-    Request ra, rc;
     execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(3));
+
+        graph->update(3);
+        EXPECT_TRUE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(cascade_through_dirty) {
+    // The cascade must not stop at an already-dirty intermediate node:
+    // after update(2) dirtied {2, 1}, update(3) still has to reach 1.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+
+        graph->update(2);
+        EXPECT_TRUE(graph->is_dirty(1));
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(3));
+
+        graph->update(3);
+        EXPECT_TRUE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(diamond_update_cascade) {
+    // Updating the bottom of a diamond dirties both branches and the top;
+    // the recompile still dedups the shared node.
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   }
+    }));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(4));
+
+        graph->update(4);
+        EXPECT_TRUE(graph->is_dirty(4));
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(1));
+
+        compiled.clear();
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value() && *result);
+        auto count4 = ranges::count(compiled, 4u);
+        EXPECT_EQ(count4, 1);
+    });
+}
+
+TEST_CASE(update_returns_dirtied) {
+    // The caller (PCM cache eviction) gets the full set of dirtied units.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+
+        auto dirtied = graph->update(3);
+        EXPECT_EQ(dirtied.size(), 3u);
+        EXPECT_TRUE(llvm::find(dirtied, 1u) != dirtied.end());
+        EXPECT_TRUE(llvm::find(dirtied, 2u) != dirtied.end());
+        EXPECT_TRUE(llvm::find(dirtied, 3u) != dirtied.end());
+    });
+}
+
+TEST_CASE(compile_after_update) {
+    // A request after an update recompiles exactly the dirtied units.
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_EQ(compiled.size(), 2u);
+
+        graph->update(2);
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_EQ(compiled.size(), 4u);
+    });
+}
+
+TEST_CASE(update_resets_resolved) {
+    // The updated file may have added/removed imports: its dependencies are
+    // re-resolved on the next compile and the new set takes effect.
+    int resolve_count = 0;
+    bool updated = false;
+    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+        if(path_id == 1) {
+            resolve_count++;
+            return updated ? llvm::SmallVector<std::uint32_t>{3}
+                           : llvm::SmallVector<std::uint32_t>{2};
+        }
+        return {};
+    };
+
+    make_graph(tracking_dispatch(compiled), std::move(resolver));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_EQ(resolve_count, 1);
+        EXPECT_EQ(compiled.size(), 2u);  // 2, then 1
+
+        updated = true;
+        graph->update(1);
+
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_EQ(resolve_count, 2);
+        auto tail = compiled | std::views::drop(2);
+        EXPECT_TRUE(ranges::find(tail, 3u) != tail.end());
+    });
+}
+
+TEST_CASE(update_cleans_back_edges) {
+    // When a re-resolve drops a dependency, the reverse edge goes with it:
+    // updating the ex-dependency no longer cascades to the ex-dependent.
+    bool updated = false;
+    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+        if(path_id == 1) {
+            return updated ? llvm::SmallVector<std::uint32_t>{}
+                           : llvm::SmallVector<std::uint32_t>{2};
+        }
+        return {};
+    };
+
+    make_graph(tracking_dispatch(compiled), std::move(resolver));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_FALSE(graph->is_dirty(1));
+
+        updated = true;
+        graph->update(1);
+
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_FALSE(graph->is_dirty(1));
+
+        graph->update(2);
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(update_unknown_id) {
+    // Updating a file the graph has never seen is a harmless no-op.
+    make_graph(instant_dispatch(), no_deps());
+
+    auto dirtied = graph->update(999);
+    EXPECT_EQ(dirtied.size(), 0u);
+    EXPECT_FALSE(graph->has_unit(999));
+}
+
+// update() against in-flight rounds: the stale round is cancelled
+// unconditionally (its result is garbage), interest is untouched, and the
+// waiters drive a fresh round with the new content. Dependencies that are
+// NOT stale themselves must keep compiling across the retry.
+
+TEST_CASE(update_during_dispatch) {
+    // The unit is updated mid-dispatch: that round's result is discarded,
+    // the waiter respawns the unit and succeeds. Exactly one retry — each
+    // retry consumes one staleness event, so there is no retry storm.
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
         auto driver = [&]() -> kota::task<> {
-            co_await md.gate(5).started.wait();
-            EXPECT_EQ(graph->refcount(5), 2u);
-
-            // Cancel both requests: E's interest drops to zero and its
-            // compilation is cancelled too.
-            ra.source.cancel();
-            rc.source.cancel();
-            co_await settle([&] { return !graph->is_compiling(5); });
-
-            EXPECT_TRUE(graph->is_dirty(5));
-            EXPECT_EQ(graph->refcount(5), 0u);
-            EXPECT_EQ(md.gate(5).calls, 1);
+            co_await md.gate(1).started.wait();
+            md.gate(1).started.reset();
+            graph->update(1);
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(md.gate(1).calls, 2);
+            md.gate(1).proceed.set();
             co_return;
         };
 
-        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+        co_await kota::when_all(compiler(), driver());
 
-        EXPECT_FALSE(ra.result.has_value());
-        EXPECT_FALSE(rc.result.has_value());
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_EQ(md.gate(1).calls, 2);
     });
 }
 
-TEST_CASE(SharedDepSequentialCancel) {
-    // Mirror of SharedDepSurvivesCancel: cancel C first (E survives via the
-    // A-chain), then cancel A too (last interest gone, E dies).
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {5}},
-                   {3, {4}},
-                   {4, {5}}
-    }));
-    md.open({1, 2, 3, 4});
-
-    Request ra, rc;
-    execute([&]() -> kota::task<> {
-        auto driver = [&]() -> kota::task<> {
-            co_await md.gate(5).started.wait();
-            EXPECT_EQ(graph->refcount(5), 2u);
-
-            rc.source.cancel();
-            co_await settle([&] { return !graph->is_compiling(4); });
-
-            // D's edge dropped; B still holds interest — E keeps compiling.
-            EXPECT_TRUE(graph->is_compiling(5));
-            EXPECT_EQ(graph->refcount(5), 1u);
-            EXPECT_EQ(md.gate(5).calls, 1);
-
-            ra.source.cancel();
-            co_await settle([&] { return !graph->is_compiling(5); });
-
-            // Last interest gone — now E is cancelled.
-            EXPECT_TRUE(graph->is_dirty(5));
-            EXPECT_EQ(graph->refcount(5), 0u);
-            EXPECT_EQ(md.gate(5).calls, 1);
-            co_return;
-        };
-
-        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
-
-        EXPECT_FALSE(ra.result.has_value());
-        EXPECT_FALSE(rc.result.has_value());
-    });
-}
-
-TEST_CASE(SharedDepQueuedCancel) {
-    // E(5) itself depends on F(9); cancel A while E is still waiting for F,
-    // i.e. E is queued behind its own dependency rather than dispatching.
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {5}},
-                   {3, {4}},
-                   {4, {5}},
-                   {5, {9}}
-    }));
-    md.open({1, 2, 3, 4, 5});
-
-    Request ra, rc;
-    execute([&]() -> kota::task<> {
-        auto driver = [&]() -> kota::task<> {
-            co_await md.gate(9).started.wait();
-            EXPECT_TRUE(graph->is_compiling(5));
-            EXPECT_EQ(graph->refcount(5), 2u);
-
-            ra.source.cancel();
-            co_await settle([&] { return !graph->is_compiling(2); });
-
-            // E keeps waiting for F; only the A-chain died.
-            EXPECT_TRUE(graph->is_compiling(5));
-            EXPECT_TRUE(graph->is_compiling(9));
-            EXPECT_EQ(graph->refcount(5), 1u);
-            EXPECT_EQ(md.gate(9).calls, 1);
-
-            md.gate(9).proceed.set();
-            co_return;
-        };
-
-        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
-
-        EXPECT_FALSE(ra.result.has_value());
-        EXPECT_TRUE(rc.result == true);
-        EXPECT_FALSE(graph->is_dirty(5));
-        EXPECT_FALSE(graph->is_dirty(9));
-    });
-}
-
-TEST_CASE(CompileDepsCancelReleases) {
-    // A plain .cpp (10) holds root references on its direct deps; cancelling
-    // the compile_deps request releases them without killing a dependency
-    // that another consumer still needs.
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {10, {5}},
-                   {3,  {4}},
-                   {4,  {5}}
-    }));
-    md.open({3, 4});
-
-    Request ra, rc;
-    execute([&]() -> kota::task<> {
-        auto driver = [&]() -> kota::task<> {
-            co_await md.gate(5).started.wait();
-            // Root reference from the compile_deps request + edge from 4.
-            EXPECT_EQ(graph->refcount(5), 2u);
-
-            ra.source.cancel();
-            co_await kota::sleep(1);
-
-            EXPECT_TRUE(ra.done);
-            EXPECT_TRUE(graph->is_compiling(5));
-            EXPECT_EQ(graph->refcount(5), 1u);
-            EXPECT_EQ(md.gate(5).calls, 1);
-
-            md.gate(5).proceed.set();
-            co_return;
-        };
-
-        co_await kota::when_all(run_deps_request(10, ra), run_request(3, rc), driver());
-
-        EXPECT_FALSE(ra.result.has_value());
-        EXPECT_TRUE(rc.result == true);
-        EXPECT_FALSE(graph->is_dirty(5));
-    });
-}
-
-TEST_CASE(SharedDepAlreadyCompiled) {
-    // E was already built by the A-chain; cancelling/finishing A afterwards
-    // must not invalidate it for the C-chain.
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {5}},
-                   {3, {4}},
-                   {4, {5}}
-    }));
-    md.open({1, 2, 3, 4, 5});
-
-    execute([&]() -> kota::task<> {
-        auto r1 = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(r1.has_value() && *r1);
-        EXPECT_EQ(md.gate(5).calls, 1);
-
-        auto r2 = co_await graph->compile(3).catch_cancel();
-        EXPECT_TRUE(r2.has_value() && *r2);
-        // E was clean — not recompiled.
-        EXPECT_EQ(md.gate(5).calls, 1);
-    });
-}
-
-// Update semantics: staleness-driven cancellation, waiters retry.
-
-TEST_CASE(UpdateWhileWaitingDeps) {
-    // Update hits unit 1 while it waits for its dependency 2. The retry
-    // re-acquires 2 within the same drain cycle, so 2's in-flight round is
-    // handed over — neither cancelled nor restarted.
+TEST_CASE(update_keeps_waited_dep) {
+    // Unit 1 is updated while waiting on its (unchanged) dependency 2. The
+    // retry re-acquires 2 within the same drain cycle, so 2's in-flight
+    // round is handed over — neither cancelled nor restarted.
     ManualDispatch md;
     make_graph(md.fn(),
                static_resolver({
@@ -1109,11 +721,11 @@ TEST_CASE(UpdateWhileWaitingDeps) {
     });
 }
 
-TEST_CASE(UpdateKeepsRetainedDep) {
-    // Unit 1 depends on {2, 3}, both dispatching, 1 waiting on both. An
-    // update changes 1's imports to {2, 4}: the orphaned 3 is cancelled,
-    // while 2's in-flight round must be handed over to the retry — not
-    // cancelled and restarted, which would waste the work done so far.
+TEST_CASE(update_keeps_retained_dep) {
+    // Unit 1 waits on {2, 3} when an update changes its imports to {2, 4}:
+    // the orphaned 3 is cancelled, while the retained 2 is handed over to
+    // the retry — not cancelled and restarted, which would waste the work
+    // done so far.
     bool flipped = false;
     auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
         if(path_id == 1) {
@@ -1173,66 +785,10 @@ TEST_CASE(UpdateKeepsRetainedDep) {
     });
 }
 
-TEST_CASE(UpdateDepCascadesCancel) {
-    // Updating a dependency cancels the in-flight rounds of its dependents;
-    // the request retries the whole chain and succeeds.
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {1, {2}},
-                   {2, {3}}
-    }));
-    md.open({1, 2});
-
-    execute([&]() -> kota::task<> {
-        bool done = false;
-        std::optional<bool> result;
-
-        auto compiler = [&]() -> kota::task<> {
-            auto r = co_await graph->compile(1).catch_cancel();
-            done = true;
-            if(r.has_value()) {
-                result = *r;
-            }
-        };
-
-        auto driver = [&]() -> kota::task<> {
-            co_await md.gate(3).started.wait();
-            EXPECT_TRUE(graph->is_compiling(1));
-            EXPECT_TRUE(graph->is_compiling(2));
-
-            md.gate(3).started.reset();
-            graph->update(3);
-            EXPECT_TRUE(graph->is_dirty(1));
-            EXPECT_TRUE(graph->is_dirty(2));
-
-            // The cascade cancelled the in-flight rounds of 3 and its
-            // dependents; the surviving waiter drives a fresh chain, which
-            // restarts 3's dispatch.
-            co_await md.gate(3).started.wait();
-            EXPECT_EQ(md.gate(3).calls, 2);
-            EXPECT_TRUE(graph->is_compiling(1));
-            EXPECT_TRUE(graph->is_compiling(2));
-            md.gate(3).proceed.set();
-            co_return;
-        };
-
-        co_await kota::when_all(compiler(), driver());
-
-        EXPECT_TRUE(done);
-        EXPECT_TRUE(result == true);
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_FALSE(graph->is_dirty(2));
-        EXPECT_FALSE(graph->is_dirty(3));
-        // No further updates arrived — exactly one retry, no storm.
-        EXPECT_EQ(md.gate(3).calls, 2);
-    });
-}
-
-TEST_CASE(UpdateSwapsDeps) {
-    // Unit 1's import set changes from {2} to {3} while its round is in
-    // flight waiting on 2. The retry re-resolves, releases the orphaned edge
-    // on 2 (cancelling 2's now-unwanted round) and acquires 3 instead.
+TEST_CASE(update_swaps_deps) {
+    // Unit 1's import set changes from {2} to {3} mid-flight: the retry
+    // re-resolves, the orphaned 2 is released (its now-unwanted round
+    // cancelled, never restarted) and its reverse edge fully detached.
     bool flipped = false;
     auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
         if(path_id == 1) {
@@ -1265,7 +821,6 @@ TEST_CASE(UpdateSwapsDeps) {
             flipped = true;
             graph->update(1);
 
-            // The retry resolves the new dependency and never restarts 2.
             co_await md.gate(3).started.wait();
             EXPECT_EQ(md.gate(2).calls, 1);
             EXPECT_EQ(md.gate(3).calls, 1);
@@ -1278,8 +833,8 @@ TEST_CASE(UpdateSwapsDeps) {
         EXPECT_TRUE(result == true);
         EXPECT_FALSE(graph->is_dirty(1));
         EXPECT_FALSE(graph->is_dirty(3));
-        // The orphaned dependency stays dirty and fully detached: updating
-        // it no longer cascades to 1.
+        // The orphan stays dirty and detached: updating it no longer
+        // cascades to 1.
         EXPECT_TRUE(graph->is_dirty(2));
         auto dirtied = graph->update(2);
         EXPECT_EQ(dirtied.size(), 1u);
@@ -1287,59 +842,17 @@ TEST_CASE(UpdateSwapsDeps) {
     });
 }
 
-// Failure semantics: no retry, edge references released.
-
-TEST_CASE(FailedDepNoRetry) {
+TEST_CASE(update_cascades_cancel) {
+    // Updating a dependency cancels the in-flight rounds of its dependents
+    // too (their results would embed the stale dependency); the surviving
+    // request retries the whole chain with the new content.
     ManualDispatch md;
     make_graph(md.fn(),
                static_resolver({
-                   {1, {2}}
+                   {1, {2}},
+                   {2, {3}}
     }));
-    md.gate(2).result = false;
     md.open({1, 2});
-
-    execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
-        // Failure propagates without retry, and 1 is never dispatched.
-        EXPECT_EQ(md.gate(2).calls, 1);
-        EXPECT_EQ(md.gate(1).calls, 0);
-        // The failed round released its edge references.
-        EXPECT_EQ(graph->refcount(2), 0u);
-        EXPECT_EQ(graph->refcount(1), 0u);
-    });
-}
-
-TEST_CASE(RecompileAfterFailure) {
-    ManualDispatch md;
-    make_graph(md.fn(),
-               static_resolver({
-                   {1, {2}}
-    }));
-    md.gate(2).result = false;
-    md.open({1, 2});
-
-    execute([&]() -> kota::task<> {
-        auto r1 = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(r1.has_value());
-        EXPECT_FALSE(*r1);
-
-        // Failure is not sticky: an explicit recompile tries again.
-        md.gate(2).result = true;
-        auto r2 = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(r2.has_value());
-        EXPECT_TRUE(*r2);
-        EXPECT_EQ(md.gate(2).calls, 2);
-        EXPECT_EQ(md.gate(1).calls, 1);
-        EXPECT_FALSE(graph->is_dirty(1));
-        EXPECT_FALSE(graph->is_dirty(2));
-    });
-}
-
-TEST_CASE(CancelAllRespawns) {
-    ManualDispatch md;
-    make_graph(md.fn(), no_deps());
 
     execute([&]() -> kota::task<> {
         bool done = false;
@@ -1353,15 +866,22 @@ TEST_CASE(CancelAllRespawns) {
             }
         };
 
-        // cancel_all kills the in-flight round; the waiter still holds its
-        // interest, so it respawns the unit and succeeds.
         auto driver = [&]() -> kota::task<> {
-            co_await md.gate(1).started.wait();
-            md.gate(1).started.reset();
-            graph->cancel_all();
-            co_await md.gate(1).started.wait();
-            EXPECT_EQ(md.gate(1).calls, 2);
-            md.gate(1).proceed.set();
+            co_await md.gate(3).started.wait();
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_TRUE(graph->is_compiling(2));
+
+            md.gate(3).started.reset();
+            graph->update(3);
+            EXPECT_TRUE(graph->is_dirty(1));
+            EXPECT_TRUE(graph->is_dirty(2));
+
+            // The updated unit itself is stale, so its dispatch restarts.
+            co_await md.gate(3).started.wait();
+            EXPECT_EQ(md.gate(3).calls, 2);
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_TRUE(graph->is_compiling(2));
+            md.gate(3).proceed.set();
             co_return;
         };
 
@@ -1370,13 +890,172 @@ TEST_CASE(CancelAllRespawns) {
         EXPECT_TRUE(done);
         EXPECT_TRUE(result == true);
         EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(3));
+        // No further updates arrived — exactly one retry, no storm.
+        EXPECT_EQ(md.gate(3).calls, 2);
     });
 }
 
-// Cycles: all terminate with failure, never deadlock.
+// Failure semantics: a failed round (compile error, cycle) propagates to
+// every waiter without retry — retrying failures would turn a syntax error
+// into a storm. Failure is not sticky: the next explicit request tries
+// again.
 
-TEST_CASE(UpdateIntroducedCycle) {
-    // The cycle only appears after update() forces a re-resolve of unit 2.
+TEST_CASE(failure_leaves_dirty) {
+    // A failing dependency fails the request; neither the failed dependency
+    // nor the never-dispatched dependent is marked clean.
+    make_graph(failing_dispatch(),
+               static_resolver({
+                   {1, {2}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(partial_dep_failure) {
+    // 1 -> {2, 3}, only 3 fails: 2's success is kept, 3 stays dirty, and 1
+    // fails without being dispatched.
+    make_graph(selective_dispatch({
+                   3
+    }),
+               static_resolver({{1, {2, 3}}}));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(failed_dep_no_retry) {
+    // The dependency fails once: the failure propagates (1 never
+    // dispatched, no retry) and the failed round releases its interest.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}}
+    }));
+    md.gate(2).result = false;
+    md.open({1, 2});
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+        EXPECT_EQ(md.gate(2).calls, 1);
+        EXPECT_EQ(md.gate(1).calls, 0);
+        EXPECT_EQ(graph->refcount(2), 0u);
+        EXPECT_EQ(graph->refcount(1), 0u);
+    });
+}
+
+TEST_CASE(recompile_after_failure) {
+    // Failure is not sticky: a new request drives a fresh attempt, which
+    // succeeds once the dependency compiles.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}}
+    }));
+    md.gate(2).result = false;
+    md.open({1, 2});
+
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r1.has_value());
+        EXPECT_FALSE(*r1);
+
+        md.gate(2).result = true;
+        auto r2 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r2.has_value());
+        EXPECT_TRUE(*r2);
+        EXPECT_EQ(md.gate(2).calls, 2);
+        EXPECT_EQ(md.gate(1).calls, 1);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+    });
+}
+
+// Cycle handling: every shape of dependency cycle terminates with failure
+// — never a deadlock, never unbounded retry.
+
+TEST_CASE(self_loop) {
+    // A unit importing itself fails immediately after resolve.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {1}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    });
+}
+
+TEST_CASE(circular_dependency) {
+    // 1 -> 2 -> 1: the waiter that would close the wait loop detects it
+    // and fails the unit instead of blocking.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {1}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    });
+}
+
+TEST_CASE(cross_branch_cycle) {
+    // 1 -> {2, 3}, 2 -> 3, 3 -> 2: sibling unit tasks would deadlock on
+    // each other's completion without wait-cycle detection.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {3}   },
+                   {3, {2}   }
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    });
+}
+
+TEST_CASE(partitioned_cycle) {
+    // The cycle (2 <-> 3) does not involve the requested root; the failure
+    // still propagates up to it.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}},
+                   {3, {2}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    });
+}
+
+TEST_CASE(update_introduced_cycle) {
+    // The cycle only appears after update() forces a re-resolve of unit 2;
+    // the retry detects it and fails instead of hanging.
     bool flipped = false;
     auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
         if(path_id == 1) {
@@ -1403,25 +1082,317 @@ TEST_CASE(UpdateIntroducedCycle) {
     });
 }
 
-TEST_CASE(PartitionedCycle) {
-    // The cycle (2 <-> 3) does not involve the requested root.
-    make_graph(instant_dispatch(),
+// Shared dependencies and request cancellation. Topology unless noted:
+// A(1) -> B(2) -> E(5) and C(3) -> D(4) -> E(5), E shared by both chains.
+// Cancelling a request must only kill the parts of its chain no other
+// consumer holds interest in.
+
+TEST_CASE(shared_dep_survives_cancel) {
+    // Cancel request A while E dispatches: the A-chain dies, but D still
+    // holds interest in E — E keeps compiling and serves C unscathed.
+    ManualDispatch md;
+    make_graph(md.fn(),
                static_resolver({
                    {1, {2}},
-                   {2, {3}},
-                   {3, {2}}
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
     }));
+    md.open({1, 2, 3, 4});
 
+    Request ra, rc;
     execute([&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        EXPECT_TRUE(result.has_value());
-        EXPECT_FALSE(*result);
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            ra.source.cancel();
+            co_await settle([&] { return !graph->is_compiling(2); });
+
+            EXPECT_TRUE(ra.done);
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            md.gate(5).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+        EXPECT_FALSE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(1));
     });
 }
 
-// Lifecycle: shutdown with tasks in flight.
+TEST_CASE(shared_dep_sequential_cancel) {
+    // Both directions, stepwise: cancel C first (E survives via the
+    // A-chain, refcount 2 -> 1), then cancel A too (last interest gone,
+    // refcount 1 -> 0, E dies). E is never restarted along the way.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4});
 
-TEST_CASE(ShutdownWithInflight) {
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            rc.source.cancel();
+            co_await settle([&] { return !graph->is_compiling(4); });
+
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            ra.source.cancel();
+            co_await settle([&] { return !graph->is_compiling(5); });
+
+            EXPECT_TRUE(graph->is_dirty(5));
+            EXPECT_EQ(graph->refcount(5), 0u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_FALSE(rc.result.has_value());
+    });
+}
+
+TEST_CASE(shared_dep_both_cancelled) {
+    // E shared at different depths (A -> B -> E, C -> E); cancelling both
+    // requests in the same tick drops E to zero and cancels it.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {5}}
+    }));
+    md.open({1, 2, 3});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            ra.source.cancel();
+            rc.source.cancel();
+            co_await settle([&] { return !graph->is_compiling(5); });
+
+            EXPECT_TRUE(graph->is_dirty(5));
+            EXPECT_EQ(graph->refcount(5), 0u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_FALSE(rc.result.has_value());
+    });
+}
+
+TEST_CASE(shared_dep_queued_cancel) {
+    // E is still queued behind its own dependency F(9) (not yet
+    // dispatching) when A is cancelled: E's task survives and keeps
+    // waiting, F is untouched.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}},
+                   {5, {9}}
+    }));
+    md.open({1, 2, 3, 4, 5});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(9).started.wait();
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            ra.source.cancel();
+            co_await settle([&] { return !graph->is_compiling(2); });
+
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_TRUE(graph->is_compiling(9));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(9).calls, 1);
+
+            md.gate(9).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+        EXPECT_FALSE(graph->is_dirty(9));
+    });
+}
+
+TEST_CASE(shared_dep_already_compiled) {
+    // E was already built by the A-chain; later requests reuse it without
+    // recompiling.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4, 5});
+
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r1.has_value() && *r1);
+        EXPECT_EQ(md.gate(5).calls, 1);
+
+        auto r2 = co_await graph->compile(3).catch_cancel();
+        EXPECT_TRUE(r2.has_value() && *r2);
+        EXPECT_EQ(md.gate(5).calls, 1);
+    });
+}
+
+TEST_CASE(compile_deps_cancel_releases) {
+    // A plain .cpp (10) holds root references on its direct deps;
+    // cancelling the compile_deps request releases them without killing a
+    // dependency that another consumer still needs.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {10, {5}},
+                   {3,  {4}},
+                   {4,  {5}}
+    }));
+    md.open({3, 4});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            // Root reference from the compile_deps request + edge from 4.
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(ra.done);
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            md.gate(5).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_deps_request(10, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+    });
+}
+
+// Lifecycle: cancel_all restarts in-flight work without dropping waiters;
+// shutdown (cancel + join) quiesces the graph with tasks still in flight.
+
+TEST_CASE(empty_graph) {
+    // A graph that never compiled anything: cancel_all is a no-op and
+    // teardown is clean.
+    make_graph(instant_dispatch(), no_deps());
+    EXPECT_FALSE(graph->has_unit(1));
+    graph->cancel_all();
+}
+
+TEST_CASE(cancel_all_recompile) {
+    // The graph stays fully usable after cancel_all: a later update +
+    // compile recompiles everything as usual.
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        co_await graph->compile(1).catch_cancel();
+        EXPECT_EQ(compiled.size(), 2u);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+
+        graph->cancel_all();
+        graph->update(2);
+        EXPECT_TRUE(graph->is_dirty(2));
+        EXPECT_TRUE(graph->is_dirty(1));
+
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_TRUE(*result);
+        EXPECT_EQ(compiled.size(), 4u);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+    });
+}
+
+TEST_CASE(cancel_all_respawns) {
+    // cancel_all kills the in-flight round; the waiter still holds its
+    // interest, so it respawns the unit and the request succeeds.
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            md.gate(1).started.reset();
+            graph->cancel_all();
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(md.gate(1).calls, 2);
+            md.gate(1).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(shutdown_with_inflight) {
+    // shutdown() with several unit tasks in flight: pending requests
+    // resolve with failure (the graph refuses to respawn), every frame
+    // unwinds, and the destructor protocol holds (idle, no asserts).
     ManualDispatch md;
     make_graph(md.fn(),
                static_resolver({
@@ -1433,7 +1404,6 @@ TEST_CASE(ShutdownWithInflight) {
     Request req;
     auto driver = [&]() -> kota::task<> {
         co_await md.gate(4).started.wait();
-        // Cancel + join with several unit tasks in flight.
         co_await graph->shutdown();
         co_return;
     };
@@ -1444,16 +1414,16 @@ TEST_CASE(ShutdownWithInflight) {
     loop->schedule(t2);
     loop->run();
 
-    // The pending request resolves with failure once the graph refuses to
-    // respawn, and all bookkeeping is quiesced.
     EXPECT_TRUE(req.done);
     EXPECT_TRUE(req.result == false);
     EXPECT_TRUE(graph->idle());
 }
 
-// Randomized stress: seeded, single-threaded, deterministic.
+// Randomized stress: a fixed-seed, single-threaded interleaving of
+// requests, cancellations, updates and dispatch completions. Verifies the
+// structural invariants at every step and full quiescence at teardown.
 
-TEST_CASE(RandomizedStress) {
+TEST_CASE(randomized_stress) {
     kota::semaphore permits{0};
     auto dispatch = [&](std::uint32_t) -> kota::task<bool> {
         co_await permits.acquire();

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -155,8 +155,12 @@ kota::task<> settle(Pred pred) {
     EXPECT_TRUE(pred());
 }
 
-// Basic compilation: a request compiles the unit and its transitive
-// dependencies, dependencies first, each dirty unit exactly once.
+/// ============================================================================
+///                              Basic compilation
+/// ============================================================================
+///
+/// A request compiles the unit and its transitive dependencies,
+/// dependencies first, each dirty unit exactly once.
 
 TEST_CASE(compile_no_deps) {
     // A unit without dependencies is dispatched once and becomes clean.
@@ -262,8 +266,39 @@ TEST_CASE(state_queries) {
     });
 }
 
-// compile_deps: compiles a unit's transitive dependencies but never the
-// unit itself — used for plain .cpp files that import modules.
+TEST_CASE(concurrent_requests_share_round) {
+    // Two concurrent requests for the same unit join one round: a single
+    // dispatch serves both.
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(graph->refcount(1), 2u);
+            md.gate(1).proceed.set();
+            // Suspend once before finishing: a when_all child that completes
+            // synchronously during the arm phase trips a when_any bookkeeping
+            // assert downstream (kotatsu bug, pending an upstream fix).
+            co_await kota::sleep(0);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(1, rc), driver());
+
+        EXPECT_TRUE(ra.result == true);
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_EQ(md.gate(1).calls, 1);
+    });
+}
+
+/// ============================================================================
+///                                 compile_deps
+/// ============================================================================
+///
+/// Compiles a unit's transitive dependencies but never the unit itself —
+/// used for plain .cpp files that import modules.
 
 TEST_CASE(compile_deps_empty) {
     // No dependencies: nothing is dispatched, the request succeeds.
@@ -428,9 +463,13 @@ TEST_CASE(compile_deps_failure) {
     });
 }
 
-// update() marks a changed file and everything that (transitively) depends
-// on it dirty, following reverse edges. Marking alone never recompiles —
-// the next request does.
+/// ============================================================================
+///                              Staleness marking
+/// ============================================================================
+///
+/// update() marks a changed file and everything that (transitively)
+/// depends on it dirty, following reverse edges. Marking alone never
+/// recompiles — the next request does.
 
 TEST_CASE(update_invalidates) {
     // Updating a dependency dirties it and its dependent.
@@ -629,10 +668,14 @@ TEST_CASE(update_unknown_id) {
     EXPECT_FALSE(graph->has_unit(999));
 }
 
-// update() against in-flight rounds: the stale round is cancelled
-// unconditionally (its result is garbage), interest is untouched, and the
-// waiters drive a fresh round with the new content. Dependencies that are
-// NOT stale themselves must keep compiling across the retry.
+/// ============================================================================
+///                          Update vs in-flight rounds
+/// ============================================================================
+///
+/// The stale round is cancelled unconditionally (its result is garbage),
+/// interest is untouched, and the waiters drive a fresh round with the
+/// new content. Dependencies that are NOT stale themselves must keep
+/// compiling across the retry.
 
 TEST_CASE(update_during_dispatch) {
     // The unit is updated mid-dispatch: that round's result is discarded,
@@ -897,10 +940,49 @@ TEST_CASE(update_cascades_cancel) {
     });
 }
 
-// Failure semantics: a failed round (compile error, cycle) propagates to
-// every waiter without retry — retrying failures would turn a syntax error
-// into a storm. Failure is not sticky: the next explicit request tries
-// again.
+TEST_CASE(shared_dep_update_retries) {
+    // The shared dependency 5 of two waiting chains is updated mid-dispatch:
+    // both chains observe the stale round and retry, sharing a single fresh
+    // round — 5 is dispatched exactly twice overall, not three times.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {5}},
+                   {3, {5}}
+    }));
+    md.open({1, 3});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            md.gate(5).started.reset();
+            graph->update(5);
+
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(md.gate(5).calls, 2);
+            md.gate(5).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_TRUE(ra.result == true);
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_EQ(md.gate(5).calls, 2);
+        EXPECT_FALSE(graph->is_dirty(5));
+    });
+}
+
+/// ============================================================================
+///                              Failure semantics
+/// ============================================================================
+///
+/// A failed round (compile error, cycle) propagates to every waiter
+/// without retry — retrying failures would turn a syntax error into a
+/// storm. Failure is not sticky: the next explicit request tries again.
 
 TEST_CASE(failure_leaves_dirty) {
     // A failing dependency fails the request; neither the failed dependency
@@ -986,8 +1068,47 @@ TEST_CASE(recompile_after_failure) {
     });
 }
 
-// Cycle handling: every shape of dependency cycle terminates with failure
-// — never a deadlock, never unbounded retry.
+TEST_CASE(shared_dep_failure_propagates) {
+    // One failing round of a shared dependency fails every consumer waiting
+    // on it; the failing dispatch runs only once.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {5}},
+                   {3, {5}}
+    }));
+    md.gate(5).result = false;
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        // Hold 5's gate until both chains wait on the same round.
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+            md.gate(5).proceed.set();
+            // Suspend once before finishing (kotatsu when_all arm bug, see
+            // concurrent_requests_share_round).
+            co_await kota::sleep(0);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_TRUE(ra.result == false);
+        EXPECT_TRUE(rc.result == false);
+        EXPECT_EQ(md.gate(5).calls, 1);
+        EXPECT_EQ(md.gate(1).calls, 0);
+        EXPECT_EQ(md.gate(3).calls, 0);
+        EXPECT_TRUE(graph->is_dirty(5));
+    });
+}
+
+/// ============================================================================
+///                                Cycle handling
+/// ============================================================================
+///
+/// Every shape of dependency cycle terminates with failure — never a
+/// deadlock, never unbounded retry.
 
 TEST_CASE(self_loop) {
     // A unit importing itself fails immediately after resolve.
@@ -1082,10 +1203,13 @@ TEST_CASE(update_introduced_cycle) {
     });
 }
 
-// Shared dependencies and request cancellation. Topology unless noted:
-// A(1) -> B(2) -> E(5) and C(3) -> D(4) -> E(5), E shared by both chains.
-// Cancelling a request must only kill the parts of its chain no other
-// consumer holds interest in.
+/// ============================================================================
+///                      Shared dependencies & cancellation
+/// ============================================================================
+///
+/// Topology unless noted: A(1) -> B(2) -> E(5) and C(3) -> D(4) -> E(5),
+/// E shared by both chains. Cancelling a request must only kill the parts
+/// of its chain no other consumer holds interest in.
 
 TEST_CASE(shared_dep_survives_cancel) {
     // Cancel request A while E dispatches: the A-chain dies, but D still
@@ -1314,8 +1438,88 @@ TEST_CASE(compile_deps_cancel_releases) {
     });
 }
 
-// Lifecycle: cancel_all restarts in-flight work without dropping waiters;
-// shutdown (cancel + join) quiesces the graph with tasks still in flight.
+TEST_CASE(duplicate_requests_cancel_one) {
+    // Two requests on the same unit; cancelling one must not disturb the
+    // round the other is waiting on.
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(graph->refcount(1), 2u);
+
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(ra.done);
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_EQ(graph->refcount(1), 1u);
+            EXPECT_EQ(md.gate(1).calls, 1);
+
+            md.gate(1).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(1, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_EQ(md.gate(1).calls, 1);
+    });
+}
+
+TEST_CASE(rerequest_within_grace) {
+    // The only request is cancelled and a new one arrives within the same
+    // drain cycle — release first, re-acquire second, strictly worse than
+    // the supersede handoff ordering. The deferred zero-interest check
+    // bridges the transient zero: the in-flight round survives instead of
+    // being killed and restarted.
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    kota::event start_c;
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto delayed_request = [&]() -> kota::task<> {
+            co_await start_c.wait();
+            co_await run_request(1, rc);
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(graph->refcount(1), 1u);
+
+            ra.source.cancel();
+            start_c.set();
+            // Two sleeps: the second is armed after the zero-interest check,
+            // so the assertions observe its (skipped) outcome.
+            co_await kota::sleep(1);
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_EQ(graph->refcount(1), 1u);
+            EXPECT_EQ(md.gate(1).calls, 1);
+
+            md.gate(1).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), delayed_request(), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_EQ(md.gate(1).calls, 1);
+    });
+}
+
+/// ============================================================================
+///                                  Lifecycle
+/// ============================================================================
+///
+/// cancel_all restarts in-flight work without dropping waiters; shutdown
+/// (cancel + join) quiesces the graph with tasks still in flight.
 
 TEST_CASE(empty_graph) {
     // A graph that never compiled anything: cancel_all is a no-op and
@@ -1419,9 +1623,13 @@ TEST_CASE(shutdown_with_inflight) {
     EXPECT_TRUE(graph->idle());
 }
 
-// Randomized stress: a fixed-seed, single-threaded interleaving of
-// requests, cancellations, updates and dispatch completions. Verifies the
-// structural invariants at every step and full quiescence at teardown.
+/// ============================================================================
+///                              Randomized stress
+/// ============================================================================
+///
+/// A fixed-seed, single-threaded interleaving of requests, cancellations,
+/// updates and dispatch completions. Verifies the structural invariants
+/// at every step and full quiescence at teardown.
 
 TEST_CASE(randomized_stress) {
     kota::semaphore permits{0};

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -136,6 +136,16 @@ kota::task<> run_request(std::uint32_t path_id, Request& req) {
     }
 }
 
+/// Zero-interest cancellation is deferred by one event-loop tick per cascade
+/// level; wait (bounded) until `pred` holds before asserting settled state.
+template <typename Pred>
+kota::task<> settle(Pred pred) {
+    for(int i = 0; i < 100 && !pred(); i++) {
+        co_await kota::sleep(1);
+    }
+    EXPECT_TRUE(pred());
+}
+
 kota::task<> run_deps_request(std::uint32_t path_id, Request& req) {
     auto result = co_await kota::with_token(graph->compile_deps(path_id), req.source.token());
     req.done = true;
@@ -839,10 +849,9 @@ TEST_CASE(SharedDepSurvivesCancel) {
             // Cancel request A: B's task exits and drops its edge on E,
             // but D's task still holds interest — E must keep compiling.
             ra.source.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !graph->is_compiling(2); });
 
             EXPECT_TRUE(ra.done);
-            EXPECT_FALSE(graph->is_compiling(2));
             EXPECT_TRUE(graph->is_compiling(5));
             EXPECT_EQ(graph->refcount(5), 1u);
             EXPECT_EQ(md.gate(5).calls, 1);
@@ -882,9 +891,8 @@ TEST_CASE(SharedDepBothCancelled) {
             // compilation is cancelled too.
             ra.source.cancel();
             rc.source.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !graph->is_compiling(5); });
 
-            EXPECT_FALSE(graph->is_compiling(5));
             EXPECT_TRUE(graph->is_dirty(5));
             EXPECT_EQ(graph->refcount(5), 0u);
             EXPECT_EQ(md.gate(5).calls, 1);
@@ -918,19 +926,17 @@ TEST_CASE(SharedDepSequentialCancel) {
             EXPECT_EQ(graph->refcount(5), 2u);
 
             rc.source.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !graph->is_compiling(4); });
 
             // D's edge dropped; B still holds interest — E keeps compiling.
-            EXPECT_FALSE(graph->is_compiling(4));
             EXPECT_TRUE(graph->is_compiling(5));
             EXPECT_EQ(graph->refcount(5), 1u);
             EXPECT_EQ(md.gate(5).calls, 1);
 
             ra.source.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !graph->is_compiling(5); });
 
             // Last interest gone — now E is cancelled.
-            EXPECT_FALSE(graph->is_compiling(5));
             EXPECT_TRUE(graph->is_dirty(5));
             EXPECT_EQ(graph->refcount(5), 0u);
             EXPECT_EQ(md.gate(5).calls, 1);
@@ -966,7 +972,7 @@ TEST_CASE(SharedDepQueuedCancel) {
             EXPECT_EQ(graph->refcount(5), 2u);
 
             ra.source.cancel();
-            co_await kota::sleep(1);
+            co_await settle([&] { return !graph->is_compiling(2); });
 
             // E keeps waiting for F; only the A-chain died.
             EXPECT_TRUE(graph->is_compiling(5));
@@ -1055,7 +1061,9 @@ TEST_CASE(SharedDepAlreadyCompiled) {
 // Update semantics: staleness-driven cancellation, waiters retry.
 
 TEST_CASE(UpdateWhileWaitingDeps) {
-    // Update hits unit 1 while it waits for its dependency 2.
+    // Update hits unit 1 while it waits for its dependency 2. The retry
+    // re-acquires 2 within the same drain cycle, so 2's in-flight round is
+    // handed over — neither cancelled nor restarted.
     ManualDispatch md;
     make_graph(md.fn(),
                static_resolver({
@@ -1079,14 +1087,14 @@ TEST_CASE(UpdateWhileWaitingDeps) {
             co_await md.gate(2).started.wait();
             EXPECT_TRUE(graph->is_compiling(1));
 
-            // Only unit 1 is updated; its round is cancelled while the
-            // waiter retries. Releasing its edge on 2 momentarily drops 2's
-            // interest to zero, so 2 restarts when the retry re-acquires it.
-            md.gate(2).started.reset();
             graph->update(1);
+            co_await kota::sleep(1);
 
-            co_await md.gate(2).started.wait();
-            EXPECT_EQ(md.gate(2).calls, 2);
+            // Unit 1's round was respawned; 2 kept compiling throughout.
+            EXPECT_TRUE(graph->is_compiling(2));
+            EXPECT_EQ(md.gate(2).calls, 1);
+            EXPECT_EQ(graph->refcount(2), 1u);
+
             md.gate(2).proceed.set();
             co_return;
         };
@@ -1097,6 +1105,71 @@ TEST_CASE(UpdateWhileWaitingDeps) {
         EXPECT_TRUE(result == true);
         EXPECT_FALSE(graph->is_dirty(1));
         EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_EQ(md.gate(2).calls, 1);
+    });
+}
+
+TEST_CASE(UpdateKeepsRetainedDep) {
+    // Unit 1 depends on {2, 3}, both dispatching, 1 waiting on both. An
+    // update changes 1's imports to {2, 4}: the orphaned 3 is cancelled,
+    // while 2's in-flight round must be handed over to the retry — not
+    // cancelled and restarted, which would waste the work done so far.
+    bool flipped = false;
+    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+        if(path_id == 1) {
+            return flipped ? llvm::SmallVector<std::uint32_t>{2, 4}
+                           : llvm::SmallVector<std::uint32_t>{2, 3};
+        }
+        return {};
+    };
+
+    ManualDispatch md;
+    make_graph(md.fn(), std::move(resolver));
+    md.open({1, 4});
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(2).started.wait();
+            co_await md.gate(3).started.wait();
+            EXPECT_EQ(graph->refcount(2), 1u);
+            EXPECT_EQ(graph->refcount(3), 1u);
+
+            flipped = true;
+            graph->update(1);
+            co_await settle([&] { return !graph->is_compiling(3); });
+
+            // 3 lost its last interest and was cancelled; 2 kept compiling.
+            EXPECT_TRUE(graph->is_dirty(3));
+            EXPECT_TRUE(graph->is_compiling(2));
+            EXPECT_EQ(md.gate(2).calls, 1);
+            EXPECT_EQ(md.gate(3).calls, 1);
+            EXPECT_EQ(graph->refcount(2), 1u);
+
+            md.gate(2).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(4));
+        // The retained dependency was dispatched exactly once overall.
+        EXPECT_EQ(md.gate(2).calls, 1);
+        EXPECT_EQ(md.gate(3).calls, 1);
     });
 }
 

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -1,7 +1,10 @@
 #include <optional>
+#include <random>
 
 #include "test/test.h"
 #include "server/compiler/compile_graph.h"
+
+#include "llvm/ADT/DenseSet.h"
 
 namespace clice::testing {
 namespace {
@@ -53,21 +56,88 @@ CompileGraph::dispatch_fn selective_dispatch(llvm::DenseSet<std::uint32_t> fail_
     };
 }
 
+/// Dispatch driven manually by per-unit events: the test observes when a
+/// unit enters dispatch (started) and decides when and how it completes
+/// (proceed/result). Cancellation can thus be injected at every suspension
+/// point with deterministic timing.
+struct ManualDispatch {
+    struct Gate {
+        kota::event started;
+        kota::event proceed;
+        bool result = true;
+        int calls = 0;
+    };
+
+    llvm::DenseMap<std::uint32_t, std::unique_ptr<Gate>> gates;
+
+    Gate& gate(std::uint32_t path_id) {
+        auto& slot = gates[path_id];
+        if(!slot) {
+            slot = std::make_unique<Gate>();
+        }
+        return *slot;
+    }
+
+    void open(std::initializer_list<std::uint32_t> path_ids) {
+        for(auto id: path_ids) {
+            gate(id).proceed.set();
+        }
+    }
+
+    CompileGraph::dispatch_fn fn() {
+        return [this](std::uint32_t path_id) -> kota::task<bool> {
+            auto& g = gate(path_id);
+            g.calls += 1;
+            g.started.set();
+            co_await g.proceed.wait();
+            co_return g.result;
+        };
+    }
+};
+
+/// A cancellable compile request and its observed result.
+/// result is empty while running and after cancellation.
+struct Request {
+    kota::cancellation_source source;
+    std::optional<bool> result;
+    bool done = false;
+};
+
 TEST_SUITE(CompileGraph) {
 
 std::vector<std::uint32_t> compiled;
+std::optional<kota::event_loop> loop;
 std::optional<CompileGraph> graph;
 
+void make_graph(CompileGraph::dispatch_fn dispatch, CompileGraph::resolve_fn resolve) {
+    loop.emplace();
+    graph.emplace(*loop, std::move(dispatch), std::move(resolve));
+}
+
+/// Run the test body, then verify the shutdown protocol: cancel + join must
+/// exit cleanly and leave the graph fully quiesced.
 template <typename F>
 void execute(F&& fn) {
-    kota::event_loop loop;
-    auto t = fn();
-    loop.schedule(t);
-    loop.run();
+    auto wrapper = [&]() -> kota::task<> {
+        co_await fn();
+        co_await graph->shutdown();
+        EXPECT_TRUE(graph->idle());
+    };
+    auto t = wrapper();
+    loop->schedule(t);
+    loop->run();
+}
+
+kota::task<> run_request(std::uint32_t path_id, Request& req) {
+    auto result = co_await kota::with_token(graph->compile(path_id), req.source.token());
+    req.done = true;
+    if(result.has_value()) {
+        req.result = *result;
+    }
 }
 
 TEST_CASE(CompileNoDeps) {
-    graph.emplace(tracking_dispatch(compiled), no_deps());
+    make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
         auto result = co_await graph->compile(1).catch_cancel();
@@ -81,9 +151,9 @@ TEST_CASE(CompileNoDeps) {
 
 TEST_CASE(CompileWithDependency) {
     // Unit 1 depends on unit 2.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -102,10 +172,10 @@ TEST_CASE(CompileWithDependency) {
 
 TEST_CASE(CompileChain) {
     // Chain: 1 -> 2 -> 3.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {3}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -124,11 +194,11 @@ TEST_CASE(CompileChain) {
 
 TEST_CASE(DiamondDependency) {
     // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2, 3}},
-                      {2, {4}   },
-                      {3, {4}   }
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   }
     }));
 
     execute([&]() -> kota::task<> {
@@ -146,9 +216,9 @@ TEST_CASE(DiamondDependency) {
 
 TEST_CASE(UpdateInvalidates) {
     // 1 -> 2.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -165,10 +235,10 @@ TEST_CASE(UpdateInvalidates) {
 
 TEST_CASE(UpdateCascade) {
     // Chain: 1 -> 2 -> 3.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {3}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -186,9 +256,9 @@ TEST_CASE(UpdateCascade) {
 
 TEST_CASE(CompileAfterUpdate) {
     // 1 -> 2.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -204,9 +274,9 @@ TEST_CASE(CompileAfterUpdate) {
 
 TEST_CASE(DispatchFailure) {
     // 1 -> 2. Dispatch always fails.
-    graph.emplace(failing_dispatch(),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(failing_dispatch(),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -219,13 +289,13 @@ TEST_CASE(DispatchFailure) {
 }
 
 TEST_CASE(CancelAll) {
-    graph.emplace(instant_dispatch(), no_deps());
+    make_graph(instant_dispatch(), no_deps());
     // Just verify it doesn't crash.
     graph->cancel_all();
 }
 
 TEST_CASE(SecondCompileSkips) {
-    graph.emplace(tracking_dispatch(compiled), no_deps());
+    make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
         co_await graph->compile(1).catch_cancel();
@@ -238,10 +308,10 @@ TEST_CASE(SecondCompileSkips) {
 
 TEST_CASE(CascadeThroughAlreadyDirty) {
     // Chain: 1 -> 2 -> 3.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {3}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -263,10 +333,10 @@ TEST_CASE(CascadeThroughAlreadyDirty) {
 
 TEST_CASE(CircularDependencyDetection) {
     // Cycle: 1 -> 2 -> 1.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {1}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {1}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -279,13 +349,13 @@ TEST_CASE(CircularDependencyDetection) {
 
 TEST_CASE(CrossBranchCycleDetection) {
     // Cross-branch cycle: 1 -> {2, 3}, 2 -> 3, 3 -> 2.
-    // With when_all, sibling branches could deadlock on each other's
-    // completion.wait() without proper deadlock detection.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2, 3}},
-                      {2, {3}   },
-                      {3, {2}   }
+    // Sibling unit tasks could deadlock on each other's completion
+    // without proper wait-cycle detection.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {3}   },
+                   {3, {2}   }
     }));
 
     execute([&]() -> kota::task<> {
@@ -309,7 +379,7 @@ TEST_CASE(UpdateResetsResolved) {
         return {};
     };
 
-    graph.emplace(tracking_dispatch(compiled), std::move(resolver));
+    make_graph(tracking_dispatch(compiled), std::move(resolver));
 
     execute([&]() -> kota::task<> {
         // First compile: resolves 1 -> {2}.
@@ -341,7 +411,7 @@ TEST_CASE(UpdateCleansBackEdges) {
         return {};
     };
 
-    graph.emplace(tracking_dispatch(compiled), std::move(resolver));
+    make_graph(tracking_dispatch(compiled), std::move(resolver));
 
     execute([&]() -> kota::task<> {
         // First compile: 1 -> {2}.
@@ -365,11 +435,11 @@ TEST_CASE(UpdateCleansBackEdges) {
 
 TEST_CASE(DiamondUpdateCascade) {
     // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2, 3}},
-                      {2, {4}   },
-                      {3, {4}   }
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   }
     }));
 
     execute([&]() -> kota::task<> {
@@ -395,10 +465,10 @@ TEST_CASE(DiamondUpdateCascade) {
 
 TEST_CASE(UpdateReturnsAllDirtied) {
     // Chain: 1 -> 2 -> 3.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {3}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -414,7 +484,7 @@ TEST_CASE(UpdateReturnsAllDirtied) {
 }
 
 TEST_CASE(HasUnitAndIsCompiling) {
-    graph.emplace(instant_dispatch(), no_deps());
+    make_graph(instant_dispatch(), no_deps());
 
     execute([&]() -> kota::task<> {
         EXPECT_FALSE(graph->has_unit(1));
@@ -428,9 +498,9 @@ TEST_CASE(HasUnitAndIsCompiling) {
 
 TEST_CASE(FailureLeavesDepsDirty) {
     // 1 -> 2. Dispatch always fails.
-    graph.emplace(failing_dispatch(),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(failing_dispatch(),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -445,9 +515,9 @@ TEST_CASE(FailureLeavesDepsDirty) {
 
 TEST_CASE(SelfLoop) {
     // Unit 1 depends on itself.
-    graph.emplace(instant_dispatch(),
-                  static_resolver({
-                      {1, {1}}
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {1}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -459,9 +529,9 @@ TEST_CASE(SelfLoop) {
 }
 
 TEST_CASE(CancelAllAndRecompile) {
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -487,51 +557,49 @@ TEST_CASE(CancelAllAndRecompile) {
 }
 
 TEST_CASE(UpdateDuringCompile) {
-    kota::event_loop loop;
-    kota::event gate;
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
 
-    auto gated_dispatch = [&gate](std::uint32_t) -> kota::task<bool> {
-        co_await gate.wait();
-        co_return true;
-    };
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
 
-    graph.emplace(std::move(gated_dispatch), no_deps());
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
 
-    bool compile_done = false;
-    bool was_cancelled = false;
+        // Update while dispatch is in flight: the round is cancelled, the
+        // waiter retries with the new content, and — with no further
+        // updates — exactly one retry happens.
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            md.gate(1).started.reset();
+            graph->update(1);
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(md.gate(1).calls, 2);
+            md.gate(1).proceed.set();
+            co_return;
+        };
 
-    // Coroutine 1: compile(1), will suspend inside dispatch waiting on gate.
-    auto compiler = [&]() -> kota::task<> {
-        auto result = co_await graph->compile(1).catch_cancel();
-        compile_done = true;
-        was_cancelled = !result.has_value();
-    };
+        co_await kota::when_all(compiler(), driver());
 
-    // Coroutine 2: update(1) while dispatch is in flight, then unblock gate.
-    auto updater = [&]() -> kota::task<> {
-        graph->update(1);
-        gate.set();
-        co_return;
-    };
-
-    auto t1 = compiler();
-    auto t2 = updater();
-    loop.schedule(t1);
-    loop.schedule(t2);
-    loop.run();
-
-    // update() cancelled the source, so compile should have been cancelled.
-    EXPECT_TRUE(compile_done);
-    EXPECT_TRUE(was_cancelled);
-    EXPECT_TRUE(graph->is_dirty(1));
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_EQ(md.gate(1).calls, 2);
+    });
 }
 
 TEST_CASE(WhenAllPartialFailure) {
     // 1 -> {2, 3}. Only unit 3 fails.
-    graph.emplace(selective_dispatch({
-                      3
+    make_graph(selective_dispatch({
+                   3
     }),
-                  static_resolver({{1, {2, 3}}}));
+               static_resolver({{1, {2, 3}}}));
 
     execute([&]() -> kota::task<> {
         auto result = co_await graph->compile(1).catch_cancel();
@@ -547,7 +615,7 @@ TEST_CASE(WhenAllPartialFailure) {
 }
 
 TEST_CASE(UpdateUnknownPathId) {
-    graph.emplace(instant_dispatch(), no_deps());
+    make_graph(instant_dispatch(), no_deps());
 
     // update on a path_id that was never compiled should not crash.
     auto dirtied = graph->update(999);
@@ -557,13 +625,13 @@ TEST_CASE(UpdateUnknownPathId) {
 
 TEST_CASE(EmptyGraphNoCompile) {
     // Construct and destroy without any compile calls.
-    graph.emplace(instant_dispatch(), no_deps());
+    make_graph(instant_dispatch(), no_deps());
     EXPECT_FALSE(graph->has_unit(1));
     graph->cancel_all();  // Should not crash on empty graph.
 }
 
 TEST_CASE(CompileDepsNoDeps) {
-    graph.emplace(tracking_dispatch(compiled), no_deps());
+    make_graph(tracking_dispatch(compiled), no_deps());
 
     execute([&]() -> kota::task<> {
         auto result = co_await graph->compile_deps(1).catch_cancel();
@@ -576,9 +644,9 @@ TEST_CASE(CompileDepsNoDeps) {
 
 TEST_CASE(CompileDepsWithDependency) {
     // Unit 1 depends on unit 2.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -595,10 +663,10 @@ TEST_CASE(CompileDepsWithDependency) {
 
 TEST_CASE(CompileDepsChain) {
     // Chain: 1 -> 2 -> 3.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2}},
-                      {2, {3}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -615,11 +683,11 @@ TEST_CASE(CompileDepsChain) {
 
 TEST_CASE(CompileDepsDiamond) {
     // Diamond: 1 -> {2, 3}, 2 -> 4, 3 -> 4.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {2, 3}},
-                      {2, {4}   },
-                      {3, {4}   }
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   }
     }));
 
     execute([&]() -> kota::task<> {
@@ -644,9 +712,9 @@ TEST_CASE(CompileDepsFailure) {
         co_return false;
     };
 
-    graph.emplace(std::move(fail_and_track),
-                  static_resolver({
-                      {1, {2}}
+    make_graph(std::move(fail_and_track),
+               static_resolver({
+                   {1, {2}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -660,9 +728,9 @@ TEST_CASE(CompileDepsFailure) {
 
 TEST_CASE(CompileDepsPlainCpp) {
     // Simulates a plain .cpp file (unit 10) that imports a module (unit 20).
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {10, {20}}
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {10, {20}}
     }));
 
     execute([&]() -> kota::task<> {
@@ -681,10 +749,10 @@ TEST_CASE(CompileDepsConcurrentDedup) {
     // Each dep should be dispatched exactly once (no duplicate compilation).
     // Unit 1 depends on {3, 4}, unit 2 depends on {3, 5}.
     // Dep 3 is shared — must be compiled only once.
-    graph.emplace(tracking_dispatch(compiled),
-                  static_resolver({
-                      {1, {3, 4}},
-                      {2, {3, 5}},
+    make_graph(tracking_dispatch(compiled),
+               static_resolver({
+                   {1, {3, 4}},
+                   {2, {3, 5}},
     }));
 
     execute([&]() -> kota::task<> {
@@ -719,7 +787,7 @@ TEST_CASE(CompileDepsResolveOnce) {
         return {};
     };
 
-    graph.emplace(tracking_dispatch(compiled), std::move(resolve));
+    make_graph(tracking_dispatch(compiled), std::move(resolve));
 
     execute([&]() -> kota::task<> {
         auto t1 = graph->compile_deps(1);
@@ -736,6 +804,464 @@ TEST_CASE(CompileDepsResolveOnce) {
 
         // resolve_fn called for units 1, 2, 3 — each at most once (3 total).
         EXPECT_EQ(resolve_count, 3);
+    });
+}
+
+// ============================================================================
+// Shared dependency matrix: A(1) -> B(2) -> E(5), C(3) -> D(4) -> E(5).
+// ============================================================================
+
+TEST_CASE(SharedDepSurvivesCancel) {
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            // E is dispatching, with interest from both chains.
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            // Cancel request A: B's task exits and drops its edge on E,
+            // but D's task still holds interest — E must keep compiling.
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(ra.done);
+            EXPECT_FALSE(graph->is_compiling(2));
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            md.gate(5).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+        EXPECT_FALSE(graph->is_dirty(3));
+        EXPECT_TRUE(graph->is_dirty(1));
+    });
+}
+
+TEST_CASE(SharedDepBothCancelled) {
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            // Cancel both requests: E's interest drops to zero and its
+            // compilation is cancelled too.
+            ra.source.cancel();
+            rc.source.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_FALSE(graph->is_compiling(5));
+            EXPECT_TRUE(graph->is_dirty(5));
+            EXPECT_EQ(graph->refcount(5), 0u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_FALSE(rc.result.has_value());
+    });
+}
+
+TEST_CASE(SharedDepQueuedCancel) {
+    // E(5) itself depends on F(9); cancel A while E is still waiting for F,
+    // i.e. E is queued behind its own dependency rather than dispatching.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}},
+                   {5, {9}}
+    }));
+    md.open({1, 2, 3, 4, 5});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(9).started.wait();
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            // E keeps waiting for F; only the A-chain died.
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_TRUE(graph->is_compiling(9));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(9).calls, 1);
+
+            md.gate(9).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+        EXPECT_FALSE(graph->is_dirty(9));
+    });
+}
+
+TEST_CASE(SharedDepAlreadyCompiled) {
+    // E was already built by the A-chain; cancelling/finishing A afterwards
+    // must not invalidate it for the C-chain.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4, 5});
+
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r1.has_value() && *r1);
+        EXPECT_EQ(md.gate(5).calls, 1);
+
+        auto r2 = co_await graph->compile(3).catch_cancel();
+        EXPECT_TRUE(r2.has_value() && *r2);
+        // E was clean — not recompiled.
+        EXPECT_EQ(md.gate(5).calls, 1);
+    });
+}
+
+// ============================================================================
+// Update semantics: staleness-driven cancellation, waiters retry.
+// ============================================================================
+
+TEST_CASE(UpdateWhileWaitingDeps) {
+    // Update hits unit 1 while it waits for its dependency 2.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}}
+    }));
+    md.open({1});
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(2).started.wait();
+            EXPECT_TRUE(graph->is_compiling(1));
+
+            // Only unit 1 is updated; its round is cancelled while the
+            // waiter retries. Releasing its edge on 2 momentarily drops 2's
+            // interest to zero, so 2 restarts when the retry re-acquires it.
+            md.gate(2).started.reset();
+            graph->update(1);
+
+            co_await md.gate(2).started.wait();
+            EXPECT_EQ(md.gate(2).calls, 2);
+            md.gate(2).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+    });
+}
+
+TEST_CASE(UpdateDepCascadesCancel) {
+    // Updating a dependency cancels the in-flight rounds of its dependents;
+    // the request retries the whole chain and succeeds.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}}
+    }));
+    md.open({1, 2});
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(3).started.wait();
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_TRUE(graph->is_compiling(2));
+
+            md.gate(3).started.reset();
+            graph->update(3);
+            EXPECT_TRUE(graph->is_dirty(1));
+            EXPECT_TRUE(graph->is_dirty(2));
+            md.gate(3).proceed.set();
+
+            // The retry drives a fresh round through the chain.
+            co_await md.gate(3).started.wait();
+            EXPECT_EQ(md.gate(3).calls, 2);
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+        EXPECT_FALSE(graph->is_dirty(3));
+        // No further updates arrived — exactly one retry, no storm.
+        EXPECT_EQ(md.gate(3).calls, 2);
+    });
+}
+
+// ============================================================================
+// Failure semantics: no retry, edge references released.
+// ============================================================================
+
+TEST_CASE(FailedDepNoRetry) {
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}}
+    }));
+    md.gate(2).result = false;
+    md.open({1, 2});
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+        // Failure propagates without retry, and 1 is never dispatched.
+        EXPECT_EQ(md.gate(2).calls, 1);
+        EXPECT_EQ(md.gate(1).calls, 0);
+        // The failed round released its edge references.
+        EXPECT_EQ(graph->refcount(2), 0u);
+        EXPECT_EQ(graph->refcount(1), 0u);
+    });
+}
+
+TEST_CASE(RecompileAfterFailure) {
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}}
+    }));
+    md.gate(2).result = false;
+    md.open({1, 2});
+
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r1.has_value());
+        EXPECT_FALSE(*r1);
+
+        // Failure is not sticky: an explicit recompile tries again.
+        md.gate(2).result = true;
+        auto r2 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r2.has_value());
+        EXPECT_TRUE(*r2);
+        EXPECT_EQ(md.gate(2).calls, 2);
+        EXPECT_EQ(md.gate(1).calls, 1);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(2));
+    });
+}
+
+// ============================================================================
+// Cycles: all terminate with failure, never deadlock.
+// ============================================================================
+
+TEST_CASE(UpdateIntroducedCycle) {
+    // The cycle only appears after update() forces a re-resolve of unit 2.
+    bool flipped = false;
+    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+        if(path_id == 1) {
+            return {2};
+        }
+        if(path_id == 2 && flipped) {
+            return {1};
+        }
+        return {};
+    };
+
+    make_graph(instant_dispatch(), std::move(resolver));
+
+    execute([&]() -> kota::task<> {
+        auto r1 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r1.has_value() && *r1);
+
+        flipped = true;
+        graph->update(2);
+
+        auto r2 = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(r2.has_value());
+        EXPECT_FALSE(*r2);
+    });
+}
+
+TEST_CASE(PartitionedCycle) {
+    // The cycle (2 <-> 3) does not involve the requested root.
+    make_graph(instant_dispatch(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {3}},
+                   {3, {2}}
+    }));
+
+    execute([&]() -> kota::task<> {
+        auto result = co_await graph->compile(1).catch_cancel();
+        EXPECT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    });
+}
+
+// ============================================================================
+// Lifecycle: shutdown with tasks in flight.
+// ============================================================================
+
+TEST_CASE(ShutdownWithInflight) {
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   }
+    }));
+
+    Request req;
+    auto driver = [&]() -> kota::task<> {
+        co_await md.gate(4).started.wait();
+        // Cancel + join with several unit tasks in flight.
+        co_await graph->shutdown();
+        co_return;
+    };
+
+    auto t1 = run_request(1, req);
+    auto t2 = driver();
+    loop->schedule(t1);
+    loop->schedule(t2);
+    loop->run();
+
+    // The pending request resolves with failure once the graph refuses to
+    // respawn, and all bookkeeping is quiesced.
+    EXPECT_TRUE(req.done);
+    EXPECT_TRUE(req.result == false);
+    EXPECT_TRUE(graph->idle());
+}
+
+// ============================================================================
+// Randomized stress: seeded, single-threaded, deterministic.
+// ============================================================================
+
+TEST_CASE(RandomizedStress) {
+    int dispatch_calls = 0;
+    kota::semaphore permits{0};
+    auto dispatch = [&](std::uint32_t) -> kota::task<bool> {
+        dispatch_calls += 1;
+        co_await permits.acquire();
+        co_return true;
+    };
+
+    make_graph(std::move(dispatch),
+               static_resolver({
+                   {1, {2, 3}},
+                   {2, {4}   },
+                   {3, {4}   },
+                   {4, {5}   },
+                   {6, {4, 7}},
+                   {7, {5}   },
+                   {8, {6}   }
+    }));
+
+    execute([&]() -> kota::task<> {
+        std::mt19937 rng(20260612u);
+        std::vector<std::unique_ptr<Request>> requests;
+        kota::task_group<> inflight(*loop);
+
+        constexpr std::uint32_t roots[] = {1, 6, 8};
+        constexpr std::uint32_t nodes[] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+        for(int step = 0; step < 200; ++step) {
+            switch(rng() % 4) {
+                case 0: {
+                    auto& req = requests.emplace_back(std::make_unique<Request>());
+                    inflight.spawn(run_request(roots[rng() % 3], *req));
+                    break;
+                }
+                case 1: {
+                    if(!requests.empty()) {
+                        requests[rng() % requests.size()]->source.cancel();
+                    }
+                    break;
+                }
+                case 2: {
+                    graph->update(nodes[rng() % 8]);
+                    break;
+                }
+                case 3: {
+                    // Let one pending dispatch finish.
+                    permits.release();
+                    break;
+                }
+            }
+
+            // Let deferred unwinds land, then check structural sanity.
+            co_await kota::sleep(0);
+            EXPECT_TRUE(graph->consistent());
+        }
+
+        // Drain: cancel every outstanding request and wait for them all.
+        for(auto& req: requests) {
+            req->source.cancel();
+        }
+        co_await inflight.join();
     });
 }
 

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -136,6 +136,14 @@ kota::task<> run_request(std::uint32_t path_id, Request& req) {
     }
 }
 
+kota::task<> run_deps_request(std::uint32_t path_id, Request& req) {
+    auto result = co_await kota::with_token(graph->compile_deps(path_id), req.source.token());
+    req.done = true;
+    if(result.has_value()) {
+        req.result = *result;
+    }
+}
+
 TEST_CASE(CompileNoDeps) {
     make_graph(tracking_dispatch(compiled), no_deps());
 
@@ -807,9 +815,7 @@ TEST_CASE(CompileDepsResolveOnce) {
     });
 }
 
-// ============================================================================
 // Shared dependency matrix: A(1) -> B(2) -> E(5), C(3) -> D(4) -> E(5).
-// ============================================================================
 
 TEST_CASE(SharedDepSurvivesCancel) {
     ManualDispatch md;
@@ -856,15 +862,15 @@ TEST_CASE(SharedDepSurvivesCancel) {
 }
 
 TEST_CASE(SharedDepBothCancelled) {
+    // E is shared at different depths: depth 2 from A, depth 1 from C.
     ManualDispatch md;
     make_graph(md.fn(),
                static_resolver({
                    {1, {2}},
                    {2, {5}},
-                   {3, {4}},
-                   {4, {5}}
+                   {3, {5}}
     }));
-    md.open({1, 2, 3, 4});
+    md.open({1, 2, 3});
 
     Request ra, rc;
     execute([&]() -> kota::task<> {
@@ -935,6 +941,46 @@ TEST_CASE(SharedDepQueuedCancel) {
     });
 }
 
+TEST_CASE(CompileDepsCancelReleases) {
+    // A plain .cpp (10) holds root references on its direct deps; cancelling
+    // the compile_deps request releases them without killing a dependency
+    // that another consumer still needs.
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {10, {5}},
+                   {3,  {4}},
+                   {4,  {5}}
+    }));
+    md.open({3, 4});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            // Root reference from the compile_deps request + edge from 4.
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            EXPECT_TRUE(ra.done);
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            md.gate(5).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(run_deps_request(10, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_TRUE(rc.result == true);
+        EXPECT_FALSE(graph->is_dirty(5));
+    });
+}
+
 TEST_CASE(SharedDepAlreadyCompiled) {
     // E was already built by the A-chain; cancelling/finishing A afterwards
     // must not invalidate it for the C-chain.
@@ -960,9 +1006,7 @@ TEST_CASE(SharedDepAlreadyCompiled) {
     });
 }
 
-// ============================================================================
 // Update semantics: staleness-driven cancellation, waiters retry.
-// ============================================================================
 
 TEST_CASE(UpdateWhileWaitingDeps) {
     // Update hits unit 1 while it waits for its dependency 2.
@@ -1042,11 +1086,15 @@ TEST_CASE(UpdateDepCascadesCancel) {
             graph->update(3);
             EXPECT_TRUE(graph->is_dirty(1));
             EXPECT_TRUE(graph->is_dirty(2));
-            md.gate(3).proceed.set();
 
-            // The retry drives a fresh round through the chain.
+            // The cascade cancelled the in-flight rounds of 3 and its
+            // dependents; the surviving waiter drives a fresh chain, which
+            // restarts 3's dispatch.
             co_await md.gate(3).started.wait();
             EXPECT_EQ(md.gate(3).calls, 2);
+            EXPECT_TRUE(graph->is_compiling(1));
+            EXPECT_TRUE(graph->is_compiling(2));
+            md.gate(3).proceed.set();
             co_return;
         };
 
@@ -1062,9 +1110,7 @@ TEST_CASE(UpdateDepCascadesCancel) {
     });
 }
 
-// ============================================================================
 // Failure semantics: no retry, edge references released.
-// ============================================================================
 
 TEST_CASE(FailedDepNoRetry) {
     ManualDispatch md;
@@ -1114,9 +1160,43 @@ TEST_CASE(RecompileAfterFailure) {
     });
 }
 
-// ============================================================================
+TEST_CASE(CancelAllRespawns) {
+    ManualDispatch md;
+    make_graph(md.fn(), no_deps());
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        // cancel_all kills the in-flight round; the waiter still holds its
+        // interest, so it respawns the unit and succeeds.
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(1).started.wait();
+            md.gate(1).started.reset();
+            graph->cancel_all();
+            co_await md.gate(1).started.wait();
+            EXPECT_EQ(md.gate(1).calls, 2);
+            md.gate(1).proceed.set();
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+    });
+}
+
 // Cycles: all terminate with failure, never deadlock.
-// ============================================================================
 
 TEST_CASE(UpdateIntroducedCycle) {
     // The cycle only appears after update() forces a re-resolve of unit 2.
@@ -1162,9 +1242,7 @@ TEST_CASE(PartitionedCycle) {
     });
 }
 
-// ============================================================================
 // Lifecycle: shutdown with tasks in flight.
-// ============================================================================
 
 TEST_CASE(ShutdownWithInflight) {
     ManualDispatch md;
@@ -1196,15 +1274,11 @@ TEST_CASE(ShutdownWithInflight) {
     EXPECT_TRUE(graph->idle());
 }
 
-// ============================================================================
 // Randomized stress: seeded, single-threaded, deterministic.
-// ============================================================================
 
 TEST_CASE(RandomizedStress) {
-    int dispatch_calls = 0;
     kota::semaphore permits{0};
     auto dispatch = [&](std::uint32_t) -> kota::task<bool> {
-        dispatch_calls += 1;
         co_await permits.acquire();
         co_return true;
     };

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -898,6 +898,52 @@ TEST_CASE(SharedDepBothCancelled) {
     });
 }
 
+TEST_CASE(SharedDepSequentialCancel) {
+    // Mirror of SharedDepSurvivesCancel: cancel C first (E survives via the
+    // A-chain), then cancel A too (last interest gone, E dies).
+    ManualDispatch md;
+    make_graph(md.fn(),
+               static_resolver({
+                   {1, {2}},
+                   {2, {5}},
+                   {3, {4}},
+                   {4, {5}}
+    }));
+    md.open({1, 2, 3, 4});
+
+    Request ra, rc;
+    execute([&]() -> kota::task<> {
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(5).started.wait();
+            EXPECT_EQ(graph->refcount(5), 2u);
+
+            rc.source.cancel();
+            co_await kota::sleep(1);
+
+            // D's edge dropped; B still holds interest — E keeps compiling.
+            EXPECT_FALSE(graph->is_compiling(4));
+            EXPECT_TRUE(graph->is_compiling(5));
+            EXPECT_EQ(graph->refcount(5), 1u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+
+            ra.source.cancel();
+            co_await kota::sleep(1);
+
+            // Last interest gone — now E is cancelled.
+            EXPECT_FALSE(graph->is_compiling(5));
+            EXPECT_TRUE(graph->is_dirty(5));
+            EXPECT_EQ(graph->refcount(5), 0u);
+            EXPECT_EQ(md.gate(5).calls, 1);
+            co_return;
+        };
+
+        co_await kota::when_all(run_request(1, ra), run_request(3, rc), driver());
+
+        EXPECT_FALSE(ra.result.has_value());
+        EXPECT_FALSE(rc.result.has_value());
+    });
+}
+
 TEST_CASE(SharedDepQueuedCancel) {
     // E(5) itself depends on F(9); cancel A while E is still waiting for F,
     // i.e. E is queued behind its own dependency rather than dispatching.
@@ -1107,6 +1153,64 @@ TEST_CASE(UpdateDepCascadesCancel) {
         EXPECT_FALSE(graph->is_dirty(3));
         // No further updates arrived — exactly one retry, no storm.
         EXPECT_EQ(md.gate(3).calls, 2);
+    });
+}
+
+TEST_CASE(UpdateSwapsDeps) {
+    // Unit 1's import set changes from {2} to {3} while its round is in
+    // flight waiting on 2. The retry re-resolves, releases the orphaned edge
+    // on 2 (cancelling 2's now-unwanted round) and acquires 3 instead.
+    bool flipped = false;
+    auto resolver = [&](std::uint32_t path_id) -> llvm::SmallVector<std::uint32_t> {
+        if(path_id == 1) {
+            return flipped ? llvm::SmallVector<std::uint32_t>{3}
+                           : llvm::SmallVector<std::uint32_t>{2};
+        }
+        return {};
+    };
+
+    ManualDispatch md;
+    make_graph(md.fn(), std::move(resolver));
+    md.open({1, 3});
+
+    execute([&]() -> kota::task<> {
+        bool done = false;
+        std::optional<bool> result;
+
+        auto compiler = [&]() -> kota::task<> {
+            auto r = co_await graph->compile(1).catch_cancel();
+            done = true;
+            if(r.has_value()) {
+                result = *r;
+            }
+        };
+
+        auto driver = [&]() -> kota::task<> {
+            co_await md.gate(2).started.wait();
+            EXPECT_TRUE(graph->is_compiling(1));
+
+            flipped = true;
+            graph->update(1);
+
+            // The retry resolves the new dependency and never restarts 2.
+            co_await md.gate(3).started.wait();
+            EXPECT_EQ(md.gate(2).calls, 1);
+            EXPECT_EQ(md.gate(3).calls, 1);
+            co_return;
+        };
+
+        co_await kota::when_all(compiler(), driver());
+
+        EXPECT_TRUE(done);
+        EXPECT_TRUE(result == true);
+        EXPECT_FALSE(graph->is_dirty(1));
+        EXPECT_FALSE(graph->is_dirty(3));
+        // The orphaned dependency stays dirty and fully detached: updating
+        // it no longer cascades to 1.
+        EXPECT_TRUE(graph->is_dirty(2));
+        auto dirtied = graph->update(2);
+        EXPECT_EQ(dirtied.size(), 1u);
+        EXPECT_FALSE(graph->is_dirty(1));
     });
 }
 


### PR DESCRIPTION
## Background

clice compiles C++20 module dependencies through `CompileGraph`: each module interface unit is a node, `resolve` lazily discovers its imports, and `dispatch` builds the PCM. Overlapping dependency closures are the normal case — two open files importing different modules that share a common dependency.

The previous cancellation model propagated cancellation through a token tree: a requester wrapped every dependency task in `with_token(...)` of its own source, recursively, and dependency compilations ran nested inside the requester's coroutine frames. That model has a structural mismatch with the problem:

1. **Dependencies form a DAG; token trees are trees.** With `A → B → E` and `C → D → E`, E's compilation runs inside whichever request got there first — say A's. Cancelling the A request tears down its whole coroutine tree and kills E's in-flight build, even though the C request still needs it. There was no notion of "who else is interested in E".
2. **Two unrelated cancellation reasons shared one mechanism.** "This request no longer needs the result" (request cancelled, import switched away) and "the source changed on disk, the in-flight result is garbage" (file update) were both expressed as `source->cancel()` inside `update()`, entangled with dirty-marking.
3. **Waiters treated every cancellation as failure.** A waiter woken by a cancelled compilation returned failure, even when the right reaction was "the result went stale — retry with the new content".

## Design

The core shift: **execution is decoupled from interest.**

**Execution** — each dirty unit compiles in an independent task spawned into a graph-owned `task_group`, cancellable only through its own per-round token. Requesters and dependent units no longer own child coroutine frames; they wait on a per-round completion event. A requester dying implies nothing, by itself, about the units it was waiting on.

**Interest** — an explicit per-unit count of in-flight demand: a request holds a root reference on the unit(s) it asked for; a running unit task holds an edge reference on each direct dependency. A unit whose count *stays* at zero for one event-loop tick while compiling has its round cancelled. The one-tick deferral matters: an interest drop is often transient — a stale round's edges being re-acquired by the retry that re-resolves it — and synchronous re-acquisition always lands within the same drain cycle, strictly before the deferred check fires. So when a unit's import set changes from `{B, C}` to `{B, E}` mid-compile, the retained B is handed over to the new round (neither cancelled nor restarted, at any cascade depth), while the orphaned C is cancelled one tick later. Cancellation cascades structurally — the dying task's guard releases its edge references, which may zero out further dependencies — and stops exactly where shared interest remains: cancel the A request and A, B unwind while E drops 2 → 1 and keeps compiling.

Edge references were chosen over counting each request's transitive closure deliberately: the closure is *lazily discovered* (`resolve` runs on first compile), so closure-counting would need per-request acquired-sets with incremental backfill as resolution proceeds. Edge counting needs zero global bookkeeping and yields the same outcomes.

The two cancellation reasons are now distinct operations:

- **Loss of interest** (reference-driven): release → zero → cancel that unit's round. "Nobody needs this."
- **Staleness** (`update()`): mark the unit and its transitive dependents dirty, bump their generation, cancel their in-flight rounds unconditionally — interest untouched. "The source changed; the results are garbage, but everybody still wants them."

What a waiter does next is decided by a three-state round outcome rather than a boolean:

- **Success** → done.
- **Failed** (compile error, dependency cycle) → propagate failure, never retry: retrying failures would turn an A↔B cycle or a plain syntax error into a retry storm.
- **Stale** (round cancelled) → a waiter that still holds interest becomes the new driver and respawns the unit. Retries are naturally bounded — each consumes one staleness event; no new `update()`, no further retry.

### Cancellation safety

kotatsu cancels by *frame destruction without resumption*: a cancelled coroutine never executes another statement past its suspension point — only destructors of already-constructed locals run. All per-round bookkeeping therefore lives in a single scope guard constructed before the unit task's first suspension: publish the outcome (default stale — the cancel path can't reach an explicit assignment), clear the compiling flag, release acquired edge references (possibly cancelling zero-interest dependencies — a synchronous primitive, safe in a destructor), fire the completion event. Edge acquisition is likewise fully synchronous, so no suspension can strand a half-registered reference.

Two kotatsu behaviors shaped the implementation and are worth knowing for review:

- `task_group` is fail-fast structured concurrency: one child finishing `Cancelled` aborts every sibling and permanently blocks new spawns. Since a cancelled round is the *normal* case here, rounds are spawned through a thin wrapper that converts the cancellation into a value, so every child finishes `Finished`. (Found empirically by the shared-dependency tests: "cancelling A killed C's entire chain".)
- `task_group` reclaims child frames only at destruction, so frames accumulate one per round until shutdown — the same trade-off as the compiler's existing AST-compile group; documented in code as a candidate kotatsu-side improvement.

### The import-switch handoff

The headline scenario: a file says `import A`, the build is in flight, the user switches to `import C`, and both chains share E. The old request's interest must go away — but if it disappears *before* the new request registers its own, E transits through zero and is killed and restarted anyway.

`ensure_compiled` therefore supersedes a stale in-flight compile in a fixed order: spawn the replacement first — it descends the new dependency chain and acquires interest synchronously (spawned tasks run to their first suspension immediately, while cancellation only lands on the next event-loop tick) — then cancel the superseded request's dependency scope. Interest on shared units overlaps across the swap; E never sees zero.

Reviewing this path surfaced two ordering hazards, both fixed here: a superseded compile re-checks the session generation before sending text to the stateful worker (the worker applies compiles in arrival order with no version check, so a stale send landing after the replacement would leave the worker on old text), and a superseded round abandons its remaining preparation instead of continuing into the PCH build.

### Cycle handling

The old ancestor-set threading cannot survive the move to independent tasks — there is no call chain to thread it through. Cycles are caught where they manifest: a self-import directly after resolve, and a would-deadlock wait — before blocking on a dependency, the waiter walks currently-compiling units' dependency edges to check whether the chain leads back to itself. Detected cycles fail the unit (no retry), including cycles that only appear after `update()` re-resolves a changed import set. Surfacing them as file-level diagnostics is follow-up work.

## Testing

The strategy is deterministic cancellation injection: a manually gated mock dispatch parks any unit mid-dispatch, the test observes interest counts at that instant, injects a request cancellation / update / shutdown, and asserts which compilations survived — by liveness, refcount, and dispatch-call counts, not just final success. Every test tears down through `shutdown()` and asserts the graph is fully quiesced (zero refcounts, no compiling residue, every completion fired); a fixed-seed randomized stress run interleaves compiles, cancellations, updates and completions with per-step structural checks.

Two integration cases run the headline scenarios against real clang module builds: switching the import target neither kills nor restarts the shared dependency (one dispatch, one PCM), and a shared dependency failing fails both consumers from a single round. Unit cases additionally pin down both cancellation directions of a shared dependency (stepwise refcount 2 → 1 → 0) and the in-flight import-set change (retained dependency handed over with a single dispatch, orphan cancelled and fully detached).

All pre-existing cases are preserved. One changes meaning intentionally: a file update during compilation used to fail the waiting request; it now retries once and succeeds, asserted by exact dispatch counts.

Verified locally on Debug and RelWithDebInfo: 615 unit / 172 integration / 2 smoke tests passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked compilation lifecycle to per-round orchestration with deterministic cancellation, interest-counted dependency management, improved deadlock detection, generation-based supersession of in‑flight compiles, and structured shutdown that cancels and joins running work.

* **New Features**
  * Added runtime diagnostics to query per‑unit refcount/idle/consistency and support for per-request cancellation scopes and safer dependency await semantics.

* **Tests**
  * Expanded deterministic, concurrency, and shutdown tests covering shared dependencies, cancellation/retry, failure propagation, and graph consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
