### PR TITLE
feat(server): error feedback channels and structured logging

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -41,7 +41,7 @@ set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG 0b38494
+    GIT_TAG 60661c15e0a13e29e59443b470e83c3b2b60fb0d
 )
 
 set(KOTA_ENABLE_ZEST ON)

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -41,7 +41,7 @@ set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG 60661c15e0a13e29e59443b470e83c3b2b60fb0d
+    GIT_TAG 0b38494
 )
 
 set(KOTA_ENABLE_ZEST ON)

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -422,7 +422,10 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
             results.push_back(build_command(path_id, entry.info, options));
         }
     } else {
-        // No matching entry — synthesize a default command.
+        // No matching entry — synthesize a default command. Config rule
+        // appends still apply: users without a CDB rely on them to supply
+        // include paths. (Removes target flags of real CDB commands; there
+        // is nothing to remove from the two-flag default.)
         std::vector<const char*> flags;
         if(file.ends_with(".cpp") || file.ends_with(".hpp") || file.ends_with(".cc")) {
             flags = {"clang++", "-std=c++20"};
@@ -432,6 +435,9 @@ llvm::SmallVector<CompileCommand> CompilationDatabase::lookup(llvm::StringRef fi
         if(options.inject_resource_dir && !resource_dir().empty()) {
             flags.push_back(strings.save("-resource-dir").data());
             flags.push_back(strings.save(resource_dir()).data());
+        }
+        for(auto& arg: options.append) {
+            flags.push_back(strings.save(arg).data());
         }
         results.push_back(CompileCommand{
             ResolvedFlags{{}, std::move(flags), false},

--- a/src/compile/diagnostic.cpp
+++ b/src/compile/diagnostic.cpp
@@ -70,7 +70,11 @@ std::optional<std::string> DiagnosticID::diagnostic_document_uri() const {
         }
 
         case DiagnosticSource::Clice: {
-            /// TODO: Add diagnostic for clice.
+            // clice's own guidance diagnostics link to the setup guide that
+            // explains how to provide a compilation database.
+            if(name == "inferred-compile-command") {
+                return "https://clice.io/en/guide/quick-start";
+            }
             return std::nullopt;
         }
     }

--- a/src/feature/code_completion.cpp
+++ b/src/feature/code_completion.cpp
@@ -256,10 +256,11 @@ public:
         FuzzyMatcher matcher(prefix.spelling);
 
         LineMap map(content, encoding);
-        auto replace_range = protocol::Range{
-            .start = to_position(map, prefix.range.begin),
-            .end = to_position(map, prefix.range.end),
-        };
+        auto start_pos = to_position(map, prefix.range.begin);
+        auto end_pos = to_position(map, prefix.range.end);
+        if(!start_pos || !end_pos)
+            return;
+        auto replace_range = protocol::Range{.start = *start_pos, .end = *end_pos};
 
         std::vector<protocol::CompletionItem> collected;
         collected.reserve(candidate_count);

--- a/src/feature/code_completion.cpp
+++ b/src/feature/code_completion.cpp
@@ -256,7 +256,10 @@ public:
         FuzzyMatcher matcher(prefix.spelling);
 
         LineMap map(content, encoding);
-        auto replace_range = *map.to_range(prefix.range.begin, prefix.range.end);
+        auto replace_range = protocol::Range{
+            .start = to_position(map, prefix.range.begin),
+            .end = to_position(map, prefix.range.end),
+        };
 
         std::vector<protocol::CompletionItem> collected;
         collected.reserve(candidate_count);

--- a/src/feature/code_completion.cpp
+++ b/src/feature/code_completion.cpp
@@ -256,11 +256,10 @@ public:
         FuzzyMatcher matcher(prefix.spelling);
 
         LineMap map(content, encoding);
-        auto start_pos = to_position(map, prefix.range.begin);
-        auto end_pos = to_position(map, prefix.range.end);
-        if(!start_pos || !end_pos)
+        auto range = to_range(map, prefix.range);
+        if(!range)
             return;
-        auto replace_range = protocol::Range{.start = *start_pos, .end = *end_pos};
+        auto replace_range = *range;
 
         std::vector<protocol::CompletionItem> collected;
         collected.reserve(candidate_count);

--- a/src/feature/diagnostics.cpp
+++ b/src/feature/diagnostics.cpp
@@ -151,7 +151,10 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
         auto offset = unit.file_offset(include_location);
         auto end_offset =
             static_cast<std::uint32_t>(offset + unit.token_spelling(include_location).size());
-        diagnostic.range = *map.to_range(offset, end_offset);
+        diagnostic.range = protocol::Range{
+            .start = to_position(map, offset),
+            .end = to_position(map, end_offset),
+        };
 
         current = std::move(diagnostic);
     }

--- a/src/feature/diagnostics.cpp
+++ b/src/feature/diagnostics.cpp
@@ -151,10 +151,11 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
         auto offset = unit.file_offset(include_location);
         auto end_offset =
             static_cast<std::uint32_t>(offset + unit.token_spelling(include_location).size());
-        diagnostic.range = protocol::Range{
-            .start = to_position(map, offset),
-            .end = to_position(map, end_offset),
-        };
+        auto start_pos = to_position(map, offset);
+        auto end_pos = to_position(map, end_offset);
+        if(!start_pos || !end_pos)
+            continue;
+        diagnostic.range = protocol::Range{.start = *start_pos, .end = *end_pos};
 
         current = std::move(diagnostic);
     }

--- a/src/feature/diagnostics.cpp
+++ b/src/feature/diagnostics.cpp
@@ -49,11 +49,15 @@ void add_related(protocol::Diagnostic& diagnostic,
     auto content = unit.file_content(raw.fid);
     LineMap map(content, encoding);
 
+    auto range = to_range(map, raw.range);
+    if(!range)
+        return;
+
     protocol::DiagnosticRelatedInformation related{
         .location =
             protocol::Location{
                                .uri = to_uri(unit.file_path(raw.fid)),
-                               .range = *map.to_range(raw.range.begin, raw.range.end),
+                               .range = *range,
                                },
         .message = raw.message,
     };
@@ -133,7 +137,10 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
         }
 
         if(raw.fid == unit.interested_file()) {
-            diagnostic.range = *map.to_range(raw.range.begin, raw.range.end);
+            auto range = to_range(map, raw.range);
+            if(!range)
+                continue;
+            diagnostic.range = *range;
             current = std::move(diagnostic);
             continue;
         }
@@ -151,11 +158,10 @@ auto diagnostics(CompilationUnitRef unit, PositionEncoding encoding)
         auto offset = unit.file_offset(include_location);
         auto end_offset =
             static_cast<std::uint32_t>(offset + unit.token_spelling(include_location).size());
-        auto start_pos = to_position(map, offset);
-        auto end_pos = to_position(map, end_offset);
-        if(!start_pos || !end_pos)
+        auto range = to_range(map, {offset, end_offset});
+        if(!range)
             continue;
-        diagnostic.range = protocol::Range{.start = *start_pos, .end = *end_pos};
+        diagnostic.range = *range;
 
         current = std::move(diagnostic);
     }

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -29,7 +29,10 @@ auto document_links(CompilationUnitRef unit, PositionEncoding encoding)
         auto range = find_directive_argument(content, offset, lang_opts);
         if(!range)
             return;
-        protocol::DocumentLink link{.range = *map.to_range(range->begin, range->end)};
+        auto protocol_range = to_range(map, *range);
+        if(!protocol_range)
+            return;
+        protocol::DocumentLink link{.range = *protocol_range};
         link.target = target.str();
         links.push_back(std::move(link));
     };

--- a/src/feature/document_symbols.cpp
+++ b/src/feature/document_symbols.cpp
@@ -179,12 +179,17 @@ void sort_symbols(std::vector<DocumentSymbol>& symbols) {
 }
 
 auto to_protocol_symbol(const DocumentSymbol& symbol, const LineMap& map)
-    -> protocol::DocumentSymbol {
+    -> std::optional<protocol::DocumentSymbol> {
+    auto range = to_range(map, symbol.range);
+    auto selection_range = to_range(map, symbol.selection_range);
+    if(!range || !selection_range)
+        return std::nullopt;
+
     protocol::DocumentSymbol result{
         .name = symbol.name,
         .kind = to_protocol_symbol_kind(symbol.kind),
-        .range = *map.to_range(symbol.range.begin, symbol.range.end),
-        .selection_range = *map.to_range(symbol.selection_range.begin, symbol.selection_range.end),
+        .range = *range,
+        .selection_range = *selection_range,
     };
 
     if(!symbol.detail.empty()) {
@@ -195,8 +200,10 @@ auto to_protocol_symbol(const DocumentSymbol& symbol, const LineMap& map)
         std::vector<std::shared_ptr<protocol::DocumentSymbol>> children;
         children.reserve(symbol.children.size());
         for(const auto& child: symbol.children) {
-            children.push_back(
-                std::make_shared<protocol::DocumentSymbol>(to_protocol_symbol(child, map)));
+            if(auto converted = to_protocol_symbol(child, map)) {
+                children.push_back(
+                    std::make_shared<protocol::DocumentSymbol>(std::move(*converted)));
+            }
         }
         result.children = std::move(children);
     }
@@ -221,7 +228,9 @@ auto document_symbols(CompilationUnitRef unit, PositionEncoding encoding)
     symbols.reserve(internal.size());
 
     for(const auto& symbol: internal) {
-        symbols.push_back(to_protocol_symbol(symbol, map));
+        if(auto converted = to_protocol_symbol(symbol, map)) {
+            symbols.push_back(std::move(*converted));
+        }
     }
 
     return symbols;

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -8,6 +8,7 @@
 #include "compile/compilation.h"
 #include "compile/compilation_unit.h"
 #include "semantic/symbol_kind.h"
+#include "support/anomaly.h"
 #include "support/markup.h"
 
 #include "kota/ipc/lsp/position.h"
@@ -21,8 +22,20 @@ namespace protocol = kota::ipc::protocol;
 using kota::ipc::lsp::LineMap;
 using kota::ipc::lsp::PositionEncoding;
 
-// FIXME: feature code uses *map.to_range() without checking the optional.
-// Need a strategy for handling out-of-range offsets gracefully.
+inline auto to_position(const LineMap& map, std::uint32_t offset) -> protocol::Position {
+    if(auto position = map.to_position(offset)) {
+        return *position;
+    }
+    LOG_ANOMALY(PositionMapFail, "offset {} cannot be mapped to a position", offset);
+    return protocol::Position{.line = 0, .character = 0};
+}
+
+inline auto to_range(const LineMap& map, LocalSourceRange range) -> protocol::Range {
+    return protocol::Range{
+        .start = to_position(map, range.begin),
+        .end = to_position(map, range.end),
+    };
+}
 
 struct CodeCompletionOptions {
     bool enable_keyword_snippet = false;

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -22,19 +22,21 @@ namespace protocol = kota::ipc::protocol;
 using kota::ipc::lsp::LineMap;
 using kota::ipc::lsp::PositionEncoding;
 
-inline auto to_position(const LineMap& map, std::uint32_t offset) -> protocol::Position {
+inline auto to_position(const LineMap& map, std::uint32_t offset)
+    -> std::optional<protocol::Position> {
     if(auto position = map.to_position(offset)) {
         return *position;
     }
     LOG_ANOMALY(PositionMapFail, "offset {} cannot be mapped to a position", offset);
-    return protocol::Position{.line = 0, .character = 0};
+    return std::nullopt;
 }
 
-inline auto to_range(const LineMap& map, LocalSourceRange range) -> protocol::Range {
-    return protocol::Range{
-        .start = to_position(map, range.begin),
-        .end = to_position(map, range.end),
-    };
+inline auto to_range(const LineMap& map, LocalSourceRange range) -> std::optional<protocol::Range> {
+    auto start = to_position(map, range.begin);
+    auto end = to_position(map, range.end);
+    if(!start || !end)
+        return std::nullopt;
+    return protocol::Range{.start = *start, .end = *end};
 }
 
 struct CodeCompletionOptions {

--- a/src/feature/folding_ranges.cpp
+++ b/src/feature/folding_ranges.cpp
@@ -357,12 +357,14 @@ auto folding_ranges(CompilationUnitRef unit, PositionEncoding encoding)
     for(const auto& item: collected) {
         auto start = to_position(map, item.range.begin);
         auto end = to_position(map, item.range.end);
+        if(!start || !end)
+            continue;
 
         protocol::FoldingRange range{
-            .start_line = start.line,
-            .start_character = start.character,
-            .end_line = end.line,
-            .end_character = end.character,
+            .start_line = start->line,
+            .start_character = start->character,
+            .end_line = end->line,
+            .end_character = end->character,
         };
 
         if(item.kind.has_value()) {

--- a/src/feature/folding_ranges.cpp
+++ b/src/feature/folding_ranges.cpp
@@ -355,7 +355,8 @@ auto folding_ranges(CompilationUnitRef unit, PositionEncoding encoding)
     result.reserve(collected.size());
 
     for(const auto& item: collected) {
-        auto [start, end] = *map.to_range(item.range.begin, item.range.end);
+        auto start = to_position(map, item.range.begin);
+        auto end = to_position(map, item.range.end);
 
         protocol::FoldingRange range{
             .start_line = start.line,

--- a/src/feature/formatting.cpp
+++ b/src/feature/formatting.cpp
@@ -59,10 +59,11 @@ auto document_format(llvm::StringRef file,
         auto begin = replacement.getOffset();
         auto end = begin + replacement.getLength();
         protocol::TextEdit edit{
-            .range = protocol::Range{
-                .start = to_position(map, begin),
-                .end = to_position(map, end),
-            },
+            .range =
+                protocol::Range{
+                                .start = to_position(map, begin),
+                                .end = to_position(map, end),
+                                },
             .new_text = replacement.getReplacementText().str(),
         };
         edits.push_back(std::move(edit));

--- a/src/feature/formatting.cpp
+++ b/src/feature/formatting.cpp
@@ -58,12 +58,12 @@ auto document_format(llvm::StringRef file,
     for(const auto& replacement: *replacements) {
         auto begin = replacement.getOffset();
         auto end = begin + replacement.getLength();
+        auto start_pos = to_position(map, begin);
+        auto end_pos = to_position(map, end);
+        if(!start_pos || !end_pos)
+            continue;
         protocol::TextEdit edit{
-            .range =
-                protocol::Range{
-                                .start = to_position(map, begin),
-                                .end = to_position(map, end),
-                                },
+            .range = protocol::Range{.start = *start_pos, .end = *end_pos},
             .new_text = replacement.getReplacementText().str(),
         };
         edits.push_back(std::move(edit));

--- a/src/feature/formatting.cpp
+++ b/src/feature/formatting.cpp
@@ -59,7 +59,10 @@ auto document_format(llvm::StringRef file,
         auto begin = replacement.getOffset();
         auto end = begin + replacement.getLength();
         protocol::TextEdit edit{
-            .range = *map.to_range(begin, end),
+            .range = protocol::Range{
+                .start = to_position(map, begin),
+                .end = to_position(map, end),
+            },
             .new_text = replacement.getReplacementText().str(),
         };
         edits.push_back(std::move(edit));

--- a/src/feature/formatting.cpp
+++ b/src/feature/formatting.cpp
@@ -56,14 +56,13 @@ auto document_format(llvm::StringRef file,
     LineMap map(content, encoding);
 
     for(const auto& replacement: *replacements) {
-        auto begin = replacement.getOffset();
-        auto end = begin + replacement.getLength();
-        auto start_pos = to_position(map, begin);
-        auto end_pos = to_position(map, end);
-        if(!start_pos || !end_pos)
+        auto begin = static_cast<std::uint32_t>(replacement.getOffset());
+        auto end = static_cast<std::uint32_t>(begin + replacement.getLength());
+        auto range = to_range(map, {begin, end});
+        if(!range)
             continue;
         protocol::TextEdit edit{
-            .range = protocol::Range{.start = *start_pos, .end = *end_pos},
+            .range = *range,
             .new_text = replacement.getReplacementText().str(),
         };
         edits.push_back(std::move(edit));

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -1311,7 +1311,7 @@ auto to_protocol_hover(CompilationUnitRef unit,
 
     if(info.symbol_range) {
         LineMap map(unit.interested_content(), unit.line_starts(), encoding);
-        result.range = *map.to_range(info.symbol_range->begin, info.symbol_range->end);
+        result.range = to_range(map, *info.symbol_range);
     }
 
     return result;

--- a/src/feature/inlay_hints.cpp
+++ b/src/feature/inlay_hints.cpp
@@ -935,7 +935,7 @@ auto inlay_hints(CompilationUnitRef unit,
 
     for(const auto& hint: collected) {
         protocol::InlayHint out{
-            .position = *map.to_position(hint.offset),
+            .position = to_position(map, hint.offset),
             .label = hint.label,
         };
 

--- a/src/feature/inlay_hints.cpp
+++ b/src/feature/inlay_hints.cpp
@@ -934,8 +934,11 @@ auto inlay_hints(CompilationUnitRef unit,
     hints.reserve(collected.size());
 
     for(const auto& hint: collected) {
+        auto pos = to_position(map, hint.offset);
+        if(!pos)
+            continue;
         protocol::InlayHint out{
-            .position = to_position(map, hint.offset),
+            .position = *pos,
             .label = hint.label,
         };
 

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -496,10 +496,12 @@ public:
         auto end = token.range.end;
         auto begin_position = to_position(map, begin);
         auto end_position = to_position(map, end);
-        auto begin_line = static_cast<std::uint32_t>(begin_position.line);
-        auto begin_char = static_cast<std::uint32_t>(begin_position.character);
-        auto end_line = static_cast<std::uint32_t>(end_position.line);
-        auto end_char = static_cast<std::uint32_t>(end_position.character);
+        if(!begin_position || !end_position)
+            return;
+        auto begin_line = static_cast<std::uint32_t>(begin_position->line);
+        auto begin_char = static_cast<std::uint32_t>(begin_position->character);
+        auto end_line = static_cast<std::uint32_t>(end_position->line);
+        auto end_char = static_cast<std::uint32_t>(end_position->character);
 
         if(begin_line == end_line) [[likely]] {
             auto delta_line = begin_line - last_line;

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -494,8 +494,8 @@ public:
 
         auto begin = token.range.begin;
         auto end = token.range.end;
-        auto begin_position = *map.to_position(begin);
-        auto end_position = *map.to_position(end);
+        auto begin_position = to_position(map, begin);
+        auto end_position = to_position(map, end);
         auto begin_line = static_cast<std::uint32_t>(begin_position.line);
         auto begin_char = static_cast<std::uint32_t>(begin_position.character);
         auto end_line = static_cast<std::uint32_t>(end_position.line);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -237,14 +237,8 @@ static void log_command_decision(llvm::StringRef path,
                                  llvm::ArrayRef<llvm::StringRef> tried,
                                  CommandSource source,
                                  llvm::ArrayRef<std::string> arguments) {
-    if(clice::logging::options.level > clice::logging::Level::info)
+    if(logging::options.level > logging::Level::info)
         return;
-    std::string tried_text;
-    for(auto tier: tried) {
-        if(!tried_text.empty())
-            tried_text += ",";
-        tried_text += tier;
-    }
     std::string joined;
     for(auto& arg: arguments) {
         joined += arg;
@@ -252,7 +246,7 @@ static void log_command_decision(llvm::StringRef path,
     }
     LOG_INFO("compile_args: file={} tried=[{}] source={} args_hash={:016x}",
              path,
-             tried_text,
+             llvm::join(tried, ","),
              command_source_name(source),
              llvm::xxh3_64bits(llvm::StringRef(joined)));
 }
@@ -272,10 +266,13 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
             log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
             return CommandSource::IncludeGraph;
         }
-    } else if(workspace.cdb.has_entry(path)) {
-        // 2. Real CDB entry for the file itself.
-        //    Apply rules from config (append/remove flags based on file patterns).
-        tried.push_back("cdb");
+    }
+
+    // 2. Real CDB entry for the file itself (lookup() synthesizes a command
+    //    for unknown files, so a non-empty result alone proves nothing).
+    //    Apply rules from config (append/remove flags based on file patterns).
+    tried.push_back("cdb");
+    if(workspace.cdb.has_entry(path)) {
         std::vector<std::string> rule_append, rule_remove;
         workspace.config.match_rules(path, rule_append, rule_remove);
         auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
@@ -285,9 +282,10 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
         arguments = cmd.to_string_argv();
         log_command_decision(path, tried, CommandSource::CdbExact, arguments);
         return CommandSource::CdbExact;
-    } else {
-        // 3. No CDB entry — try automatic header context resolution.
-        tried.push_back("cdb");
+    }
+
+    // 3. No CDB entry — try automatic header context resolution.
+    if(!(session && session->active_context.has_value())) {
         tried.push_back("include_graph");
         if(fill_header_context_args(path, path_id, directory, arguments, session)) {
             log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
@@ -347,16 +345,17 @@ bool Compiler::fill_header_context_args(llvm::StringRef path,
     }
 
     auto host_path = workspace.path_pool.resolve(ctx_ptr->host_path_id);
+    if(!workspace.cdb.has_entry(host_path)) {
+        LOG_WARN("fill_header_context_args: host {} has no CDB entry", host_path);
+        return false;
+    }
+
     // Apply rules matching the HEADER path (what the user is editing) on top of
     // the host's command — rules are expected to apply uniformly to every file.
     std::vector<std::string> rule_append, rule_remove;
     workspace.config.match_rules(path, rule_append, rule_remove);
     auto host_results =
         workspace.cdb.lookup(host_path, {.remove = rule_remove, .append = rule_append});
-    if(host_results.empty()) {
-        LOG_WARN("fill_header_context_args: host {} has no CDB entry", host_path);
-        return false;
-    }
 
     workspace.toolchain.resolve_or_warn(host_results.front());
 
@@ -397,8 +396,7 @@ std::optional<HeaderFileContext> Compiler::resolve_header_context(std::uint32_t 
     if(session && session->active_context.has_value()) {
         auto preferred = *session->active_context;
         auto preferred_path = workspace.path_pool.resolve(preferred);
-        auto results = workspace.cdb.lookup(preferred_path);
-        if(!results.empty()) {
+        if(workspace.cdb.has_entry(preferred_path)) {
             auto c = workspace.dep_graph.find_include_chain(preferred, header_path_id);
             if(!c.empty()) {
                 host_path_id = preferred;
@@ -407,12 +405,12 @@ std::optional<HeaderFileContext> Compiler::resolve_header_context(std::uint32_t 
         }
     }
 
-    // Fall back to the first available host that has a CDB entry.
+    // Fall back to the first available host that has a real CDB entry —
+    // a host with a synthesized command would just be a fallback in disguise.
     if(chain.empty()) {
         for(auto candidate: hosts) {
             auto candidate_path = workspace.path_pool.resolve(candidate);
-            auto results = workspace.cdb.lookup(candidate_path);
-            if(results.empty())
+            if(!workspace.cdb.has_entry(candidate_path))
                 continue;
             auto c = workspace.dep_graph.find_include_chain(candidate, header_path_id);
             if(c.empty())

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -706,6 +706,14 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         co_return false;
     }
 
+    // Commit on the thread pool: it fsyncs the freshly written PCH.
+    auto committed =
+        co_await kota::queue([&] { return workspace.store->commit(std::move(pending)); });
+    if(!committed.has_value() || !committed.value().has_value()) {
+        LOG_WARN("Failed to commit PCH for {}", path);
+        co_return false;
+    }
+
     auto& st = workspace.pch_cache[path_id];
     st.path = committed.value().value();
     st.bound = bound;
@@ -878,10 +886,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     params.path = file_path;
     params.version = session->version;
     params.text = session->text;
-    if(!fill_compile_args(file_path, params.directory, params.arguments, session.get())) {
-        finish_compile();
-        co_return;
-    }
+    auto source = fill_compile_args(file_path, params.directory, params.arguments, session.get());
 
     bool deps_ok = co_await ensure_deps(*session,
                                         params.directory,
@@ -1098,9 +1103,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     wp.file = path;
     wp.version = session->version;
     wp.text = session->text;
-    if(!fill_compile_args(path, wp.directory, wp.arguments, session.get())) {
-        co_return kota::outcome_error(kota::ipc::Error{"Failed to fill compile arguments"});
-    }
+    fill_compile_args(path, wp.directory, wp.arguments, session.get());
 
     if(!co_await ensure_deps(*session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
         LOG_WARN("forward_build: dependency preparation failed for {}", path);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1,13 +1,16 @@
 #include "server/compiler/compiler.h"
 
+#include <algorithm>
 #include <format>
 #include <ranges>
 #include <string>
 
 #include "command/argument_parser.h"
 #include "command/search_config.h"
+#include "compile/diagnostic.h"
 #include "index/tu_index.h"
 #include "server/protocol/worker.h"
+#include "support/anomaly.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 #include "syntax/include_resolver.h"
@@ -137,8 +140,7 @@ void Compiler::init_compile_graph() {
         worker::BuildParams bp;
         bp.kind = worker::BuildKind::BuildPCM;
         bp.file = file_path;
-        if(!fill_compile_args(file_path, bp.directory, bp.arguments))
-            co_return false;
+        fill_compile_args(file_path, bp.directory, bp.arguments);
 
         if(!workspace.store) {
             LOG_WARN("BuildPCM skipped for module {}: cache store is unavailable", mod_it->second);
@@ -177,9 +179,14 @@ void Compiler::init_compile_graph() {
         auto result = co_await pool.send_stateless(bp);
         if(!result.has_value() || !result.value().success) {
             workspace.store->abort(pending);
-            LOG_WARN("BuildPCM failed for module {}: {}",
-                     mod_it->second,
-                     result.has_value() ? result.value().error : result.error().message);
+            if(result.has_value() && result.value().has_user_errors) {
+                LOG_WARN("BuildPCM failed for module {}: {}", mod_it->second, result.value().error);
+            } else {
+                LOG_ANOMALY(PcmBuildFail,
+                            "PCM build failed for module {}: {}",
+                            mod_it->second,
+                            result.has_value() ? result.value().error : result.error().message);
+            }
             co_return false;
         }
 
@@ -214,33 +221,93 @@ void Compiler::init_compile_graph() {
     LOG_INFO("CompileGraph initialized with {} module(s)", workspace.path_to_module.size());
 }
 
-bool Compiler::fill_compile_args(llvm::StringRef path,
-                                 std::string& directory,
-                                 std::vector<std::string>& arguments,
-                                 Session* session) {
+llvm::StringRef command_source_name(CommandSource source) {
+    switch(source) {
+        case CommandSource::CdbExact: return "cdb_exact";
+        case CommandSource::IncludeGraph: return "include_graph";
+        case CommandSource::Inferred: return "inferred";
+        case CommandSource::Fallback: return "fallback";
+    }
+    return "unknown";
+}
+
+/// Per-file command selection decision log: which tiers were tried, which one
+/// was hit, and a hash of the final command for correlating later failures.
+static void log_command_decision(llvm::StringRef path,
+                                 llvm::ArrayRef<llvm::StringRef> tried,
+                                 CommandSource source,
+                                 llvm::ArrayRef<std::string> arguments) {
+    if(clice::logging::options.level > clice::logging::Level::info)
+        return;
+    std::string tried_text;
+    for(auto tier: tried) {
+        if(!tried_text.empty())
+            tried_text += ",";
+        tried_text += tier;
+    }
+    std::string joined;
+    for(auto& arg: arguments) {
+        joined += arg;
+        joined += '\0';
+    }
+    LOG_INFO("compile_args: file={} tried=[{}] source={} args_hash={:016x}",
+             path,
+             tried_text,
+             command_source_name(source),
+             llvm::xxh3_64bits(llvm::StringRef(joined)));
+}
+
+CommandSource Compiler::fill_compile_args(llvm::StringRef path,
+                                          std::string& directory,
+                                          std::vector<std::string>& arguments,
+                                          Session* session) {
     auto path_id = workspace.path_pool.intern(path);
+    llvm::SmallVector<llvm::StringRef, 3> tried;
 
     // 1. If the session has an active header context via switchContext,
     //    use the host source's CDB entry with file path replaced and preamble injected.
     if(session && session->active_context.has_value()) {
-        return fill_header_context_args(path, path_id, directory, arguments, session);
-    }
-
-    // 2. Normal CDB lookup for the file itself.
-    //    Apply rules from config (append/remove flags based on file patterns).
-    std::vector<std::string> rule_append, rule_remove;
-    workspace.config.match_rules(path, rule_append, rule_remove);
-    auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
-    if(!results.empty()) {
+        tried.push_back("switch_context");
+        if(fill_header_context_args(path, path_id, directory, arguments, session)) {
+            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
+            return CommandSource::IncludeGraph;
+        }
+    } else if(workspace.cdb.has_entry(path)) {
+        // 2. Real CDB entry for the file itself.
+        //    Apply rules from config (append/remove flags based on file patterns).
+        tried.push_back("cdb");
+        std::vector<std::string> rule_append, rule_remove;
+        workspace.config.match_rules(path, rule_append, rule_remove);
+        auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
         workspace.toolchain.resolve_or_warn(results.front());
         auto& cmd = results.front();
         directory = cmd.resolved.directory.str();
         arguments = cmd.to_string_argv();
-        return true;
+        log_command_decision(path, tried, CommandSource::CdbExact, arguments);
+        return CommandSource::CdbExact;
+    } else {
+        // 3. No CDB entry — try automatic header context resolution.
+        tried.push_back("cdb");
+        tried.push_back("include_graph");
+        if(fill_header_context_args(path, path_id, directory, arguments, session)) {
+            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
+            return CommandSource::IncludeGraph;
+        }
     }
 
-    // 3. No CDB entry — try automatic header context resolution.
-    return fill_header_context_args(path, path_id, directory, arguments, session);
+    // 4. Nothing matched — use the default command the CDB layer synthesizes
+    //    for unknown files, so the file still compiles and produces
+    //    diagnostics instead of failing silently.
+    tried.push_back("fallback");
+    std::vector<std::string> rule_append, rule_remove;
+    workspace.config.match_rules(path, rule_append, rule_remove);
+    auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
+    workspace.toolchain.resolve_or_warn(results.front());
+    auto& cmd = results.front();
+    directory = cmd.resolved.directory.str();
+    arguments = cmd.to_string_argv();
+    log_command_decision(path, tried, CommandSource::Fallback, arguments);
+    return CommandSource::Fallback;
 }
 
 bool Compiler::fill_header_context_args(llvm::StringRef path,
@@ -468,9 +535,48 @@ std::string uri_to_path(const std::string& uri) {
     return uri;
 }
 
+/// Clang diagnostics indicating that an input file could not be found —
+/// the symptom of a guessed compile command missing include paths.
+static bool is_file_not_found(const protocol::Diagnostic& diagnostic) {
+    if(!diagnostic.code.has_value())
+        return false;
+    auto* code = std::get_if<protocol::string>(&*diagnostic.code);
+    return code && (*code == "err_pp_file_not_found" || *code == "err_pp_error_opening_file" ||
+                    *code == "err_module_not_found");
+}
+
+/// File-top warning explaining that diagnostics were produced with a guessed
+/// compile command, pointing at the compilation database documentation.
+static protocol::Diagnostic make_inferred_command_diagnostic(CommandSource source) {
+    DiagnosticID id{
+        .value = 0,
+        .level = DiagnosticLevel::Warning,
+        .source = DiagnosticSource::Clice,
+        .name = "inferred-compile-command",
+    };
+
+    protocol::Diagnostic diagnostic;
+    diagnostic.range = protocol::Range{
+        .start = protocol::Position{.line = 0, .character = 0},
+        .end = protocol::Position{.line = 0, .character = 0},
+    };
+    diagnostic.severity = protocol::DiagnosticSeverity::Warning;
+    diagnostic.code = id.name.str();
+    if(auto uri = id.diagnostic_document_uri()) {
+        diagnostic.code_description = protocol::CodeDescription{.href = std::move(*uri)};
+    }
+    diagnostic.source = "clice";
+    diagnostic.message = std::format(
+        "No compilation database entry for this file (compile command was {}), so some includes " "may not be found. Configure compile_commands.json for accurate diagnostics.",
+        source == CommandSource::Fallback ? "synthesized from defaults"
+                                          : "inferred from an including file");
+    return diagnostic;
+}
+
 void Compiler::publish_diagnostics(const std::string& uri,
                                    int version,
-                                   const kota::codec::RawValue& diagnostics_json) {
+                                   const kota::codec::RawValue& diagnostics_json,
+                                   CommandSource source) {
     if(!peer)
         return;
     std::vector<protocol::Diagnostic> diagnostics;
@@ -480,6 +586,13 @@ void Compiler::publish_diagnostics(const std::string& uri,
             LOG_WARN("Failed to deserialize diagnostics JSON for {}", uri);
         }
     }
+
+    // Guidance (and only when it can explain something): an exact CDB match
+    // never gets the note, and neither does a guessed command that worked.
+    if(source != CommandSource::CdbExact && std::ranges::any_of(diagnostics, is_file_not_found)) {
+        diagnostics.insert(diagnostics.begin(), make_inferred_command_diagnostic(source));
+    }
+
     protocol::PublishDiagnosticsParams params;
     params.uri = uri;
     params.version = version;
@@ -584,17 +697,14 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
-        LOG_WARN("PCH build failed for {}: {}",
-                 path,
-                 result.has_value() ? result.value().error : result.error().message);
-        co_return false;
-    }
-
-    // Commit on the thread pool: it fsyncs the freshly written PCH.
-    auto committed =
-        co_await kota::queue([&] { return workspace.store->commit(std::move(pending)); });
-    if(!committed.has_value() || !committed.value().has_value()) {
-        LOG_WARN("Failed to commit PCH for {}", path);
+        if(result.has_value() && result.value().has_user_errors) {
+            LOG_WARN("PCH build failed for {}: {}", path, result.value().error);
+        } else {
+            LOG_ANOMALY(PchBuildFail,
+                        "PCH build failed for {}: {}",
+                        path,
+                        result.has_value() ? result.value().error : result.error().message);
+        }
         co_return false;
     }
 
@@ -809,7 +919,9 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     }
 
     if(!result.has_value()) {
-        LOG_WARN("Compile failed for {}: {}", uri_str, result.error().message);
+        // The worker accepts arbitrary user code; a failure at this layer is
+        // an IPC/worker breakage, never a user-code problem.
+        LOG_ANOMALY(CompileFail, "Compile failed for {}: {}", uri_str, result.error().message);
         clear_diagnostics(uri_str);
         finish_compile();
         co_return;
@@ -828,7 +940,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     auto version = session->version;
     finish_compile();
 
-    publish_diagnostics(uri_str, version, result.value().diagnostics);
+    publish_diagnostics(uri_str, version, result.value().diagnostics, source);
     if(on_indexing_needed)
         on_indexing_needed();
 }
@@ -945,22 +1057,32 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 
     if(position) {
         auto offset = map.to_offset(*position);
-        if(!offset)
-            co_return serde_raw{"null"};
+        if(!offset) {
+            co_return kota::outcome_error(kota::ipc::Error{
+                kota::ipc::protocol::ErrorCode::InvalidParams,
+                std::format("Invalid position {}:{}", position->line, position->character)});
+        }
         wp.offset = *offset;
     }
 
     if(range) {
         auto start = map.to_offset(range->start);
         auto end = map.to_offset(range->end);
-        if(start && end) {
-            wp.range = {*start, *end};
+        if(!start || !end) {
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Invalid range"});
         }
+        wp.range = {*start, *end};
     }
 
     auto result = co_await pool.send_stateful(path_id, wp);
     if(!result.has_value()) {
-        co_return serde_raw{};
+        LOG_ANOMALY(WorkerRequestFail,
+                    "query (kind={}) failed for {}: {}",
+                    static_cast<int>(kind),
+                    path,
+                    result.error().message);
+        co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value());
 }
@@ -979,11 +1101,12 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     wp.version = session->version;
     wp.text = session->text;
     if(!fill_compile_args(path, wp.directory, wp.arguments, session.get())) {
-        co_return serde_raw{};
+        co_return kota::outcome_error(kota::ipc::Error{"Failed to fill compile arguments"});
     }
 
     if(!co_await ensure_deps(*session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
-        co_return serde_raw{};
+        LOG_WARN("forward_build: dependency preparation failed for {}", path);
+        co_return kota::outcome_error(kota::ipc::Error{"Dependency preparation failed"});
     }
 
     if(session->generation != gen) {
@@ -992,13 +1115,21 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
 
     lsp::LineMap map(wp.text);
     auto offset = map.to_offset(position);
-    if(!offset)
-        co_return serde_raw{"null"};
+    if(!offset) {
+        co_return kota::outcome_error(kota::ipc::Error{
+            kota::ipc::protocol::ErrorCode::InvalidParams,
+            std::format("Invalid position {}:{}", position.line, position.character)});
+    }
     wp.offset = *offset;
 
     auto result = co_await pool.send_stateless(wp);
     if(!result.has_value()) {
-        co_return serde_raw{};
+        LOG_ANOMALY(WorkerRequestFail,
+                    "build (kind={}) failed for {}: {}",
+                    static_cast<int>(kind),
+                    path,
+                    result.error().message);
+        co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value().result_json);
 }
@@ -1018,14 +1149,18 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
         lsp::LineMap map(wp.text);
         auto begin = map.to_offset(range->start);
         auto end = map.to_offset(range->end);
-        if(!begin || !end)
-            co_return serde_raw{"null"};
+        if(!begin || !end) {
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                 "Invalid formatting range"});
+        }
         wp.format_range = {*begin, *end};
     }
 
     auto result = co_await pool.send_stateless(wp);
     if(!result.has_value()) {
-        co_return serde_raw{"null"};
+        LOG_ANOMALY(WorkerRequestFail, "format failed for {}: {}", path, result.error().message);
+        co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value().result_json);
 }
@@ -1043,8 +1178,7 @@ Compiler::RawResult Compiler::handle_completion(const protocol::Position& positi
            pctx.kind == CompletionContext::IncludeAngled) {
             std::string directory;
             std::vector<std::string> arguments;
-            if(!fill_compile_args(path, directory, arguments))
-                co_return serde_raw{"[]"};
+            fill_compile_args(path, directory, arguments);
 
             std::vector<const char*> args_ptrs;
             args_ptrs.reserve(arguments.size());

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -4,6 +4,7 @@
 #include <format>
 #include <ranges>
 #include <string>
+#include <utility>
 
 #include "command/argument_parser.h"
 #include "command/search_config.h"
@@ -69,6 +70,36 @@ struct BuildingGuard {
         completion->set();
     }
 };
+
+/// A PCH/PCM build failure is expected when the worker reported user-code
+/// errors or the dispatch failed for an operational reason (memory-pressure
+/// preemption, crash/restart window); anything else is clice breakage and is
+/// reported as an anomaly.
+static bool expected_build_failure(const auto& result) {
+    return result.has_value() ? result.value().has_user_errors
+                              : worker::is_operational_error(result.error());
+}
+
+/// The error text of a failed build: the worker's message when it responded,
+/// the dispatch error otherwise.
+const static std::string& build_failure_message(const auto& result) {
+    return result.has_value() ? result.value().error : result.error().message;
+}
+
+/// Clamp a client-supplied position to the document, following LSP
+/// semantics: a character beyond the line length defaults to the line end,
+/// a line beyond the document defaults to the end of the content.
+static lsp::LineMap::Offset clamped_offset(const lsp::LineMap& map,
+                                           const protocol::Position& position) {
+    if(auto offset = map.to_offset(position)) {
+        return *offset;
+    }
+    auto starts = map.line_starts();
+    if(position.line >= starts.size()) {
+        return static_cast<lsp::LineMap::Offset>(map.content().size());
+    }
+    return map.line_bounds(starts[position.line]).end;
+}
 
 /// Detect whether the cursor is inside a preamble directive (include/import).
 
@@ -159,13 +190,25 @@ void Compiler::init_compile_graph() {
                                               canonicalize(bp.arguments, ArgsProfile::Frontend)}));
 
         // Check if cached PCM is still valid.
+        llvm::StringRef pcm_miss = "no_entry";
         if(auto pcm_it = workspace.pcm_cache.find(path_id); pcm_it != workspace.pcm_cache.end()) {
-            if(pcm_it->second.key == pcm_key && workspace.store->lookup("pcm", pcm_key) &&
-               !deps_changed(workspace.path_pool, pcm_it->second.deps)) {
+            if(pcm_it->second.key != pcm_key) {
+                pcm_miss = "key_changed";
+            } else if(!workspace.store->lookup("pcm", pcm_key)) {
+                pcm_miss = "evicted";
+            } else if(deps_changed(workspace.path_pool, pcm_it->second.deps)) {
+                pcm_miss = "deps_changed";
+            } else {
                 workspace.pcm_paths[path_id] = pcm_it->second.path;
+                LOG_PERF("cache", "ns=pcm event=hit key={} module={}", pcm_key, mod_it->second);
                 co_return true;
             }
         }
+        LOG_PERF("cache",
+                 "ns=pcm event=miss reason={} key={} module={}",
+                 pcm_miss,
+                 pcm_key,
+                 mod_it->second);
 
         bp.module_name = mod_it->second;
         auto pending = workspace.store->begin_store("pcm", pcm_key);
@@ -179,13 +222,15 @@ void Compiler::init_compile_graph() {
         auto result = co_await pool.send_stateless(bp);
         if(!result.has_value() || !result.value().success) {
             workspace.store->abort(pending);
-            if(result.has_value() && result.value().has_user_errors) {
-                LOG_WARN("BuildPCM failed for module {}: {}", mod_it->second, result.value().error);
+            if(expected_build_failure(result)) {
+                LOG_WARN("BuildPCM failed for module {}: {}",
+                         mod_it->second,
+                         build_failure_message(result));
             } else {
                 LOG_ANOMALY(PcmBuildFail,
                             "PCM build failed for module {}: {}",
                             mod_it->second,
-                            result.has_value() ? result.value().error : result.error().message);
+                            build_failure_message(result));
             }
             co_return false;
         }
@@ -221,14 +266,15 @@ void Compiler::init_compile_graph() {
     LOG_INFO("CompileGraph initialized with {} module(s)", workspace.path_to_module.size());
 }
 
-llvm::StringRef command_source_name(CommandSource source) {
+/// Stable snake_case name of a CommandSource, used in the decision log.
+static llvm::StringRef command_source_name(CommandSource source) {
     switch(source) {
         case CommandSource::CdbExact: return "cdb_exact";
         case CommandSource::IncludeGraph: return "include_graph";
         case CommandSource::Inferred: return "inferred";
         case CommandSource::Fallback: return "fallback";
     }
-    return "unknown";
+    std::unreachable();
 }
 
 /// Per-file command selection decision log: which tiers were tried, which one
@@ -258,6 +304,19 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
     auto path_id = workspace.path_pool.intern(path);
     llvm::SmallVector<llvm::StringRef, 3> tried;
 
+    // Fill from the CDB layer with config rules applied (append/remove flags
+    // based on file patterns). Also used for tier 4: lookup() synthesizes a
+    // default command for files without an entry.
+    auto fill_from_cdb = [&] {
+        std::vector<std::string> rule_append, rule_remove;
+        workspace.config.match_rules(path, rule_append, rule_remove);
+        auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
+        workspace.toolchain.resolve_or_warn(results.front());
+        auto& cmd = results.front();
+        directory = cmd.resolved.directory.str();
+        arguments = cmd.to_string_argv();
+    };
+
     // 1. If the session has an active header context via switchContext,
     //    use the host source's CDB entry with file path replaced and preamble injected.
     if(session && session->active_context.has_value()) {
@@ -270,16 +329,9 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
 
     // 2. Real CDB entry for the file itself (lookup() synthesizes a command
     //    for unknown files, so a non-empty result alone proves nothing).
-    //    Apply rules from config (append/remove flags based on file patterns).
     tried.push_back("cdb");
     if(workspace.cdb.has_entry(path)) {
-        std::vector<std::string> rule_append, rule_remove;
-        workspace.config.match_rules(path, rule_append, rule_remove);
-        auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
-        workspace.toolchain.resolve_or_warn(results.front());
-        auto& cmd = results.front();
-        directory = cmd.resolved.directory.str();
-        arguments = cmd.to_string_argv();
+        fill_from_cdb();
         log_command_decision(path, tried, CommandSource::CdbExact, arguments);
         return CommandSource::CdbExact;
     }
@@ -297,13 +349,7 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
     //    for unknown files, so the file still compiles and produces
     //    diagnostics instead of failing silently.
     tried.push_back("fallback");
-    std::vector<std::string> rule_append, rule_remove;
-    workspace.config.match_rules(path, rule_append, rule_remove);
-    auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
-    workspace.toolchain.resolve_or_warn(results.front());
-    auto& cmd = results.front();
-    directory = cmd.resolved.directory.str();
-    arguments = cmd.to_string_argv();
+    fill_from_cdb();
     log_command_decision(path, tried, CommandSource::Fallback, arguments);
     return CommandSource::Fallback;
 }
@@ -638,15 +684,25 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     // Reuse existing PCH if the key and deps haven't changed.  The store
     // lookup refreshes the blob's LRU position and catches eviction.
+    llvm::StringRef pch_miss = "no_entry";
     if(auto it = workspace.pch_cache.find(path_id); it != workspace.pch_cache.end()) {
         auto& st = it->second;
-        if(st.key == pch_key && !st.path.empty() && workspace.store &&
-           workspace.store->lookup("pch", pch_key) && !deps_changed(workspace.path_pool, st.deps)) {
+        if(st.key != pch_key) {
+            pch_miss = "key_changed";
+        } else if(st.path.empty()) {
+            pch_miss = "incomplete_entry";
+        } else if(!(workspace.store && workspace.store->lookup("pch", pch_key))) {
+            pch_miss = "evicted";
+        } else if(deps_changed(workspace.path_pool, st.deps)) {
+            pch_miss = "deps_changed";
+        } else {
             st.bound = bound;
             session.pch_ref = Session::PCHRef{path_id, pch_key, bound};
+            LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, path);
             co_return true;
         }
     }
+    LOG_PERF("cache", "ns=pch event=miss reason={} key={} file={}", pch_miss, pch_key, path);
 
     // Preamble incomplete (user still typing) — defer rebuild, reuse old PCH if available.
     if(!is_preamble_complete(text, bound)) {
@@ -695,13 +751,13 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
-        if(result.has_value() && result.value().has_user_errors) {
-            LOG_WARN("PCH build failed for {}: {}", path, result.value().error);
+        if(expected_build_failure(result)) {
+            LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
         } else {
             LOG_ANOMALY(PchBuildFail,
                         "PCH build failed for {}: {}",
                         path,
-                        result.has_value() ? result.value().error : result.error().message);
+                        build_failure_message(result));
         }
         co_return false;
     }
@@ -922,9 +978,14 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     }
 
     if(!result.has_value()) {
-        // The worker accepts arbitrary user code; a failure at this layer is
-        // an IPC/worker breakage, never a user-code problem.
-        LOG_ANOMALY(CompileFail, "Compile failed for {}: {}", uri_str, result.error().message);
+        if(worker::is_operational_error(result.error())) {
+            LOG_WARN("Compile did not complete for {}: {}", uri_str, result.error().message);
+        } else {
+            // The worker accepts arbitrary user code; a non-operational
+            // failure at this layer is IPC/worker breakage, never a
+            // user-code problem.
+            LOG_ANOMALY(CompileFail, "Compile failed for {}: {}", uri_str, result.error().message);
+        }
         clear_diagnostics(uri_str);
         finish_compile();
         co_return;
@@ -1059,32 +1120,22 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
     wp.path = path;
 
     if(position) {
-        auto offset = map.to_offset(*position);
-        if(!offset) {
-            co_return kota::outcome_error(kota::ipc::Error{
-                kota::ipc::protocol::ErrorCode::InvalidParams,
-                std::format("Invalid position {}:{}", position->line, position->character)});
-        }
-        wp.offset = *offset;
+        wp.offset = clamped_offset(map, *position);
     }
 
     if(range) {
-        auto start = map.to_offset(range->start);
-        auto end = map.to_offset(range->end);
-        if(!start || !end) {
-            co_return kota::outcome_error(
-                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Invalid range"});
-        }
-        wp.range = {*start, *end};
+        wp.range = {clamped_offset(map, range->start), clamped_offset(map, range->end)};
     }
 
     auto result = co_await pool.send_stateful(path_id, wp);
     if(!result.has_value()) {
-        LOG_ANOMALY(WorkerRequestFail,
-                    "query (kind={}) failed for {}: {}",
-                    static_cast<int>(kind),
-                    path,
-                    result.error().message);
+        if(!worker::is_operational_error(result.error())) {
+            LOG_ANOMALY(WorkerRequestFail,
+                        "query (kind={}) failed for {}: {}",
+                        static_cast<int>(kind),
+                        path,
+                        result.error().message);
+        }
         co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value());
@@ -1111,25 +1162,21 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     }
 
     if(session->generation != gen) {
-        co_return serde_raw{};
+        co_return serde_raw{"null"};
     }
 
     lsp::LineMap map(wp.text);
-    auto offset = map.to_offset(position);
-    if(!offset) {
-        co_return kota::outcome_error(kota::ipc::Error{
-            kota::ipc::protocol::ErrorCode::InvalidParams,
-            std::format("Invalid position {}:{}", position.line, position.character)});
-    }
-    wp.offset = *offset;
+    wp.offset = clamped_offset(map, position);
 
     auto result = co_await pool.send_stateless(wp);
     if(!result.has_value()) {
-        LOG_ANOMALY(WorkerRequestFail,
-                    "build (kind={}) failed for {}: {}",
-                    static_cast<int>(kind),
-                    path,
-                    result.error().message);
+        if(!worker::is_operational_error(result.error())) {
+            LOG_ANOMALY(WorkerRequestFail,
+                        "build (kind={}) failed for {}: {}",
+                        static_cast<int>(kind),
+                        path,
+                        result.error().message);
+        }
         co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value().result_json);
@@ -1148,19 +1195,17 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
 
     if(range) {
         lsp::LineMap map(wp.text);
-        auto begin = map.to_offset(range->start);
-        auto end = map.to_offset(range->end);
-        if(!begin || !end) {
-            co_return kota::outcome_error(
-                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                                 "Invalid formatting range"});
-        }
-        wp.format_range = {*begin, *end};
+        wp.format_range = {clamped_offset(map, range->start), clamped_offset(map, range->end)};
     }
 
     auto result = co_await pool.send_stateless(wp);
     if(!result.has_value()) {
-        LOG_ANOMALY(WorkerRequestFail, "format failed for {}: {}", path, result.error().message);
+        if(!worker::is_operational_error(result.error())) {
+            LOG_ANOMALY(WorkerRequestFail,
+                        "format failed for {}: {}",
+                        path,
+                        result.error().message);
+        }
         co_return kota::outcome_error(std::move(result.error()));
     }
     co_return std::move(result.value().result_json);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -14,6 +14,7 @@
 #include "support/anomaly.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
+#include "support/timer.h"
 #include "syntax/include_resolver.h"
 #include "syntax/scan.h"
 
@@ -21,6 +22,7 @@
 #include "kota/codec/json/json.h"
 #include "kota/ipc/lsp/position.h"
 #include "kota/ipc/lsp/uri.h"
+#include "kota/meta/enum.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -934,6 +936,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 
     LOG_INFO("ensure_compiled: starting compile path_id={} gen={}", pid, gen);
 
+    ScopedTimer timer;
     auto file_path = std::string(workspace.path_pool.resolve(pid));
     auto uri = lsp::URI::from_file_path(file_path);
     std::string uri_str = uri.has_value() ? uri->str() : file_path;
@@ -1004,6 +1007,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     auto version = session->version;
     finish_compile();
 
+    LOG_PERF("request", "kind=Compile file={} total_ms={}", file_path, timer.ms());
     publish_diagnostics(uri_str, version, result.value().diagnostics, source);
     if(on_indexing_needed)
         on_indexing_needed();
@@ -1107,9 +1111,11 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
     auto gen = session->generation;
     auto map = session->line_map();
 
+    ScopedTimer timer;
     if(!co_await ensure_compiled(session)) {
         co_return serde_raw{"null"};
     }
+    auto wait_ms = timer.ms();
 
     if(session->generation != gen) {
         co_return serde_raw{"null"};
@@ -1138,6 +1144,12 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    LOG_PERF("request",
+             "kind={} file={} wait_ms={} total_ms={}",
+             kota::meta::enum_name(kind, "query"),
+             path,
+             wait_ms,
+             timer.ms());
     co_return std::move(result.value());
 }
 
@@ -1156,10 +1168,12 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     wp.text = session->text;
     fill_compile_args(path, wp.directory, wp.arguments, session.get());
 
+    ScopedTimer timer;
     if(!co_await ensure_deps(*session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
         LOG_WARN("forward_build: dependency preparation failed for {}", path);
         co_return kota::outcome_error(kota::ipc::Error{"Dependency preparation failed"});
     }
+    auto wait_ms = timer.ms();
 
     if(session->generation != gen) {
         co_return serde_raw{"null"};
@@ -1179,6 +1193,12 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    LOG_PERF("request",
+             "kind={} file={} wait_ms={} total_ms={}",
+             kota::meta::enum_name(kind, "build"),
+             path,
+             wait_ms,
+             timer.ms());
     co_return std::move(result.value().result_json);
 }
 
@@ -1198,6 +1218,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
         wp.format_range = {clamped_offset(map, range->start), clamped_offset(map, range->end)};
     }
 
+    ScopedTimer timer;
     auto result = co_await pool.send_stateless(wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
@@ -1208,6 +1229,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    LOG_PERF("request", "kind=Format file={} total_ms={}", path, timer.ms());
     co_return std::move(result.value().result_json);
 }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1119,6 +1119,11 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 
     if(range) {
         wp.range = {clamped_offset(map, range->start), clamped_offset(map, range->end)};
+        if(wp.range.begin > wp.range.end) {
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                 "Range start is after its end"});
+        }
     }
 
     auto result = co_await pool.send_stateful(path_id, wp);
@@ -1194,6 +1199,11 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     if(range) {
         lsp::LineMap map(wp.text);
         wp.format_range = {clamped_offset(map, range->start), clamped_offset(map, range->end)};
+        if(wp.format_range.begin > wp.format_range.end) {
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                 "Range start is after its end"});
+        }
     }
 
     ScopedTimer timer;

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -22,7 +22,6 @@
 #include "kota/codec/json/json.h"
 #include "kota/ipc/lsp/position.h"
 #include "kota/ipc/lsp/uri.h"
-#include "kota/meta/enum.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -229,7 +228,7 @@ void Compiler::init_compile_graph() {
                          mod_it->second,
                          build_failure_message(result));
             } else {
-                LOG_ANOMALY(PcmBuildFail,
+                LOG_ANOMALY(PCMBuildFail,
                             "PCM build failed for module {}: {}",
                             mod_it->second,
                             build_failure_message(result));
@@ -268,17 +267,6 @@ void Compiler::init_compile_graph() {
     LOG_INFO("CompileGraph initialized with {} module(s)", workspace.path_to_module.size());
 }
 
-/// Stable snake_case name of a CommandSource, used in the decision log.
-static llvm::StringRef command_source_name(CommandSource source) {
-    switch(source) {
-        case CommandSource::CdbExact: return "cdb_exact";
-        case CommandSource::IncludeGraph: return "include_graph";
-        case CommandSource::Inferred: return "inferred";
-        case CommandSource::Fallback: return "fallback";
-    }
-    std::unreachable();
-}
-
 /// Per-file command selection decision log: which tiers were tried, which one
 /// was hit, and a hash of the final command for correlating later failures.
 static void log_command_decision(llvm::StringRef path,
@@ -295,7 +283,7 @@ static void log_command_decision(llvm::StringRef path,
     LOG_INFO("compile_args: file={} tried=[{}] source={} args_hash={:016x}",
              path,
              llvm::join(tried, ","),
-             command_source_name(source),
+             source,
              llvm::xxh3_64bits(llvm::StringRef(joined)));
 }
 
@@ -334,8 +322,8 @@ CommandSource Compiler::fill_compile_args(llvm::StringRef path,
     tried.push_back("cdb");
     if(workspace.cdb.has_entry(path)) {
         fill_from_cdb();
-        log_command_decision(path, tried, CommandSource::CdbExact, arguments);
-        return CommandSource::CdbExact;
+        log_command_decision(path, tried, CommandSource::CDBExact, arguments);
+        return CommandSource::CDBExact;
     }
 
     // 3. No CDB entry — try automatic header context resolution.
@@ -635,7 +623,7 @@ void Compiler::publish_diagnostics(const std::string& uri,
 
     // Guidance (and only when it can explain something): an exact CDB match
     // never gets the note, and neither does a guessed command that worked.
-    if(source != CommandSource::CdbExact && std::ranges::any_of(diagnostics, is_file_not_found)) {
+    if(source != CommandSource::CDBExact && std::ranges::any_of(diagnostics, is_file_not_found)) {
         diagnostics.insert(diagnostics.begin(), make_inferred_command_diagnostic(source));
     }
 
@@ -756,7 +744,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         if(expected_build_failure(result)) {
             LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
         } else {
-            LOG_ANOMALY(PchBuildFail,
+            LOG_ANOMALY(PCHBuildFail,
                         "PCH build failed for {}: {}",
                         path,
                         build_failure_message(result));
@@ -1138,18 +1126,13 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "query (kind={}) failed for {}: {}",
-                        static_cast<int>(kind),
+                        kind,
                         path,
                         result.error().message);
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
-    LOG_PERF("request",
-             "kind={} file={} wait_ms={} total_ms={}",
-             kota::meta::enum_name(kind, "query"),
-             path,
-             wait_ms,
-             timer.ms());
+    LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value());
 }
 
@@ -1187,18 +1170,13 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "build (kind={}) failed for {}: {}",
-                        static_cast<int>(kind),
+                        kind,
                         path,
                         result.error().message);
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
-    LOG_PERF("request",
-             "kind={} file={} wait_ms={} total_ms={}",
-             kota::meta::enum_name(kind, "build"),
-             path,
-             wait_ms,
-             timer.ms());
+    LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value().result_json);
 }
 

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -29,6 +29,25 @@ namespace protocol = kota::ipc::protocol;
 /// Convert a file:// URI to a local file path.
 std::string uri_to_path(const std::string& uri);
 
+/// Where the compile command for a file came from. Anything other than
+/// CdbExact means the command was guessed to some degree, which is why
+/// diagnostics produced with it may deserve a guidance note (see
+/// Compiler::publish_diagnostics).
+enum class CommandSource : std::uint8_t {
+    /// Direct compilation database entry for the file.
+    CdbExact,
+    /// Header compiled in the context of a host source found through the
+    /// include graph (automatic or via clice/switchContext).
+    IncludeGraph,
+    /// Reserved for command transfer heuristics (e.g. nearest CDB entry);
+    /// no producer yet.
+    Inferred,
+    /// Synthesized default command — no CDB entry and no usable host source.
+    Fallback,
+};
+
+llvm::StringRef command_source_name(CommandSource source);
+
 /// Compilation service — drives worker processes to build ASTs, PCHs, and PCMs.
 ///
 /// Compiler holds no persistent state of its own.  All project-wide data
@@ -58,12 +77,15 @@ public:
 
     void init_compile_graph();
 
-    /// Fill compile arguments for a file (CDB lookup + header context fallback).
+    /// Fill compile arguments for a file and report where they came from.
+    /// Tries, in order: CDB entry, header context through the include graph,
+    /// and finally a synthesized fallback command — so it always succeeds.
+    /// Emits a per-file decision log (tiers tried, tier hit, command hash).
     /// @param session  If non-null, used for header context resolution on open files.
-    bool fill_compile_args(llvm::StringRef path,
-                           std::string& directory,
-                           std::vector<std::string>& arguments,
-                           Session* session = nullptr);
+    CommandSource fill_compile_args(llvm::StringRef path,
+                                    std::string& directory,
+                                    std::vector<std::string>& arguments,
+                                    Session* session = nullptr);
 
     /// Compile an open file's AST if dirty.  On success, updates session's
     /// file_index, pch_ref, ast_deps, and publishes diagnostics.
@@ -123,9 +145,14 @@ private:
     bool is_stale(const Session& session);
     void record_deps(Session& session, llvm::ArrayRef<std::string> deps);
 
+    /// Deserialize worker-produced diagnostics and publish them. When the
+    /// compile command was not an exact CDB match and the diagnostics contain
+    /// file-not-found class errors, a file-top guidance diagnostic explaining
+    /// the inferred command is merged into the same publish.
     void publish_diagnostics(const std::string& uri,
                              int version,
-                             const kota::codec::RawValue& diags);
+                             const kota::codec::RawValue& diags,
+                             CommandSource source);
 
     std::optional<HeaderFileContext> resolve_header_context(std::uint32_t header_path_id,
                                                             Session* session);

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -46,6 +46,7 @@ enum class CommandSource : std::uint8_t {
     Fallback,
 };
 
+/// Stable snake_case name of a CommandSource, used in the decision log.
 llvm::StringRef command_source_name(CommandSource source);
 
 /// Compilation service — drives worker processes to build ASTs, PCHs, and PCMs.

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -30,12 +30,12 @@ namespace protocol = kota::ipc::protocol;
 std::string uri_to_path(const std::string& uri);
 
 /// Where the compile command for a file came from. Anything other than
-/// CdbExact means the command was guessed to some degree, which is why
+/// CDBExact means the command was guessed to some degree, which is why
 /// diagnostics produced with it may deserve a guidance note (see
 /// Compiler::publish_diagnostics).
 enum class CommandSource : std::uint8_t {
     /// Direct compilation database entry for the file.
-    CdbExact,
+    CDBExact,
     /// Header compiled in the context of a host source found through the
     /// include graph (automatic or via clice/switchContext).
     IncludeGraph,

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -46,9 +46,6 @@ enum class CommandSource : std::uint8_t {
     Fallback,
 };
 
-/// Stable snake_case name of a CommandSource, used in the decision log.
-llvm::StringRef command_source_name(CommandSource source);
-
 /// Compilation service — drives worker processes to build ASTs, PCHs, and PCMs.
 ///
 /// Compiler holds no persistent state of its own.  All project-wide data

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -941,7 +941,10 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
     worker::BuildParams params;
     params.kind = worker::BuildKind::Index;
     params.file = file_path;
-    if(!compiler.fill_compile_args(file_path, params.directory, params.arguments, nullptr))
+    // Bulk background indexing sticks to real commands; synthesized fallback
+    // commands would fill the index with guesses.
+    if(compiler.fill_compile_args(file_path, params.directory, params.arguments, nullptr) ==
+       CommandSource::Fallback)
         co_return;
 
     workspace.fill_pcm_deps(params.pcms);

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -12,6 +12,7 @@
 #include "server/worker/worker_pool.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
+#include "support/timer.h"
 
 #include "kota/ipc/lsp/position.h"
 #include "kota/ipc/lsp/protocol.h"
@@ -145,6 +146,7 @@ kota::task<> Indexer::save() {
     if(!workspace.store)
         co_return;
     auto& store = *workspace.store;
+    ScopedTimer timer;
 
     // Phase 1, synchronous: serialize the ProjectIndex and every dirty
     // shard to tmp files.  No suspension point in between, so the batch is
@@ -197,11 +199,18 @@ kota::task<> Indexer::save() {
             LOG_WARN("Failed to commit index blob {}", key);
         }
     }
+
+    LOG_PERF("index",
+             "phase=save shards={} total={} elapsed_ms={}",
+             shards.size(),
+             total,
+             timer.ms());
 }
 
 void Indexer::load() {
     if(!workspace.store)
         return;
+    ScopedTimer timer;
 
     bool has_project = false;
     auto project_path = workspace.store->lookup("index", "project");
@@ -245,6 +254,11 @@ void Indexer::load() {
     if(!workspace.merged_indices.empty()) {
         LOG_INFO("Loaded {} MergedIndex shards", workspace.merged_indices.size());
     }
+    LOG_PERF("startup",
+             "phase=index_load symbols={} shards={} elapsed_ms={}",
+             workspace.project_index.symbols.size(),
+             workspace.merged_indices.size(),
+             timer.ms());
 }
 
 bool Indexer::need_update(llvm::StringRef file_path) {
@@ -951,14 +965,20 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
 
     LOG_INFO("[{}/{}] Indexing {}", index, total, file_path);
 
+    ScopedTimer timer;
     auto result = co_await pool.send_stateless(params);
     if(result.has_value() && result.value().success && !result.value().tu_index_data.empty()) {
-        LOG_INFO("[{}/{}] Indexed {}: {} bytes",
+        auto index_ms = timer.ms();
+        ScopedTimer merge_timer;
+        merge(result.value().tu_index_data.data(), result.value().tu_index_data.size());
+        LOG_PERF("index",
+                 "progress={}/{} file={} bytes={} index_ms={} merge_ms={}",
                  index,
                  total,
                  file_path,
-                 result.value().tu_index_data.size());
-        merge(result.value().tu_index_data.data(), result.value().tu_index_data.size());
+                 result.value().tu_index_data.size(),
+                 index_ms,
+                 merge_timer.ms());
     } else if(result.has_value() && !result.value().success) {
         LOG_WARN("[{}/{}] Index failed for {}: {}", index, total, file_path, result.value().error);
     } else if(result.has_value() && result.value().tu_index_data.empty()) {
@@ -1009,6 +1029,9 @@ kota::task<> Indexer::run_background_indexing() {
         }
     }
 
+    // Timed after the progress handshake so a slow client's create() wait
+    // (up to 3s) does not inflate the reported indexing duration.
+    ScopedTimer timer;
     kota::task_group<> workers(loop);
 
     while(index_queue_pos < index_queue.size()) {
@@ -1041,7 +1064,12 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     indexing_active = false;
-    LOG_INFO("Background indexing complete: {} files dispatched", dispatched);
+    LOG_PERF("index",
+             "phase=run dispatched={} skipped={} total={} elapsed_ms={}",
+             dispatched,
+             total - dispatched,
+             total,
+             timer.ms());
     co_await save();
 }
 

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -108,7 +108,7 @@ struct BuildResult {
     bool success = true;
     std::string error;
     /// On failure: whether `error` carries user-code compile errors. A failure
-    /// withOUT user errors indicates clice infrastructure breakage (anomaly).
+    /// without user errors indicates clice infrastructure breakage (anomaly).
     bool has_user_errors = false;
     std::string output_path;  ///< PCH or PCM path
     std::vector<std::string> deps;

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -107,6 +107,9 @@ struct BuildParams {
 struct BuildResult {
     bool success = true;
     std::string error;
+    /// On failure: whether `error` carries user-code compile errors. A failure
+    /// withOUT user errors indicates clice infrastructure breakage (anomaly).
+    bool has_user_errors = false;
     std::string output_path;  ///< PCH or PCM path
     std::vector<std::string> deps;
     std::string tu_index_data;

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -15,6 +15,29 @@ namespace clice::worker {
 
 namespace protocol = kota::ipc::protocol;
 
+/// Error codes attached to master-side dispatch failures. They mark expected
+/// operational conditions — memory-pressure preemption and crash/restart
+/// windows — as opposed to real IPC breakage: callers must not classify them
+/// as anomalies (see support/anomaly.h). The crash itself is already reported
+/// as a WorkerCrash anomaly by the pool.
+namespace dispatch_errc {
+
+/// The request was deliberately cancelled (memory-pressure preemption).
+constexpr inline protocol::integer cancelled =
+    static_cast<protocol::integer>(protocol::ErrorCode::RequestCancelled);
+
+/// No live worker could take the request (crash/restart window or pool stop).
+constexpr inline protocol::integer worker_unavailable = -33000;
+
+}  // namespace dispatch_errc
+
+/// True when a dispatch failure is an expected operational condition rather
+/// than clice infrastructure breakage.
+inline bool is_operational_error(const protocol::Error& error) {
+    return error.code == dispatch_errc::cancelled ||
+           error.code == dispatch_errc::worker_unavailable;
+}
+
 /// Kind of AST query dispatched to a stateful worker.
 enum class QueryKind : uint8_t {
     Hover,

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -205,10 +205,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                const CompileCommandParams& params) -> RequestResult<CompileCommandParams> {
             std::string directory;
             std::vector<std::string> arguments;
-            if(!srv.compiler.fill_compile_args(params.path, directory, arguments)) {
-                co_return kota::outcome_error(
-                    kota::ipc::Error{std::format("no compile command found for {}", params.path)});
-            }
+            srv.compiler.fill_compile_args(params.path, directory, arguments);
 
             co_return CompileCommandResult{
                 .file = params.path,

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -10,6 +10,7 @@
 #include "server/protocol/extension.h"
 #include "server/protocol/worker.h"
 #include "server/service/master_server.h"
+#include "support/anomaly.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 
@@ -36,9 +37,23 @@ static serde_raw to_raw(const T& value) {
     return serde_raw{json ? std::move(*json) : "null"};
 }
 
+/// Error response for feature requests on files with no open session.
+static kota::ipc::Error document_not_open() {
+    return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Document not open"};
+}
+
 LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(server), peer(peer) {
     server.compiler.set_peer(&peer);
     server.indexer.set_peer(&peer);
+
+    // Anomaly/guidance messages from the master process reach the client as
+    // window/logMessage notifications from here on.
+    logging::set_notify_hook([&peer](logging::NotifyLevel level, std::string_view message) {
+        peer.send_notification(protocol::LogMessageParams{
+            static_cast<protocol::MessageType>(level),
+            std::string(message),
+        });
+    });
 
     using StringVec = std::vector<std::string>;
 
@@ -143,6 +158,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
 
     peer.on_notification([this]([[maybe_unused]] const protocol::InitializedParams& params) {
         this->server.initialize();
+        this->publish_config_diagnostics();
     });
 
     peer.on_request(
@@ -252,7 +268,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         co_return co_await srv.compiler.forward_query(
             worker::QueryKind::Hover,
             session,
@@ -266,7 +282,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         co_return co_await srv.compiler.forward_query(worker::QueryKind::SemanticTokens, session);
     });
 
@@ -277,7 +293,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
             auto session = srv.find_session(path_id);
             if(!session)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(document_not_open());
             co_return co_await srv.compiler.forward_query(worker::QueryKind::InlayHints,
                                                           session,
                                                           {},
@@ -291,7 +307,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
             auto session = srv.find_session(path_id);
             if(!session)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(document_not_open());
             co_return co_await srv.compiler.forward_query(worker::QueryKind::FoldingRange, session);
         });
 
@@ -302,7 +318,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         co_return co_await srv.compiler.forward_query(worker::QueryKind::DocumentSymbol, session);
     });
 
@@ -313,10 +329,10 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         auto result = co_await srv.compiler.forward_query(worker::QueryKind::DocumentLink, session);
         if(!result.has_value())
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(std::move(result.error()));
         auto& links = result.value();
         if(session->pch_ref) {
             auto& pch_cache = srv.workspace.pch_cache;
@@ -342,7 +358,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
             auto session = srv.find_session(path_id);
             if(!session)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(document_not_open());
             co_return co_await srv.compiler.forward_query(worker::QueryKind::CodeAction, session);
         });
 
@@ -393,7 +409,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         co_return co_await srv.compiler.forward_query(worker::QueryKind::GoToDefinition,
                                                       session,
                                                       pos);
@@ -440,7 +456,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         auto pause = srv.indexer.scoped_pause();
         auto result =
             co_await srv.compiler.handle_completion(params.text_document_position_params.position,
@@ -455,7 +471,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
             auto session = srv.find_session(path_id);
             if(!session)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(document_not_open());
             auto pause = srv.indexer.scoped_pause();
             auto result =
                 co_await srv.compiler.forward_build(worker::BuildKind::SignatureHelp,
@@ -471,7 +487,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
             auto session = srv.find_session(path_id);
             if(!session)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(document_not_open());
             auto pause = srv.indexer.scoped_pause();
             co_return co_await srv.compiler.forward_format(session);
         });
@@ -483,7 +499,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path_id = srv.workspace.path_pool.intern(path);
         auto session = srv.find_session(path_id);
         if(!session)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(document_not_open());
         auto pause = srv.indexer.scoped_pause();
         co_return co_await srv.compiler.forward_format(session, params.range);
     });
@@ -510,10 +526,10 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                         const protocol::CallHierarchyIncomingCallsParams& params) -> RawResult {
         auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
         if(!info)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                 "Failed to resolve call hierarchy item"});
         auto results = this->server.indexer.find_incoming_calls(info->hash);
-        if(results.empty())
-            co_return serde_raw{"null"};
         co_return to_raw(results);
     });
 
@@ -522,10 +538,10 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                         const protocol::CallHierarchyOutgoingCallsParams& params) -> RawResult {
         auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
         if(!info)
-            co_return serde_raw{"null"};
+            co_return kota::outcome_error(
+                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                 "Failed to resolve call hierarchy item"});
         auto results = this->server.indexer.find_outgoing_calls(info->hash);
-        if(results.empty())
-            co_return serde_raw{"null"};
         co_return to_raw(results);
     });
 
@@ -552,10 +568,10 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                              const protocol::TypeHierarchySupertypesParams& params) -> RawResult {
             auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
             if(!info)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(
+                    kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                     "Failed to resolve type hierarchy item"});
             auto results = this->server.indexer.find_supertypes(info->hash);
-            if(results.empty())
-                co_return serde_raw{"null"};
             co_return to_raw(results);
         });
 
@@ -564,18 +580,16 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                              const protocol::TypeHierarchySubtypesParams& params) -> RawResult {
             auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
             if(!info)
-                co_return serde_raw{"null"};
+                co_return kota::outcome_error(
+                    kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                                     "Failed to resolve type hierarchy item"});
             auto results = this->server.indexer.find_subtypes(info->hash);
-            if(results.empty())
-                co_return serde_raw{"null"};
             co_return to_raw(results);
         });
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::WorkspaceSymbolParams& params) -> RawResult {
             auto results = this->server.indexer.search_symbols(params.query);
-            if(results.empty())
-                co_return serde_raw{"null"};
             co_return to_raw(results);
         });
 
@@ -706,7 +720,48 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         });
 }
 
+/// Publish clice.toml load problems as diagnostics on the config file's URI.
+/// The file is usually not open in the editor — publishing to a closed file
+/// is fine, the client shows it in the problems panel. A clean load publishes
+/// an empty list so diagnostics from a previous (broken) state clear.
+void LSPClient::publish_config_diagnostics() {
+    if(server.config_path.empty())
+        return;
+
+    auto uri = lsp::URI::from_file_path(server.config_path);
+    if(!uri) {
+        LOG_WARN("Cannot build URI for config file {}", server.config_path);
+        return;
+    }
+
+    protocol::PublishDiagnosticsParams params;
+    params.uri = uri->str();
+    for(auto& issue: server.config_issues) {
+        // rich_error positions are 1-based; LSP wants 0-based. An unknown
+        // position (0) maps to the file top. The range spans a single
+        // character — clients render it as the whole token anyway.
+        auto line = issue.line > 0 ? issue.line - 1 : 0;
+        auto character = issue.column > 0 ? issue.column - 1 : 0;
+
+        protocol::Diagnostic diagnostic;
+        diagnostic.range = protocol::Range{
+            .start = protocol::Position{line, character    },
+            .end = protocol::Position{line, character + 1},
+        };
+        diagnostic.severity = issue.severity == ConfigIssue::Severity::Error
+                                  ? protocol::DiagnosticSeverity::Error
+                                  : protocol::DiagnosticSeverity::Warning;
+        diagnostic.source = "clice";
+        diagnostic.message = issue.message;
+        params.diagnostics.push_back(std::move(diagnostic));
+
+        LOG_GUIDANCE("Configuration problem in {}: {}", issue.file, issue.message);
+    }
+    peer.send_notification(params);
+}
+
 LSPClient::~LSPClient() {
+    logging::set_notify_hook(nullptr);
     server.compiler.set_peer(nullptr);
     server.indexer.set_peer(nullptr);
 }

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -720,22 +720,18 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         });
 }
 
-/// Publish clice.toml load problems as diagnostics on the config file's URI.
-/// The file is usually not open in the editor — publishing to a closed file
-/// is fine, the client shows it in the problems panel. A clean load publishes
-/// an empty list so diagnostics from a previous (broken) state clear.
+/// Publish clice.toml load problems as diagnostics, each on its own file's
+/// URI (multiple files can contribute issues when the first config candidate
+/// is malformed and the next one loads). The files are usually not open in
+/// the editor — publishing to a closed file is fine, the client shows it in
+/// the problems panel. The loaded file always gets a publish, so a clean
+/// load clears diagnostics from a previous (broken) state.
 void LSPClient::publish_config_diagnostics() {
     if(server.config_path.empty())
         return;
 
-    auto uri = lsp::URI::from_file_path(server.config_path);
-    if(!uri) {
-        LOG_WARN("Cannot build URI for config file {}", server.config_path);
-        return;
-    }
-
-    protocol::PublishDiagnosticsParams params;
-    params.uri = uri->str();
+    llvm::StringMap<std::vector<protocol::Diagnostic>> by_file;
+    by_file[server.config_path];
     for(auto& issue: server.config_issues) {
         // rich_error positions are 1-based; LSP wants 0-based. An unknown
         // position (0) maps to the file top. The range spans a single
@@ -753,11 +749,22 @@ void LSPClient::publish_config_diagnostics() {
                                   : protocol::DiagnosticSeverity::Warning;
         diagnostic.source = "clice";
         diagnostic.message = issue.message;
-        params.diagnostics.push_back(std::move(diagnostic));
+        by_file[issue.file].push_back(std::move(diagnostic));
 
         LOG_GUIDANCE("Configuration problem in {}: {}", issue.file, issue.message);
     }
-    peer.send_notification(params);
+
+    for(auto& [file, diagnostics]: by_file) {
+        auto uri = lsp::URI::from_file_path(file.str());
+        if(!uri) {
+            LOG_WARN("Cannot build URI for config file {}", file.str());
+            continue;
+        }
+        protocol::PublishDiagnosticsParams params;
+        params.uri = uri->str();
+        params.diagnostics = std::move(diagnostics);
+        peer.send_notification(params);
+    }
 }
 
 LSPClient::~LSPClient() {

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -42,12 +42,20 @@ static kota::ipc::Error document_not_open() {
     return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Document not open"};
 }
 
+/// Error response when a call/type hierarchy item cannot be resolved back to
+/// an indexed symbol.
+static kota::ipc::Error item_not_resolved(llvm::StringRef kind) {
+    return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                            std::format("Failed to resolve {} item", kind)};
+}
+
 LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(server), peer(peer) {
     server.compiler.set_peer(&peer);
     server.indexer.set_peer(&peer);
 
-    // Anomaly/guidance messages from the master process reach the client as
-    // window/logMessage notifications from here on.
+    // The notify hook is process-wide and forwards anomaly/guidance messages
+    // as window/logMessage notifications. It captures the peer, so it must
+    // live exactly as long as this LSPClient (cleared in the destructor).
     logging::set_notify_hook([&peer](logging::NotifyLevel level, std::string_view message) {
         peer.send_notification(protocol::LogMessageParams{
             static_cast<protocol::MessageType>(level),
@@ -526,9 +534,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                         const protocol::CallHierarchyIncomingCallsParams& params) -> RawResult {
         auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
         if(!info)
-            co_return kota::outcome_error(
-                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                                 "Failed to resolve call hierarchy item"});
+            co_return kota::outcome_error(item_not_resolved("call hierarchy"));
         auto results = this->server.indexer.find_incoming_calls(info->hash);
         co_return to_raw(results);
     });
@@ -538,9 +544,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                         const protocol::CallHierarchyOutgoingCallsParams& params) -> RawResult {
         auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
         if(!info)
-            co_return kota::outcome_error(
-                kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                                 "Failed to resolve call hierarchy item"});
+            co_return kota::outcome_error(item_not_resolved("call hierarchy"));
         auto results = this->server.indexer.find_outgoing_calls(info->hash);
         co_return to_raw(results);
     });
@@ -568,9 +572,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                              const protocol::TypeHierarchySupertypesParams& params) -> RawResult {
             auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
             if(!info)
-                co_return kota::outcome_error(
-                    kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                                     "Failed to resolve type hierarchy item"});
+                co_return kota::outcome_error(item_not_resolved("type hierarchy"));
             auto results = this->server.indexer.find_supertypes(info->hash);
             co_return to_raw(results);
         });
@@ -580,9 +582,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                              const protocol::TypeHierarchySubtypesParams& params) -> RawResult {
             auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
             if(!info)
-                co_return kota::outcome_error(
-                    kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                                     "Failed to resolve type hierarchy item"});
+                co_return kota::outcome_error(item_not_resolved("type hierarchy"));
             auto results = this->server.indexer.find_subtypes(info->hash);
             co_return to_raw(results);
         });
@@ -731,7 +731,9 @@ void LSPClient::publish_config_diagnostics() {
         return;
 
     llvm::StringMap<std::vector<protocol::Diagnostic>> by_file;
-    by_file[server.config_path];
+    // The loaded file always gets a publish (even with zero issues), so a
+    // clean load clears diagnostics from a previous broken state.
+    by_file.try_emplace(server.config_path);
     for(auto& issue: server.config_issues) {
         // rich_error positions are 1-based; LSP wants 0-based. An unknown
         // position (0) maps to the file top. The range spans a single
@@ -741,8 +743,8 @@ void LSPClient::publish_config_diagnostics() {
 
         protocol::Diagnostic diagnostic;
         diagnostic.range = protocol::Range{
-            .start = protocol::Position{line, character    },
-            .end = protocol::Position{line, character + 1},
+            .start = protocol::Position{.line = line, .character = character    },
+            .end = protocol::Position{.line = line, .character = character + 1},
         };
         diagnostic.severity = issue.severity == ConfigIssue::Severity::Error
                                   ? protocol::DiagnosticSeverity::Error

--- a/src/server/service/lsp_client.h
+++ b/src/server/service/lsp_client.h
@@ -16,6 +16,9 @@ public:
 private:
     using RawResult = kota::task<kota::codec::RawValue, kota::ipc::Error>;
 
+    /// Push clice.toml load problems as diagnostics on the config file URI.
+    void publish_config_diagnostics();
+
     MasterServer& server;
     kota::ipc::JsonPeer& peer;
 };

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -8,6 +8,7 @@
 #include "server/protocol/worker.h"
 #include "server/service/agent_client.h"
 #include "server/service/lsp_client.h"
+#include "support/anomaly.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 
@@ -50,16 +51,24 @@ MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
 MasterServer::~MasterServer() = default;
 
 void MasterServer::initialize() {
-    workspace.config = Config::load_from_workspace(workspace_root);
+    config_issues.clear();
+    config_path.clear();
+    // Load clice.toml raw and overlay initializationOptions BEFORE computing
+    // defaults: derived fields (logging_dir, index_dir, ...) must follow the
+    // final merged values (e.g. a cache_dir overridden by the client).
+    workspace.config = Config::load_from_workspace(workspace_root,
+                                                   &config_issues,
+                                                   &config_path,
+                                                   /*with_defaults=*/false);
     if(!init_options_json.empty()) {
         if(auto ov = kota::codec::json::parse(init_options_json, workspace.config); !ov) {
-            LOG_WARN("Failed to apply initializationOptions: {}", ov.error().to_string());
+            LOG_GUIDANCE("Failed to apply initializationOptions: {}", ov.error().to_string());
         } else {
-            workspace.config.apply_defaults(workspace_root);
             LOG_INFO("Applied initializationOptions overlay");
         }
         init_options_json.clear();
     }
+    workspace.config.apply_defaults(workspace_root);
 
     auto& cfg = workspace.config.project;
 
@@ -85,7 +94,7 @@ void MasterServer::initialize() {
     pool_opts.worker_memory_limit = cfg.worker_memory_limit;
     pool_opts.log_dir = session_log_dir;
     if(!pool.start(pool_opts)) {
-        LOG_ERROR("Failed to start worker pool");
+        LOG_ANOMALY(WorkerSpawnFail, "Failed to start worker pool");
         return;
     }
 
@@ -286,7 +295,9 @@ void MasterServer::load_workspace() {
     }
 
     if(cdb_path.empty()) {
-        LOG_WARN("No compile_commands.json found in workspace {}", workspace_root);
+        LOG_GUIDANCE(
+            "No compile_commands.json found in workspace {}. Compile commands will be " "guessed; see https://clice.io/en/guide/quick-start for setup.",
+            workspace_root);
         return;
     }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -11,6 +11,7 @@
 #include "support/anomaly.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
+#include "support/timer.h"
 
 #include "kota/async/async.h"
 #include "kota/codec/json/json.h"
@@ -78,6 +79,7 @@ void MasterServer::initialize() {
         session_log_dir =
             path::join(cfg.logging_dir, std::format("{:%Y-%m-%d_%H-%M-%S}_{}", now, pid));
         logging::file_logger("master", session_log_dir, logging::options);
+        LOG_INFO("Session log directory: {}", session_log_dir);
     }
 
     LOG_INFO("Server ready (stateful={}, stateless={}, idle={}ms)",
@@ -301,8 +303,10 @@ void MasterServer::load_workspace() {
         return;
     }
 
+    ScopedTimer cdb_timer;
     auto count = workspace.cdb.load(cdb_path);
     LOG_INFO("Loaded CDB from {} with {} entries", cdb_path, count);
+    LOG_PERF("startup", "phase=cdb_load entries={} elapsed_ms={}", count, cdb_timer.ms());
 
     auto report = scan_dependency_graph(workspace.cdb,
                                         workspace.toolchain,
@@ -334,6 +338,11 @@ void MasterServer::load_workspace() {
         report.waves);
     if(unresolved > 0)
         LOG_WARN("{} unresolved includes", unresolved);
+    LOG_PERF("startup",
+             "phase=dep_scan files={} edges={} elapsed_ms={}",
+             report.total_files,
+             report.total_edges,
+             report.elapsed_ms);
 
     workspace.build_module_map();
     indexer.load();
@@ -420,6 +429,11 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
     auto port = opts.port.value_or(0);
     auto record = opts.record.value_or("");
     auto ws = opts.workspace.value_or("");
+
+    LOG_INFO("clice master starting: pid={}, mode={}, workspace={}",
+             llvm::sys::Process::getProcessId(),
+             mode == ServerMode::Pipe ? "pipe" : "socket",
+             ws.empty() ? "<from LSP initialize>" : ws);
 
     if(mode == ServerMode::Socket && (port <= 0 || port > 65535)) {
         LOG_ERROR("--port must be between 1 and 65535 in socket mode");

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -2,11 +2,13 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "server/compiler/compiler.h"
 #include "server/compiler/indexer.h"
 #include "server/service/session.h"
 #include "server/worker/worker_pool.h"
+#include "server/workspace/config.h"
 #include "server/workspace/workspace.h"
 
 #include "kota/async/async.h"
@@ -124,6 +126,12 @@ private:
     std::string workspace_root;
     std::string session_log_dir;
     std::string init_options_json;
+
+    /// Problems found while loading clice.toml during initialize(), kept so
+    /// LSPClient can publish them as diagnostics on the config file's URI.
+    std::vector<ConfigIssue> config_issues;
+    /// Path of the config file that was found (empty when none).
+    std::string config_path;
 };
 
 int run_serve_mode(const ServerOptions& opts, const char* self_path);

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -286,7 +286,9 @@ int run_stateful_worker_mode(std::uint64_t memory_limit,
                              const std::string& log_dir) {
     logging::stderr_logger(worker_name, logging::options);
     if(!log_dir.empty()) {
-        logging::file_logger(worker_name, log_dir, logging::options);
+        // File only: worker stderr is reserved for crash/unexpected output,
+        // which the master relays into its own log (see logging taxonomy).
+        logging::file_logger(worker_name, log_dir, logging::options, /*mirror_stderr=*/false);
     }
 
     LOG_INFO("Starting stateful worker, memory_limit={}MB", memory_limit / (1024 * 1024));

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -117,7 +117,11 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
     } else {
         LOG_WARN("BuildPCH failed: file={}, {}ms, errors=[{}]", params.file, timer.ms(), errors);
         fs::remove(tmp_path);
-        return {false, errors.empty() ? "PCH compilation failed" : errors};
+        worker::BuildResult result;
+        result.success = false;
+        result.error = errors.empty() ? "PCH compilation failed" : errors;
+        result.has_user_errors = !errors.empty();
+        return result;
     }
 }
 
@@ -173,7 +177,11 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
                  timer.ms(),
                  errors);
         fs::remove(tmp_path);
-        return {false, errors.empty() ? "PCM compilation failed" : errors};
+        worker::BuildResult result;
+        result.success = false;
+        result.error = errors.empty() ? "PCM compilation failed" : errors;
+        result.has_user_errors = !errors.empty();
+        return result;
     }
 }
 

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -291,7 +291,9 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
 
     logging::stderr_logger(worker_name, logging::options);
     if(!log_dir.empty()) {
-        logging::file_logger(worker_name, log_dir, logging::options);
+        // File only: worker stderr is reserved for crash/unexpected output,
+        // which the master relays into its own log (see logging taxonomy).
+        logging::file_logger(worker_name, log_dir, logging::options, /*mirror_stderr=*/false);
     }
 
     LOG_INFO("Starting stateless worker");

--- a/src/server/worker/worker_common.h
+++ b/src/server/worker/worker_common.h
@@ -2,27 +2,16 @@
 
 /// Shared utilities for stateful and stateless worker processes.
 
-#include <chrono>
 #include <string>
 #include <vector>
 
 #include "compile/compilation.h"
+#include "support/timer.h"
 
 #include "kota/codec/json/json.h"
 #include "kota/ipc/codec/json.h"
 
 namespace clice {
-
-/// RAII timer for measuring elapsed milliseconds.
-struct ScopedTimer {
-    std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-
-    long long ms() const {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-                   std::chrono::steady_clock::now() - start)
-            .count();
-    }
-};
 
 /// Fill CompilationParams directory and arguments from worker request fields.
 inline void fill_args(CompilationParams& cp,

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -322,15 +322,17 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     w.alive = false;
 
     if(exit_signal != 0) {
-        LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
-                  w.name,
-                  exit_signal,
-                  w.restart_count);
+        LOG_ANOMALY(WorkerCrash,
+                    "Worker {} killed by signal {} (restarts: {})",
+                    w.name,
+                    exit_signal,
+                    w.restart_count);
     } else {
-        LOG_ERROR("Worker {} exited with code {} (restarts: {})",
-                  w.name,
-                  exit_code,
-                  w.restart_count);
+        LOG_ANOMALY(WorkerCrash,
+                    "Worker {} exited with code {} (restarts: {})",
+                    w.name,
+                    exit_code,
+                    w.restart_count);
     }
 
     WorkerCrashInfo info;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -4,6 +4,7 @@
 #include <csignal>
 #include <string>
 
+#include "support/anomaly.h"
 #include "support/logging.h"
 
 #include "kota/async/io/system.h"
@@ -81,9 +82,10 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
 
     auto result = kota::process::spawn(opts, loop);
     if(!result) {
-        LOG_ERROR("Failed to spawn {} worker: {}",
-                  stateful ? "stateful" : "stateless",
-                  result.error().message());
+        LOG_ANOMALY(WorkerSpawnFail,
+                    "Failed to spawn {} worker: {}",
+                    stateful ? "stateful" : "stateless",
+                    result.error().message());
         return false;
     }
 
@@ -320,15 +322,17 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     w.alive = false;
 
     if(exit_signal != 0) {
-        LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
-                  w.name,
-                  exit_signal,
-                  w.restart_count);
+        LOG_ANOMALY(WorkerCrash,
+                    "Worker {} killed by signal {} (restarts: {})",
+                    w.name,
+                    exit_signal,
+                    w.restart_count);
     } else {
-        LOG_ERROR("Worker {} exited with code {} (restarts: {})",
-                  w.name,
-                  exit_code,
-                  w.restart_count);
+        LOG_ANOMALY(WorkerCrash,
+                    "Worker {} exited with code {} (restarts: {})",
+                    w.name,
+                    exit_code,
+                    w.restart_count);
     }
 
     WorkerCrashInfo info;
@@ -419,7 +423,10 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
 
     auto result = kota::process::spawn(opts, loop);
     if(!result) {
-        LOG_ERROR("Failed to respawn worker {}: {}", worker_name, result.error().message());
+        LOG_ANOMALY(WorkerSpawnFail,
+                    "Failed to respawn worker {}: {}",
+                    worker_name,
+                    result.error().message());
         return false;
     }
 

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -322,17 +322,15 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     w.alive = false;
 
     if(exit_signal != 0) {
-        LOG_ANOMALY(WorkerCrash,
-                    "Worker {} killed by signal {} (restarts: {})",
-                    w.name,
-                    exit_signal,
-                    w.restart_count);
+        LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
+                  w.name,
+                  exit_signal,
+                  w.restart_count);
     } else {
-        LOG_ANOMALY(WorkerCrash,
-                    "Worker {} exited with code {} (restarts: {})",
-                    w.name,
-                    exit_code,
-                    w.restart_count);
+        LOG_ERROR("Worker {} exited with code {} (restarts: {})",
+                  w.name,
+                  exit_code,
+                  w.restart_count);
     }
 
     WorkerCrashInfo info;

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -309,11 +309,13 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
                                                 const Params& params,
                                                 kota::ipc::request_options opts) {
     if(stateful_workers.empty()) {
-        co_return kota::outcome_error(kota::ipc::Error{"No stateful workers available"});
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                                                       "No stateful workers available"});
     }
     auto idx = assign_worker(path_id);
     if(!stateful_workers[idx].alive) {
-        co_return kota::outcome_error(kota::ipc::Error{"Assigned stateful worker is down"});
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                                                       "Assigned stateful worker is down"});
     }
     co_return co_await stateful_workers[idx].peer->send_request(params, opts);
 }
@@ -322,7 +324,8 @@ template <typename Params>
 RequestResult<Params> WorkerPool::send_stateless(const Params& params,
                                                  kota::ipc::request_options opts) {
     if(stateless_workers.empty()) {
-        co_return kota::outcome_error(kota::ipc::Error{"No stateless workers available"});
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                                                       "No stateless workers available"});
     }
 
     // Retry once on transport error, excluding the failed peer so the
@@ -331,7 +334,9 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     for(int attempt = 0; attempt < 2; ++attempt) {
         auto idx = co_await acquire_stateless_slot(params.priority, exclude);
         if(idx >= stateless_workers.size())
-            co_return kota::outcome_error(kota::ipc::Error{"All stateless workers are down"});
+            co_return kota::outcome_error(
+                kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                                 "All stateless workers are down"});
 
         StatelessSlot slot(*this, idx);
 
@@ -362,12 +367,14 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         // If deliberately cancelled by memory pressure, don't retry.
         if(preempt_src && preempt_src->cancelled())
             co_return kota::outcome_error(
-                kota::ipc::Error{"Request cancelled due to memory pressure"});
+                kota::ipc::Error{worker::dispatch_errc::cancelled,
+                                 "Request cancelled due to memory pressure"});
 
         // Transport error — retry on a different worker.
         exclude = idx;
     }
-    co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});
+    co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                                                   "Stateless request failed after retries"});
 }
 
 template <typename Params>

--- a/src/server/workspace/config.cpp
+++ b/src/server/workspace/config.cpp
@@ -206,6 +206,9 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root,
                                    std::vector<ConfigIssue>* issues,
                                    std::string* loaded_path,
                                    bool with_defaults) {
+    if(loaded_path)
+        loaded_path->clear();
+
     if(!workspace_root.empty()) {
         for(auto* name: {"clice.toml", ".clice/config.toml"}) {
             auto config_path = path::join(workspace_root, name);

--- a/src/server/workspace/config.cpp
+++ b/src/server/workspace/config.cpp
@@ -136,7 +136,29 @@ void Config::match_rules(llvm::StringRef file_path,
     }
 }
 
-std::optional<Config> Config::load(llvm::StringRef path, llvm::StringRef workspace_root) {
+/// Codec config for the strict validation pass: reject unknown keys.
+struct DenyUnknownKeys {
+    constexpr static bool deny_unknown_fields = true;
+};
+
+static ConfigIssue make_issue(ConfigIssue::Severity severity,
+                              llvm::StringRef path,
+                              const kota::codec::rich_error& error) {
+    ConfigIssue issue;
+    issue.severity = severity;
+    issue.file = path.str();
+    issue.message = error.to_string();
+    if(error.location) {
+        issue.line = static_cast<std::uint32_t>(error.location->line);
+        issue.column = static_cast<std::uint32_t>(error.location->column);
+    }
+    return issue;
+}
+
+std::optional<Config> Config::load(llvm::StringRef path,
+                                   llvm::StringRef workspace_root,
+                                   std::vector<ConfigIssue>* issues,
+                                   bool with_defaults) {
     auto content = fs::read(path);
     if(!content)
         return std::nullopt;
@@ -144,11 +166,25 @@ std::optional<Config> Config::load(llvm::StringRef path, llvm::StringRef workspa
     auto result = kota::codec::toml::parse<Config>(*content);
     if(!result) {
         LOG_ERROR("Invalid clice.toml {}: {}", path, result.error().to_string());
+        if(issues)
+            issues->push_back(make_issue(ConfigIssue::Severity::Error, path, result.error()));
         return std::nullopt;
     }
 
+    // Second, strict decode pass that rejects unknown keys. The lenient
+    // result above still applies — this only surfaces typos (e.g. a
+    // misspelled option silently doing nothing) as Warning issues.
+    if(issues) {
+        Config probe{};
+        if(auto strict = kota::codec::toml::from_toml<DenyUnknownKeys>(*content, probe); !strict) {
+            LOG_WARN("clice.toml {}: {}", path, strict.error().to_string());
+            issues->push_back(make_issue(ConfigIssue::Severity::Warning, path, strict.error()));
+        }
+    }
+
     auto config = std::move(*result);
-    config.apply_defaults(workspace_root);
+    if(with_defaults)
+        config.apply_defaults(workspace_root);
     LOG_INFO("Loaded config from {}", path);
     return config;
 }
@@ -166,13 +202,18 @@ std::optional<Config> Config::load_from_json(llvm::StringRef json, llvm::StringR
     return config;
 }
 
-Config Config::load_from_workspace(llvm::StringRef workspace_root) {
+Config Config::load_from_workspace(llvm::StringRef workspace_root,
+                                   std::vector<ConfigIssue>* issues,
+                                   std::string* loaded_path,
+                                   bool with_defaults) {
     if(!workspace_root.empty()) {
         for(auto* name: {"clice.toml", ".clice/config.toml"}) {
             auto config_path = path::join(workspace_root, name);
             if(!llvm::sys::fs::exists(config_path))
                 continue;
-            if(auto config = load(config_path, workspace_root))
+            if(loaded_path)
+                *loaded_path = config_path;
+            if(auto config = load(config_path, workspace_root, issues, with_defaults))
                 return std::move(*config);
             // Present but malformed: fall through to defaults, but surface
             // the situation clearly so users know their config wasn't applied.
@@ -181,6 +222,8 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root) {
     }
 
     Config config;
+    if(!with_defaults)
+        return config;
     config.apply_defaults(workspace_root);
     LOG_INFO(
         "No clice.toml found, using default configuration " "(stateful={}, stateless={}, memory_limit={}MB)",

--- a/src/server/workspace/config.cpp
+++ b/src/server/workspace/config.cpp
@@ -209,11 +209,13 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root,
     if(loaded_path)
         loaded_path->clear();
 
+    bool found = false;
     if(!workspace_root.empty()) {
         for(auto* name: {"clice.toml", ".clice/config.toml"}) {
             auto config_path = path::join(workspace_root, name);
             if(!llvm::sys::fs::exists(config_path))
                 continue;
+            found = true;
             if(loaded_path)
                 *loaded_path = config_path;
             if(auto config = load(config_path, workspace_root, issues, with_defaults))
@@ -224,15 +226,14 @@ Config Config::load_from_workspace(llvm::StringRef workspace_root,
         }
     }
 
+    if(!found) {
+        LOG_INFO("No clice.toml found in {}, using default configuration", workspace_root);
+    }
+
     Config config;
-    if(!with_defaults)
-        return config;
-    config.apply_defaults(workspace_root);
-    LOG_INFO(
-        "No clice.toml found, using default configuration " "(stateful={}, stateless={}, memory_limit={}MB)",
-        config.project.stateful_worker_count.value,
-        config.project.stateless_worker_count.value,
-        config.project.worker_memory_limit.value / (1024 * 1024));
+    if(with_defaults) {
+        config.apply_defaults(workspace_root);
+    }
     return config;
 }
 

--- a/src/server/workspace/config.h
+++ b/src/server/workspace/config.h
@@ -48,6 +48,25 @@ struct CompiledRule {
     std::vector<std::string> remove;
 };
 
+/// A problem found while loading a configuration file, carrying enough
+/// structure to publish an LSP diagnostic on the file's URI.
+struct ConfigIssue {
+    enum class Severity : std::uint8_t {
+        /// The configuration was rejected and defaults are in effect.
+        Error,
+        /// The configuration still applies (e.g. an unknown key was ignored).
+        Warning,
+    };
+
+    Severity severity;
+    /// Absolute path of the configuration file.
+    std::string file;
+    std::string message;
+    /// 1-based position in the file; 0 when unknown.
+    std::uint32_t line = 0;
+    std::uint32_t column = 0;
+};
+
 /// Configuration for the clice LSP server, loadable from clice.toml
 /// or passed via LSP initializationOptions.
 struct Config {
@@ -65,8 +84,17 @@ struct Config {
                      std::vector<std::string>& append,
                      std::vector<std::string>& remove) const;
 
-    /// Try to load configuration from a TOML file.
-    static std::optional<Config> load(llvm::StringRef path, llvm::StringRef workspace_root);
+    /// Try to load configuration from a TOML file. Parse/validation problems
+    /// are appended to `issues` when provided: decode failures as Error (the
+    /// caller falls back to defaults), unknown keys as Warning (the rest of
+    /// the file still applies). Set `with_defaults` to false when further
+    /// config sources will be overlaid before apply_defaults() runs — derived
+    /// fields (index_dir, logging_dir, ...) must be computed only once, from
+    /// the final merged values.
+    static std::optional<Config> load(llvm::StringRef path,
+                                      llvm::StringRef workspace_root,
+                                      std::vector<ConfigIssue>* issues = nullptr,
+                                      bool with_defaults = true);
 
     /// Try to load configuration from a JSON string (e.g. initializationOptions).
     static std::optional<Config> load_from_json(llvm::StringRef json,
@@ -74,7 +102,13 @@ struct Config {
 
     /// Load config from the workspace, trying standard locations.
     /// Returns a default config (with apply_defaults) if no file is found.
-    static Config load_from_workspace(llvm::StringRef workspace_root);
+    /// `loaded_path`, when provided, receives the path of the config file
+    /// that was found (even if it failed to parse), or stays empty.
+    /// `with_defaults` as in load().
+    static Config load_from_workspace(llvm::StringRef workspace_root,
+                                      std::vector<ConfigIssue>* issues = nullptr,
+                                      std::string* loaded_path = nullptr,
+                                      bool with_defaults = true);
 };
 
 }  // namespace clice

--- a/src/support/anomaly.cpp
+++ b/src/support/anomaly.cpp
@@ -1,0 +1,108 @@
+#include "support/anomaly.h"
+
+#include <array>
+#include <atomic>
+#include <cstdlib>
+
+#include "support/logging.h"
+
+#include "llvm/Support/Process.h"
+
+namespace clice::logging {
+
+namespace {
+
+std::array<std::atomic<std::uint32_t>, anomaly_id_count> report_counts;
+
+std::function<void(NotifyLevel, std::string_view)> notify_hook;
+
+std::function<void(AnomalyId)> testing_trap;
+
+[[maybe_unused]] bool trap_disabled_by_env() {
+    static bool disabled = llvm::sys::Process::GetEnv("CLICE_ANOMALY_NO_TRAP").has_value();
+    return disabled;
+}
+
+void trap(AnomalyId id) {
+    if(testing_trap) {
+        testing_trap(id);
+        return;
+    }
+#ifndef NDEBUG
+    /// Debug builds treat anomalies as assertion failures: flush the log so
+    /// the report survives, then abort. CLICE_ANOMALY_NO_TRAP exists for
+    /// integration tests that intentionally trigger anomalies and verify the
+    /// Release behavior (report and continue).
+    if(!trap_disabled_by_env()) {
+        spdlog::shutdown();
+        std::abort();
+    }
+#endif
+}
+
+}  // namespace
+
+std::string_view anomaly_name(AnomalyId id) {
+    switch(id) {
+        case AnomalyId::PchBuildFail: return "pch_build_fail";
+        case AnomalyId::PcmBuildFail: return "pcm_build_fail";
+        case AnomalyId::CompileFail: return "compile_fail";
+        case AnomalyId::WorkerRequestFail: return "worker_request_fail";
+        case AnomalyId::WorkerCrash: return "worker_crash";
+        case AnomalyId::WorkerSpawnFail: return "worker_spawn_fail";
+        case AnomalyId::PositionMapFail: return "position_map_fail";
+    }
+    return "unknown";
+}
+
+bool anomaly_should_report(AnomalyId id) {
+    if(options.level > Level::err)
+        return false;
+
+    auto& count = report_counts[static_cast<std::size_t>(id)];
+    auto previous = count.fetch_add(1, std::memory_order_relaxed);
+    if(previous < anomaly_report_limit)
+        return true;
+
+    if(previous == anomaly_report_limit) {
+        logging::err("[anomaly:{}] report limit ({}) reached, suppressing further reports",
+                     anomaly_name(id),
+                     anomaly_report_limit);
+    }
+    return false;
+}
+
+void report_anomaly(AnomalyId id, std::string message, std::source_location location) {
+    auto text = std::format("[anomaly:{}] {}", anomaly_name(id), message);
+    logging::log(spdlog::level::err, location, "{}", text);
+    if(notify_hook)
+        notify_hook(NotifyLevel::Error, text);
+    trap(id);
+}
+
+bool guidance_should_report() {
+    return options.level <= Level::warn;
+}
+
+void report_guidance(std::string message, std::source_location location) {
+    auto text = std::format("[guidance] {}", message);
+    logging::log(spdlog::level::warn, location, "{}", text);
+    if(notify_hook)
+        notify_hook(NotifyLevel::Warning, text);
+}
+
+void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook) {
+    notify_hook = std::move(hook);
+}
+
+void set_anomaly_trap_for_testing(std::function<void(AnomalyId)> trap) {
+    testing_trap = std::move(trap);
+}
+
+void reset_anomaly_for_testing() {
+    for(auto& count: report_counts)
+        count.store(0, std::memory_order_relaxed);
+    testing_trap = nullptr;
+}
+
+}  // namespace clice::logging

--- a/src/support/anomaly.cpp
+++ b/src/support/anomaly.cpp
@@ -72,7 +72,7 @@ bool anomaly_should_report(AnomalyId id) {
     return false;
 }
 
-void report_anomaly(AnomalyId id, std::string message, std::source_location location) {
+void report_anomaly(AnomalyId id, std::string_view message, std::source_location location) {
     auto text = std::format("[anomaly:{}] {}", anomaly_name(id), message);
     logging::log(spdlog::level::err, location, "{}", text);
     if(notify_hook)
@@ -84,7 +84,7 @@ bool guidance_should_report() {
     return options.level <= Level::warn;
 }
 
-void report_guidance(std::string message, std::source_location location) {
+void report_guidance(std::string_view message, std::source_location location) {
     auto text = std::format("[guidance] {}", message);
     logging::log(spdlog::level::warn, location, "{}", text);
     if(notify_hook)
@@ -95,8 +95,8 @@ void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook) {
     notify_hook = std::move(hook);
 }
 
-void set_anomaly_trap_for_testing(std::function<void(AnomalyId)> trap) {
-    testing_trap = std::move(trap);
+void set_anomaly_trap_for_testing(std::function<void(AnomalyId)> hook) {
+    testing_trap = std::move(hook);
 }
 
 void reset_anomaly_for_testing() {

--- a/src/support/anomaly.cpp
+++ b/src/support/anomaly.cpp
@@ -42,20 +42,6 @@ void trap(AnomalyId id) {
 
 }  // namespace
 
-std::string_view anomaly_name(AnomalyId id) {
-    switch(id) {
-        case AnomalyId::PchBuildFail: return "pch_build_fail";
-        case AnomalyId::PcmBuildFail: return "pcm_build_fail";
-        case AnomalyId::CompileFail: return "compile_fail";
-        case AnomalyId::WorkerRequestFail: return "worker_request_fail";
-        case AnomalyId::WorkerCrash: return "worker_crash";
-        case AnomalyId::WorkerSpawnFail: return "worker_spawn_fail";
-        case AnomalyId::PositionMapFail: return "position_map_fail";
-        case AnomalyId::Count: break;
-    }
-    return "unknown";
-}
-
 bool anomaly_should_report(AnomalyId id) {
     if(options.level > Level::err)
         return false;
@@ -68,7 +54,7 @@ bool anomaly_should_report(AnomalyId id) {
     if(previous == anomaly_report_limit) {
         auto text =
             std::format("[anomaly:{}] report limit ({}) reached, suppressing further reports",
-                        anomaly_name(id),
+                        id,
                         anomaly_report_limit);
         logging::err("{}", text);
         if(notify_hook)
@@ -78,7 +64,7 @@ bool anomaly_should_report(AnomalyId id) {
 }
 
 void report_anomaly(AnomalyId id, std::string_view message, std::source_location location) {
-    auto text = std::format("[anomaly:{}] {}", anomaly_name(id), message);
+    auto text = std::format("[anomaly:{}] {}", id, message);
     logging::log(spdlog::level::err, location, "{}", text);
     if(notify_hook)
         notify_hook(NotifyLevel::Error, text);

--- a/src/support/anomaly.cpp
+++ b/src/support/anomaly.cpp
@@ -29,10 +29,10 @@ void trap(AnomalyId id) {
         return;
     }
 #ifndef NDEBUG
-    /// Debug builds treat anomalies as assertion failures: flush the log so
-    /// the report survives, then abort. CLICE_ANOMALY_NO_TRAP exists for
-    /// integration tests that intentionally trigger anomalies and verify the
-    /// Release behavior (report and continue).
+    // Debug builds treat anomalies as assertion failures: flush the log so
+    // the report survives, then abort. CLICE_ANOMALY_NO_TRAP exists for
+    // integration tests that intentionally trigger anomalies and verify the
+    // Release behavior (report and continue).
     if(!trap_disabled_by_env()) {
         spdlog::shutdown();
         std::abort();
@@ -51,6 +51,7 @@ std::string_view anomaly_name(AnomalyId id) {
         case AnomalyId::WorkerCrash: return "worker_crash";
         case AnomalyId::WorkerSpawnFail: return "worker_spawn_fail";
         case AnomalyId::PositionMapFail: return "position_map_fail";
+        case AnomalyId::Count: break;
     }
     return "unknown";
 }
@@ -65,9 +66,13 @@ bool anomaly_should_report(AnomalyId id) {
         return true;
 
     if(previous == anomaly_report_limit) {
-        logging::err("[anomaly:{}] report limit ({}) reached, suppressing further reports",
-                     anomaly_name(id),
-                     anomaly_report_limit);
+        auto text =
+            std::format("[anomaly:{}] report limit ({}) reached, suppressing further reports",
+                        anomaly_name(id),
+                        anomaly_report_limit);
+        logging::err("{}", text);
+        if(notify_hook)
+            notify_hook(NotifyLevel::Error, text);
     }
     return false;
 }

--- a/src/support/anomaly.cpp
+++ b/src/support/anomaly.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <cstdlib>
+#include <mutex>
 
 #include "support/logging.h"
 
@@ -14,9 +15,19 @@ namespace {
 
 std::array<std::atomic<std::uint32_t>, anomaly_id_count> report_counts;
 
+/// Guards the two hooks below. Reporting sites copy the hook under the lock
+/// and invoke it outside, so a hook may safely re-enter this module (e.g. a
+/// testing trap calling reset_anomaly_for_testing).
+std::mutex hook_mutex;
+
 std::function<void(NotifyLevel, std::string_view)> notify_hook;
 
 std::function<void(AnomalyId)> testing_trap;
+
+std::function<void(NotifyLevel, std::string_view)> current_notify_hook() {
+    std::lock_guard lock(hook_mutex);
+    return notify_hook;
+}
 
 [[maybe_unused]] bool trap_disabled_by_env() {
     static bool disabled = llvm::sys::Process::GetEnv("CLICE_ANOMALY_NO_TRAP").has_value();
@@ -24,8 +35,13 @@ std::function<void(AnomalyId)> testing_trap;
 }
 
 void trap(AnomalyId id) {
-    if(testing_trap) {
-        testing_trap(id);
+    std::function<void(AnomalyId)> testing;
+    {
+        std::lock_guard lock(hook_mutex);
+        testing = testing_trap;
+    }
+    if(testing) {
+        testing(id);
         return;
     }
 #ifndef NDEBUG
@@ -57,8 +73,8 @@ bool anomaly_should_report(AnomalyId id) {
                         id,
                         anomaly_report_limit);
         logging::err("{}", text);
-        if(notify_hook)
-            notify_hook(NotifyLevel::Error, text);
+        if(auto hook = current_notify_hook())
+            hook(NotifyLevel::Error, text);
     }
     return false;
 }
@@ -66,8 +82,8 @@ bool anomaly_should_report(AnomalyId id) {
 void report_anomaly(AnomalyId id, std::string_view message, std::source_location location) {
     auto text = std::format("[anomaly:{}] {}", id, message);
     logging::log(spdlog::level::err, location, "{}", text);
-    if(notify_hook)
-        notify_hook(NotifyLevel::Error, text);
+    if(auto hook = current_notify_hook())
+        hook(NotifyLevel::Error, text);
     trap(id);
 }
 
@@ -78,21 +94,24 @@ bool guidance_should_report() {
 void report_guidance(std::string_view message, std::source_location location) {
     auto text = std::format("[guidance] {}", message);
     logging::log(spdlog::level::warn, location, "{}", text);
-    if(notify_hook)
-        notify_hook(NotifyLevel::Warning, text);
+    if(auto hook = current_notify_hook())
+        hook(NotifyLevel::Warning, text);
 }
 
 void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook) {
+    std::lock_guard lock(hook_mutex);
     notify_hook = std::move(hook);
 }
 
 void set_anomaly_trap_for_testing(std::function<void(AnomalyId)> hook) {
+    std::lock_guard lock(hook_mutex);
     testing_trap = std::move(hook);
 }
 
 void reset_anomaly_for_testing() {
     for(auto& count: report_counts)
         count.store(0, std::memory_order_relaxed);
+    std::lock_guard lock(hook_mutex);
     testing_trap = nullptr;
 }
 

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <source_location>
+#include <string>
+#include <string_view>
+
+namespace clice::logging {
+
+/// Stable identifiers for anomalies — internal states that should be
+/// unreachable when clice works correctly. Reaching one indicates a bug in
+/// clice itself, NOT a problem with user input or user code: those are
+/// reported as LSP errors, guidance messages or plain logs instead.
+///
+/// Debug builds abort on the first occurrence so the CI Debug matrix and
+/// local development surface the bug as early as possible. Release builds
+/// log the occurrence with an `[anomaly:<name>]` marker, forward it to the
+/// notify hook (master process: `window/logMessage`) and continue running.
+enum class AnomalyId : std::uint8_t {
+    /// PCH build failed without a user-code error to explain it.
+    PchBuildFail,
+    /// PCM build failed without a user-code error to explain it.
+    PcmBuildFail,
+    /// AST compile request to a stateful worker failed at the IPC layer.
+    CompileFail,
+    /// Feature query/build forwarded to a worker failed at the IPC layer.
+    WorkerRequestFail,
+    /// A worker process died unexpectedly.
+    WorkerCrash,
+    /// Worker pool failed to spawn or respawn a worker process.
+    WorkerSpawnFail,
+    /// An internally-produced offset or range failed to map to a position.
+    PositionMapFail,
+};
+
+constexpr inline std::size_t anomaly_id_count =
+    static_cast<std::size_t>(AnomalyId::PositionMapFail) + 1;
+
+/// Stable snake_case name used in the `[anomaly:<name>]` marker. Integration
+/// tests match on these strings — renaming an enumerator must not silently
+/// change them.
+std::string_view anomaly_name(AnomalyId id);
+
+/// Per-ID report cap per process; further occurrences are suppressed.
+constexpr inline std::uint32_t anomaly_report_limit = 8;
+
+/// Gate evaluated BEFORE the format arguments of LOG_ANOMALY: checks the log
+/// level and bumps the per-ID rate-limit counter. Logs a final suppression
+/// notice when the cap is reached.
+bool anomaly_should_report(AnomalyId id);
+
+/// Log "[anomaly:<name>] <message>" at err level, forward it to the notify
+/// hook, then trap: Debug builds abort (after flushing the log) unless the
+/// trap is overridden for tests or CLICE_ANOMALY_NO_TRAP is set in the
+/// environment; Release builds continue.
+void report_anomaly(AnomalyId id,
+                    std::string message,
+                    std::source_location location = std::source_location::current());
+
+/// Gate evaluated BEFORE the format arguments of LOG_GUIDANCE.
+bool guidance_should_report();
+
+/// Log "[guidance] <message>" at warn level and forward it to the notify hook.
+/// For user-actionable situations that are not clice bugs (missing CDB,
+/// invalid configuration, ...).
+void report_guidance(std::string message,
+                     std::source_location location = std::source_location::current());
+
+/// Severity forwarded to the notify hook; values mirror LSP MessageType.
+enum class NotifyLevel : std::uint8_t {
+    Error = 1,
+    Warning = 2,
+};
+
+/// Process-wide hook that pushes anomaly/guidance messages to the LSP client.
+/// The master sets it once a client peer is available; workers never set it.
+/// Invoked synchronously from the reporting call site — all current call
+/// sites in the master run on the event-loop thread.
+void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook);
+
+/// Replace the debug trap so unit tests can observe anomalies (in any build
+/// type) without aborting the test process.
+void set_anomaly_trap_for_testing(std::function<void(AnomalyId)> trap);
+
+/// Clear rate-limit counters and the testing trap.
+void reset_anomaly_for_testing();
+
+}  // namespace clice::logging
+
+/// Soft assertion for internal invariants (see AnomalyId). The gate runs
+/// before the format arguments are evaluated, so suppressed reports cost
+/// nothing — arguments must not carry needed side effects.
+#define LOG_ANOMALY(id, fmt, ...)                                                                  \
+    do {                                                                                           \
+        if(clice::logging::anomaly_should_report(clice::logging::AnomalyId::id)) {                 \
+            clice::logging::report_anomaly(clice::logging::AnomalyId::id,                          \
+                                           std::format(fmt __VA_OPT__(, ) __VA_ARGS__));           \
+        }                                                                                          \
+    } while(0)
+
+/// User-facing guidance via window/logMessage (master) and the log file.
+/// Same lazy-evaluation contract as LOG_ANOMALY.
+#define LOG_GUIDANCE(fmt, ...)                                                                     \
+    do {                                                                                           \
+        if(clice::logging::guidance_should_report()) {                                             \
+            clice::logging::report_guidance(std::format(fmt __VA_OPT__(, ) __VA_ARGS__));          \
+        }                                                                                          \
+    } while(0)

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -56,7 +56,7 @@ bool anomaly_should_report(AnomalyId id);
 /// trap is overridden for tests or CLICE_ANOMALY_NO_TRAP is set in the
 /// environment; Release builds continue.
 void report_anomaly(AnomalyId id,
-                    std::string message,
+                    std::string_view message,
                     std::source_location location = std::source_location::current());
 
 /// Gate evaluated BEFORE the format arguments of LOG_GUIDANCE.
@@ -65,7 +65,7 @@ bool guidance_should_report();
 /// Log "[guidance] <message>" at warn level and forward it to the notify hook.
 /// For user-actionable situations that are not clice bugs (missing CDB,
 /// invalid configuration, ...).
-void report_guidance(std::string message,
+void report_guidance(std::string_view message,
                      std::source_location location = std::source_location::current());
 
 /// Severity forwarded to the notify hook; values mirror LSP MessageType.

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -7,6 +7,10 @@
 #include <string>
 #include <string_view>
 
+/// Anomaly and guidance reporting — the policy layer on top of the logging
+/// transport. The full channel design (which situation goes to which
+/// channel, and why this file is separate from logging.h) is documented at
+/// the top of support/logging.h.
 namespace clice::logging {
 
 /// Stable identifiers for anomalies — internal states that should be
@@ -16,13 +20,14 @@ namespace clice::logging {
 ///
 /// Debug builds abort on the first occurrence so the CI Debug matrix and
 /// local development surface the bug as early as possible. Release builds
-/// log the occurrence with an `[anomaly:<name>]` marker, forward it to the
+/// log the occurrence with an `[anomaly:<id>]` marker (the enumerator name,
+/// rendered via the reflective enum formatter), forward it to the
 /// notify hook (master process: `window/logMessage`) and continue running.
 enum class AnomalyId : std::uint8_t {
     /// PCH build failed without a user-code error to explain it.
-    PchBuildFail,
+    PCHBuildFail,
     /// PCM build failed without a user-code error to explain it.
-    PcmBuildFail,
+    PCMBuildFail,
     /// AST compile request to a stateful worker failed at the IPC layer.
     CompileFail,
     /// Feature query/build forwarded to a worker failed at the IPC layer.
@@ -39,11 +44,6 @@ enum class AnomalyId : std::uint8_t {
 };
 
 constexpr inline std::size_t anomaly_id_count = static_cast<std::size_t>(AnomalyId::Count);
-
-/// Stable snake_case name used in the `[anomaly:<name>]` marker. Integration
-/// tests match on these strings — renaming an enumerator must not silently
-/// change them.
-std::string_view anomaly_name(AnomalyId id);
 
 /// Per-ID report cap per process; further occurrences are suppressed.
 constexpr inline std::uint32_t anomaly_report_limit = 8;

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -78,8 +78,10 @@ enum class NotifyLevel : std::uint8_t {
 
 /// Process-wide hook that pushes anomaly/guidance messages to the LSP client.
 /// The master sets it once a client peer is available; workers never set it.
-/// Invoked synchronously from the reporting call site — all current call
-/// sites in the master run on the event-loop thread.
+/// Hook registration is internally synchronized, so reporting from any
+/// thread is safe — but the hook itself is invoked from the reporting
+/// thread, so what it DOES must be safe there (the master's hook touches
+/// the peer and is only ever invoked from the event-loop thread).
 void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook);
 
 /// Replace the debug trap so unit tests can observe anomalies (in any build

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -33,10 +33,12 @@ enum class AnomalyId : std::uint8_t {
     WorkerSpawnFail,
     /// An internally-produced offset or range failed to map to a position.
     PositionMapFail,
+
+    /// Number of ids, not a reportable anomaly — keep last.
+    Count,
 };
 
-constexpr inline std::size_t anomaly_id_count =
-    static_cast<std::size_t>(AnomalyId::PositionMapFail) + 1;
+constexpr inline std::size_t anomaly_id_count = static_cast<std::size_t>(AnomalyId::Count);
 
 /// Stable snake_case name used in the `[anomaly:<name>]` marker. Integration
 /// tests match on these strings — renaming an enumerator must not silently

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -551,10 +551,11 @@ void CacheStore::State::evict_locked(Namespace& ns, llvm::StringRef keep_key) {
                       ns.config.name);
             continue;
         }
-        LOG_DEBUG("CacheStore: evicted {} ({} bytes) from {}",
-                  candidate.key,
-                  candidate.size,
-                  ns.config.name);
+        LOG_PERF("cache",
+                 "ns={} event=evict key={} bytes={}",
+                 ns.config.name,
+                 candidate.key,
+                 candidate.size);
         ns.total_size -= candidate.size;
         ns.entries.erase(candidate.key);
         dirty = true;

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -11,6 +11,7 @@
 #include "spdlog/sinks/ringbuffer_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/stdout_sinks.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Signals.h"
 
 namespace clice::logging {
@@ -39,7 +40,10 @@ void stderr_logger(std::string_view name, const Options& options) {
     spdlog::set_default_logger(std::move(logger));
 }
 
-void file_logger(std::string_view name, std::string_view dir, const Options& options) {
+void file_logger(std::string_view name,
+                 std::string_view dir,
+                 const Options& options,
+                 bool mirror_stderr) {
     if(auto ec = llvm::sys::fs::create_directories(dir)) {
         spdlog::error("Failed to create log directory {}: {}", std::string(dir), ec.message());
         return;
@@ -59,8 +63,10 @@ void file_logger(std::string_view name, std::string_view dir, const Options& opt
 
     auto replay_buffer = ringbuffer_sink;
 
-    auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>(options.color);
-    std::array<spdlog::sink_ptr, 2> sinks = {file_sink, console_sink};
+    llvm::SmallVector<spdlog::sink_ptr, 2> sinks = {file_sink};
+    if(mirror_stderr) {
+        sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>(options.color));
+    }
     auto logger = std::make_shared<spdlog::logger>(std::string(name), sinks.begin(), sinks.end());
     logger->set_level(options.level);
     logger->set_pattern(pattern);
@@ -80,7 +86,7 @@ void file_logger(std::string_view name, std::string_view dir, const Options& opt
         ringbuffer_sink.reset();
     }
 
-    install_crash_handler(filepath);
+    install_crash_handler(filepath, /*stderr_trace=*/mirror_stderr);
 }
 
 static std::unique_ptr<llvm::raw_fd_ostream> crash_log_stream;
@@ -93,7 +99,7 @@ static void crash_handler(void*) {
     }
 }
 
-void install_crash_handler(std::string_view log_path) {
+void install_crash_handler(std::string_view log_path, bool stderr_trace) {
     std::error_code ec;
     crash_log_stream =
         std::make_unique<llvm::raw_fd_ostream>(llvm::StringRef(log_path.data(), log_path.size()),
@@ -105,7 +111,11 @@ void install_crash_handler(std::string_view log_path) {
         return;
     }
     llvm::sys::AddSignalHandler(crash_handler, nullptr);
-    llvm::sys::PrintStackTraceOnErrorSignal("clice");
+    // Workers skip the stderr backtrace: their crash traces belong in their
+    // own log file only, not relayed into the master log via the stderr pipe.
+    if(stderr_trace) {
+        llvm::sys::PrintStackTraceOnErrorSignal("clice");
+    }
 }
 
 }  // namespace clice::logging

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -11,15 +11,44 @@
 
 #include "spdlog/spdlog.h"
 
-/// # Logging taxonomy
+/// # Logging & error-feedback design
 ///
-/// clice reports through several channels; pick by audience and purpose:
+/// Every report in clice answers one question first: WHO must act on it,
+/// and is it clice's fault? That decides the channel — not how severe the
+/// message feels. The channels:
 ///
-/// ## File/console log — LOG_TRACE .. LOG_FATAL
-/// The developer-facing record of what the server did.
+///   situation                                   → channel
+///   ─────────────────────────────────────────────────────────────────────
+///   a clice invariant broke (a bug in clice)    → LOG_ANOMALY   (anomaly.h)
+///   the user must fix their setup or config     → LOG_GUIDANCE  (anomaly.h)
+///     ... and it is tied to a specific file     →   + a published diagnostic
+///   a request cannot be served                  → LSP error response
+///   an operation failed but is expected in       → LOG_WARN / LOG_ERROR
+///     operation (user code errors, crash
+///     windows, cancellations)
+///   a measurement for profiling                 → LOG_PERF
+///   the narrative of what the server did        → LOG_INFO/DEBUG/TRACE
+///
+/// Two hard rules fall out of this:
+/// - LOG_ANOMALY is a soft assertion. If a condition is reachable through
+///   user input or normal operation, it is NOT an anomaly — downgrade it.
+///   Debug builds abort on anomalies (see CLICE_ANOMALY_NO_TRAP); Release
+///   logs "[anomaly:<id>]" and pushes window/logMessage.
+/// - Failures the user can cause must never abort or spam anomalies:
+///   classify them structurally (has_user_errors, dispatch_errc) and log
+///   them as warn/error instead.
+///
+/// The anomaly/guidance channels live in support/anomaly.h, deliberately
+/// NOT in this header: they are reporting policy (trap, per-id rate limit,
+/// client notify hook, test hooks) layered on top of this transport, and
+/// their AnomalyId enum evolves — this header is included by every TU, so
+/// keeping the enum out of it keeps "add an anomaly id" from recompiling
+/// the whole project.
+///
+/// ## Levels — LOG_TRACE .. LOG_FATAL
 /// - trace: extremely verbose, per-token / per-payload detail.
-/// - debug: control-flow detail for chasing a specific bug (per-lookup
-///   cache decisions, scheduler state changes, generation checks).
+/// - debug: control-flow detail for chasing a specific bug (scheduler
+///   state changes, generation checks, deferred rebuilds).
 /// - info: one line per meaningful event — startup steps, per-file
 ///   compile/index results, command decision logs. This is the default
 ///   level; an info-level session log must be enough to reconstruct what
@@ -38,18 +67,6 @@
 /// durations), "request" (per-request latency: wait_ms = time until a
 /// worker was ready, total_ms = end-to-end). Use stable key=value pairs and
 /// `_ms` suffixes for durations — scripts aggregate these lines.
-///
-/// ## Anomalies — LOG_ANOMALY(id, ...) (support/anomaly.h)
-/// Soft assertions for states that are unreachable unless clice itself is
-/// buggy. Debug builds abort (see CLICE_ANOMALY_NO_TRAP); Release logs
-/// "[anomaly:<id>]" and pushes window/logMessage. Never use for conditions
-/// reachable through user input or normal operation.
-///
-/// ## Guidance — LOG_GUIDANCE(...) (support/anomaly.h)
-/// User-actionable situations that are not clice bugs (missing CDB, invalid
-/// configuration), pushed to the client via window/logMessage as warnings.
-/// File-specific guidance is additionally published as diagnostics
-/// (inferred-compile-command, clice.toml issues).
 ///
 /// ## Process ownership
 /// The master logs to <logging_dir>/<session>/master.log and mirrors to

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -11,6 +11,57 @@
 
 #include "spdlog/spdlog.h"
 
+/// # Logging taxonomy
+///
+/// clice reports through several channels; pick by audience and purpose:
+///
+/// ## File/console log — LOG_TRACE .. LOG_FATAL
+/// The developer-facing record of what the server did.
+/// - trace: extremely verbose, per-token / per-payload detail.
+/// - debug: control-flow detail for chasing a specific bug (per-lookup
+///   cache decisions, scheduler state changes, generation checks).
+/// - info: one line per meaningful event — startup steps, per-file
+///   compile/index results, command decision logs. This is the default
+///   level; an info-level session log must be enough to reconstruct what
+///   the server did and why.
+/// - warn: something went wrong but was handled or is expected in operation
+///   (user-code compile errors, worker-down windows, cancelled requests).
+/// - err: an operation failed and its result is lost or wrong; the server
+///   keeps running.
+/// - critical (LOG_FATAL): unrecoverable; flushes the log and aborts.
+///
+/// ## Perf lines — LOG_PERF(topic, ...)
+/// Greppable measurements for profiling on real codebases, rendered as
+/// "[perf:<topic>] key=value ..." at info level, e.g.
+/// `grep 'perf:index' master.log`. Topics in use: "index" (per-file and
+/// phase timings), "cache" (hit/miss with reason), "startup" (phase
+/// durations). Use stable key=value pairs and `_ms` suffixes for durations —
+/// scripts aggregate these lines.
+///
+/// ## Anomalies — LOG_ANOMALY(id, ...) (support/anomaly.h)
+/// Soft assertions for states that are unreachable unless clice itself is
+/// buggy. Debug builds abort (see CLICE_ANOMALY_NO_TRAP); Release logs
+/// "[anomaly:<id>]" and pushes window/logMessage. Never use for conditions
+/// reachable through user input or normal operation.
+///
+/// ## Guidance — LOG_GUIDANCE(...) (support/anomaly.h)
+/// User-actionable situations that are not clice bugs (missing CDB, invalid
+/// configuration), pushed to the client via window/logMessage as warnings.
+/// File-specific guidance is additionally published as diagnostics
+/// (inferred-compile-command, clice.toml issues).
+///
+/// ## Process ownership
+/// The master logs to <logging_dir>/<session>/master.log and mirrors to
+/// stderr, which editors show in their output panel. Workers log ONLY to
+/// their own <session>/<worker>.log (mirror_stderr = false): a worker's
+/// stderr is reserved for unexpected third-party output — assertion
+/// failures, sanitizer reports — which the pool relays line-by-line into the
+/// master log. Crash backtraces are appended to the owning process's log
+/// file by install_crash_handler (error signals including SIGABRT, so
+/// LOG_FATAL and Debug anomaly traps are covered); a worker's backtrace goes
+/// ONLY to its own log file, while the master's is also printed to stderr.
+/// Before file_logger runs, backtraces reach stderr only (master) or are
+/// lost (workers without a log dir).
 namespace clice::logging {
 
 using Level = spdlog::level::level_enum;
@@ -26,12 +77,22 @@ extern Options options;
 
 void stderr_logger(std::string_view name, const Options& options);
 
-void file_logger(std::string_view name, std::string_view dir, const Options& options);
+/// Log to <dir>/<name>.log, replaying lines buffered by stderr_logger.
+/// With mirror_stderr, every line is also written to stderr — the master
+/// uses this so editors can show its log; workers must pass false (their
+/// stderr is reserved for crash output, relayed by the pool).
+void file_logger(std::string_view name,
+                 std::string_view dir,
+                 const Options& options,
+                 bool mirror_stderr = true);
 
-/// Install a signal handler that writes crash stacktraces to the given log file.
-/// Also enables LLVM's default stderr stacktrace output.
+/// Install a signal handler that writes crash stacktraces to the given log
+/// file. With stderr_trace, LLVM's stderr stacktrace output is enabled too —
+/// the master wants it (editors capture its stderr), workers must not (their
+/// stderr pipe would relay the trace into the master log; a worker's crash
+/// trace belongs in its own log file only).
 /// Must be called after file_logger so the log file path is known.
-void install_crash_handler(std::string_view log_path);
+void install_crash_handler(std::string_view log_path, bool stderr_trace = true);
 
 template <typename... Args>
 struct logging_rformat {
@@ -112,6 +173,10 @@ void critical [[noreturn]] (logging_format<Args...> fmt, Args&&... args) {
 #define LOG_WARN(fmt, ...) LOG_MESSAGE(warn, fmt, __VA_ARGS__)
 #define LOG_ERROR(fmt, ...) LOG_MESSAGE(err, fmt, __VA_ARGS__)
 #define LOG_FATAL(fmt, ...) clice::logging::critical(fmt __VA_OPT__(, ) __VA_ARGS__);
+
+/// Performance measurement line (see the taxonomy above): `topic` must be a
+/// string literal, the message should be stable key=value pairs.
+#define LOG_PERF(topic, fmt, ...) LOG_INFO("[perf:" topic "] " fmt __VA_OPT__(, ) __VA_ARGS__)
 
 #define LOG_MESSAGE_RET(ret, name, fmt, ...)                                                       \
     do {                                                                                           \

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -35,8 +35,9 @@
 /// "[perf:<topic>] key=value ..." at info level, e.g.
 /// `grep 'perf:index' master.log`. Topics in use: "index" (per-file and
 /// phase timings), "cache" (hit/miss with reason), "startup" (phase
-/// durations). Use stable key=value pairs and `_ms` suffixes for durations —
-/// scripts aggregate these lines.
+/// durations), "request" (per-request latency: wait_ms = time until a
+/// worker was ready, total_ms = end-to-end). Use stable key=value pairs and
+/// `_ms` suffixes for durations — scripts aggregate these lines.
 ///
 /// ## Anomalies — LOG_ANOMALY(id, ...) (support/anomaly.h)
 /// Soft assertions for states that are unreachable unless clice itself is

--- a/src/support/timer.h
+++ b/src/support/timer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <chrono>
+
+namespace clice {
+
+/// Wall-clock timer for perf log lines (see LOG_PERF in support/logging.h).
+struct ScopedTimer {
+    std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
+
+    long long ms() const {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now() - start)
+            .count();
+    }
+};
+
+}  // namespace clice

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,15 @@ import pytest
 
 from tests.cdb import generate_cdb, generate_test_data_cdbs
 from tests.integration.utils.client import CliceClient
+from tests.integration.utils.assertions import assert_no_anomaly
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Store test outcome so fixtures can detect failures during teardown."""
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -56,7 +65,8 @@ def workspace(request: pytest.FixtureRequest, test_data_dir: Path) -> Path | Non
     """
     marker = request.node.get_closest_marker("workspace")
     if marker is None:
-        return None
+        yield None
+        return
     if not marker.args or not isinstance(marker.args[0], str):
         raise pytest.UsageError(
             "@pytest.mark.workspace requires a string argument, e.g. "
@@ -69,7 +79,11 @@ def workspace(request: pytest.FixtureRequest, test_data_dir: Path) -> Path | Non
     clice_dir = path / ".clice"
     if clice_dir.exists():
         shutil.rmtree(clice_dir)
-    return path
+    yield path
+    # Post-test cleanup: drop the cache generated during the test so static
+    # test-data directories don't accumulate state.
+    if clice_dir.exists():
+        shutil.rmtree(clice_dir, ignore_errors=True)
 
 
 @pytest.fixture
@@ -95,7 +109,21 @@ async def client(
 
     yield c
 
-    await shutdown_client(c)
+    test_failed = (
+        getattr(request.node, "rep_call", None) is not None
+        and request.node.rep_call.failed
+    )
+    await shutdown_client(c, verbose=test_failed)
+    check_no_anomaly(request, c)
+
+
+def check_no_anomaly(request: pytest.FixtureRequest, c: CliceClient) -> None:
+    """Teardown gate: anomalies are internal clice bugs — every test session
+    must end without one. Tests that intentionally trigger anomalies opt out
+    with @pytest.mark.allow_anomaly and assert on them explicitly."""
+    if request.node.get_closest_marker("allow_anomaly") is not None:
+        return
+    assert_no_anomaly(c, c.workspace)
 
 
 def find_free_port() -> int:
@@ -129,6 +157,29 @@ async def agentic(
     yield executable, host, port
 
     await shutdown_client(c)
+    check_no_anomaly(request, c)
+
+
+def generate_cdb(workspace: Path) -> None:
+    """Generate compile_commands.json using CMake with Ninja backend."""
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        raise RuntimeError("cmake executable not found in PATH")
+    toolchain = Path(__file__).resolve().parent.parent / "cmake" / "toolchain.cmake"
+    cmd = [
+        cmake,
+        "-G",
+        "Ninja",
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        f"-DCMAKE_TOOLCHAIN_FILE={toolchain}",
+        "-S",
+        str(workspace),
+        "-B",
+        str(workspace / "build"),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        raise RuntimeError(f"cmake failed:\n{result.stderr}")
 
 
 async def make_client(executable: Path, workspace: Path) -> CliceClient:
@@ -203,7 +254,7 @@ async def assert_server_exited_cleanly(server, timeout: float = 10.0) -> None:
         pytest.fail("\n".join(failures))
 
 
-async def shutdown_client(c: CliceClient) -> None:
+async def shutdown_client(c: CliceClient, *, verbose: bool = False) -> None:
     """Gracefully shut down a client, force-kill if needed."""
     try:
         await asyncio.wait_for(c.shutdown_async(None), timeout=10.0)
@@ -214,6 +265,11 @@ async def shutdown_client(c: CliceClient) -> None:
         c.exit(None)
     except Exception:
         pass
+
+    if verbose and c.log_messages:
+        for msg in c.log_messages:
+            level = {1: "ERROR", 2: "WARN", 3: "INFO", 4: "LOG"}.get(msg.type, "?")
+            print(f"[logMessage/{level}] {msg.message}", flush=True)
 
     try:
         await assert_server_exited_cleanly(c.server)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,27 +160,6 @@ async def agentic(
     check_no_anomaly(request, c)
 
 
-def generate_cdb(workspace: Path) -> None:
-    """Generate compile_commands.json using CMake with Ninja backend."""
-    cmake = shutil.which("cmake")
-    if cmake is None:
-        raise RuntimeError("cmake executable not found in PATH")
-    toolchain = Path(__file__).resolve().parent.parent / "cmake" / "toolchain.cmake"
-    cmd = [
-        cmake,
-        "-G",
-        "Ninja",
-        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-        f"-DCMAKE_TOOLCHAIN_FILE={toolchain}",
-        "-S",
-        str(workspace),
-        "-B",
-        str(workspace / "build"),
-    ]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    if result.returncode != 0:
-        raise RuntimeError(f"cmake failed:\n{result.stderr}")
-
 
 async def make_client(executable: Path, workspace: Path) -> CliceClient:
     """Spawn a fresh clice server and initialize it. For multi-session tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,6 @@ async def agentic(
     check_no_anomaly(request, c)
 
 
-
 async def make_client(executable: Path, workspace: Path) -> CliceClient:
     """Spawn a fresh clice server and initialize it. For multi-session tests."""
     c = CliceClient()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def test_data_dir() -> Path:
 
 
 @pytest.fixture
-def workspace(request: pytest.FixtureRequest, test_data_dir: Path) -> Path | None:
+def workspace(request: pytest.FixtureRequest, test_data_dir: Path):
     """Resolve workspace path from @pytest.mark.workspace("subdir") marker.
 
     If the workspace contains a CMakeLists.txt, automatically runs cmake

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,12 @@ async def client(
         getattr(request.node, "rep_call", None) is not None
         and request.node.rep_call.failed
     )
-    await shutdown_client(c, verbose=test_failed)
-    check_no_anomaly(request, c)
+    # The anomaly gate must run even when shutdown itself fails — a crashed
+    # server is exactly when the anomaly evidence matters most.
+    try:
+        await shutdown_client(c, verbose=test_failed)
+    finally:
+        check_no_anomaly(request, c)
 
 
 def check_no_anomaly(request: pytest.FixtureRequest, c: CliceClient) -> None:
@@ -156,8 +160,10 @@ async def agentic(
 
     yield executable, host, port
 
-    await shutdown_client(c)
-    check_no_anomaly(request, c)
+    try:
+        await shutdown_client(c)
+    finally:
+        check_no_anomaly(request, c)
 
 
 async def make_client(executable: Path, workspace: Path) -> CliceClient:

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -143,7 +143,7 @@ async def test_concurrent_connections(agentic, workspace):
 async def indexed_agentic(request, executable, workspace):
     """Start server with LSP+agentic, compile a file, wait for indexing."""
     from tests.integration.utils.client import CliceClient
-    from tests.conftest import shutdown_client, find_free_port
+    from tests.conftest import check_no_anomaly, shutdown_client, find_free_port
 
     host = "127.0.0.1"
     port = find_free_port()
@@ -173,6 +173,7 @@ async def indexed_agentic(request, executable, workspace):
     rpc.close()
     c.close(uri)
     await shutdown_client(c)
+    check_no_anomaly(request, c)
 
 
 @pytest.mark.workspace("index_features")

--- a/tests/integration/agentic/test_cli.py
+++ b/tests/integration/agentic/test_cli.py
@@ -31,7 +31,7 @@ async def indexed_server(request, executable, workspace):
     """Start server with LSP+agentic, compile a file, wait for indexing."""
     import asyncio
     from tests.integration.utils.client import CliceClient
-    from tests.conftest import shutdown_client, find_free_port
+    from tests.conftest import check_no_anomaly, shutdown_client, find_free_port
 
     host = "127.0.0.1"
     port = find_free_port()
@@ -60,6 +60,7 @@ async def indexed_server(request, executable, workspace):
 
     c.close(uri)
     await shutdown_client(c)
+    check_no_anomaly(request, c)
 
 
 @pytest.mark.workspace("index_features")

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -17,6 +17,7 @@ from lsprotocol.types import (
 
 from tests.conftest import make_client, shutdown_client
 from tests.integration.utils import write_cdb, doc
+from tests.integration.utils.wait import MTIME_GRANULARITY, SETTLE_TIME
 from tests.integration.utils.cache import (
     cache_root,
     list_pch_files,
@@ -97,7 +98,7 @@ async def test_pch_reused_on_close_reopen(client, tmp_path):
 
     # Close.
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(SETTLE_TIME)
 
     # Clear diagnostics so we can wait for fresh ones.
     client.diagnostics.pop(uri, None)
@@ -224,7 +225,7 @@ async def test_pch_rebuilt_on_header_change(client, tmp_path):
     assert len(pch_before) >= 1
 
     # Modify header — changes preamble content hash.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").write_text("#pragma once\nstruct V2 { int b; };\n")
     # Also update main.cpp to use V2 so it compiles cleanly.
     (tmp_path / "main.cpp").write_text(
@@ -233,7 +234,7 @@ async def test_pch_rebuilt_on_header_change(client, tmp_path):
 
     # Close and reopen to get fresh preamble.
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(SETTLE_TIME)
     client.diagnostics.pop(uri, None)
 
     uri2, _ = await client.open_and_wait(tmp_path / "main.cpp")

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -26,7 +26,7 @@ from tests.integration.utils.cache import (
     pin_cache_to_workspace,
     read_cache_json,
 )
-from tests.integration.utils.assertions import assert_clean_compile
+from tests.integration.utils.assertions import assert_clean_compile, assert_no_anomaly
 
 
 async def test_pch_written_to_cache_dir(client, tmp_path):
@@ -135,6 +135,7 @@ async def test_pch_survives_server_restart(executable, tmp_path):
     cache_s1 = read_cache_json(tmp_path)
     assert cache_s1 is not None, "cache.json should exist after session 1"
 
+    assert_no_anomaly(c1, tmp_path)
     await shutdown_client(c1)
 
     # Session 2: restart server, reopen file.
@@ -153,6 +154,7 @@ async def test_pch_survives_server_restart(executable, tmp_path):
         "PCH file should not be rebuilt (mtime should be unchanged)"
     )
 
+    assert_no_anomaly(c2, tmp_path)
     await shutdown_client(c2)
 
 

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -378,6 +378,7 @@ async def test_kill9_recovery(executable, tmp_path):
     # Blob directories contain only committed blobs, never partial writes.
     stray = [p for p in (cache_root(tmp_path) / "pch").iterdir() if p.suffix != ".pch"]
     assert stray == [], f"Crash residue in pch/: {stray}"
+    assert_no_anomaly(c2, tmp_path)
     await shutdown_client(c2)
 
     # Clean shutdown removed session 2's own tmp; session 1's residue was

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -345,7 +345,9 @@ async def test_didclose_clears_hover(client, tmp_path):
     with pytest.raises(Exception, match="Document not open"):
         await asyncio.wait_for(
             client.text_document_hover_async(
-                HoverParams(text_document=doc(uri), position=Position(line=0, character=4))
+                HoverParams(
+                    text_document=doc(uri), position=Position(line=0, character=4)
+                )
             ),
             timeout=10.0,
         )

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -343,8 +343,11 @@ async def test_didclose_clears_hover(client, tmp_path):
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
 
     with pytest.raises(Exception, match="Document not open"):
-        await client.text_document_hover_async(
-            HoverParams(text_document=doc(uri), position=Position(line=0, character=4))
+        await asyncio.wait_for(
+            client.text_document_hover_async(
+                HoverParams(text_document=doc(uri), position=Position(line=0, character=4))
+            ),
+            timeout=10.0,
         )
 
 

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -23,7 +23,11 @@ from lsprotocol.types import (
 from tests.conftest import make_client, shutdown_client
 from tests.integration.utils import write_cdb, doc
 from tests.integration.utils.cache import list_pch_files, pin_cache_to_workspace
-from tests.integration.utils.wait import wait_for_recompile
+from tests.integration.utils.wait import (
+    MTIME_GRANULARITY,
+    SETTLE_TIME,
+    wait_for_recompile,
+)
 from tests.integration.utils.assertions import assert_clean_compile, assert_has_errors
 
 
@@ -44,7 +48,7 @@ async def test_header_change_invalidates_ast(client, tmp_path):
 
     # Modify header on disk — introduce an error.
     # Ensure mtime advances past filesystem granularity (1s on some FSes).
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").write_text(
         "inline int value() { return }\n"
     )  # syntax error
@@ -73,7 +77,7 @@ async def test_header_change_invalidates_pch(client, tmp_path):
 
     # Modify header — rename struct field.
     # Ensure mtime advances past filesystem granularity (1s on some FSes).
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").write_text(
         "#pragma once\nstruct Foo { int y; };\n"  # x -> y
     )
@@ -117,16 +121,22 @@ async def test_touch_without_content_change_skips_recompile(client, tmp_path):
     assert_clean_compile(client, uri)
 
     # Touch the header — mtime changes but content stays the same.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     original_content = (tmp_path / "header.h").read_text()
     (tmp_path / "header.h").write_text(original_content)
 
     # Hover triggers ensure_compiled which runs deps_changed.
     # Layer 2 hash confirms nothing actually changed → cached AST reused.
-    # Hover on "main" (line 1, col 4) which should be hoverable.
-    hover = await client.text_document_hover_async(
-        HoverParams(text_document=doc(uri), position=Position(line=1, character=4))
-    )
+    # The first hover may see ast_dirty=true (mtime changed, hash check in
+    # progress), so retry to let the hash check complete.
+    hover = None
+    for _ in range(3):
+        hover = await client.text_document_hover_async(
+            HoverParams(text_document=doc(uri), position=Position(line=1, character=4))
+        )
+        if hover is not None:
+            break
+        await asyncio.sleep(SETTLE_TIME)
     assert hover is not None
 
     # No new diagnostics should appear — the file is still clean.
@@ -147,7 +157,7 @@ async def test_header_replaced_with_different_content(client, tmp_path):
     assert_clean_compile(client, uri)
 
     # Replace header — delete and recreate with a breaking change.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").unlink()
     (tmp_path / "header.h").write_text("inline int renamed_value() { return 1; }\n")
 
@@ -172,7 +182,7 @@ async def test_fix_error_clears_diagnostics(client, tmp_path):
     assert_has_errors(client, uri, "Expected diagnostics from broken header")
 
     # Fix the header.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").write_text("inline int value() { return 1; }\n")
 
     # Hover triggers recompilation — diagnostics should clear.
@@ -200,7 +210,7 @@ async def test_multiple_files_share_header(client, tmp_path):
     assert_clean_compile(client, uri_b)
 
     # Break the shared header.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "shared.h").write_text("inline int shared() { return }\n")
 
     # Both files should get diagnostics after hover.
@@ -225,7 +235,7 @@ async def test_transitive_header_change(client, tmp_path):
     assert_clean_compile(client, uri)
 
     # Modify the transitive dep (base.h).
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "base.h").write_text("inline int base() { return }\n")  # broken
 
     await wait_for_recompile(client, uri)
@@ -312,7 +322,7 @@ async def test_didclose_then_reopen(client, tmp_path):
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
 
     # Modify on disk while closed.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "main.cpp").write_text("int main() { return }\n")  # broken
 
     # Reopen — should compile the new (broken) content from disk.
@@ -323,7 +333,7 @@ async def test_didclose_then_reopen(client, tmp_path):
 
 
 async def test_didclose_clears_hover(client, tmp_path):
-    """After didClose, hover on the closed file should return None."""
+    """After didClose, hover on the closed file should return an error."""
     (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
     write_cdb(tmp_path, ["main.cpp"])
     await client.initialize(tmp_path)
@@ -332,10 +342,10 @@ async def test_didclose_clears_hover(client, tmp_path):
 
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
 
-    hover = await client.text_document_hover_async(
-        HoverParams(text_document=doc(uri), position=Position(line=0, character=4))
-    )
-    assert hover is None, "Hover on closed file should return None"
+    with pytest.raises(Exception, match="Document not open"):
+        await client.text_document_hover_async(
+            HoverParams(text_document=doc(uri), position=Position(line=0, character=4))
+        )
 
 
 async def test_didsave_triggers_recompile_for_dependents(client, tmp_path):
@@ -351,7 +361,7 @@ async def test_didsave_triggers_recompile_for_dependents(client, tmp_path):
     assert_clean_compile(client, uri)
 
     # Modify header on disk and send didSave.
-    await asyncio.sleep(1.1)
+    await asyncio.sleep(MTIME_GRANULARITY)
     (tmp_path / "header.h").write_text("inline int value() { return }\n")  # broken
     client.text_document_did_save(
         DidSaveTextDocumentParams(

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -28,7 +28,11 @@ from tests.integration.utils.wait import (
     SETTLE_TIME,
     wait_for_recompile,
 )
-from tests.integration.utils.assertions import assert_clean_compile, assert_has_errors
+from tests.integration.utils.assertions import (
+    assert_clean_compile,
+    assert_has_errors,
+    assert_no_anomaly,
+)
 
 
 async def test_header_change_invalidates_ast(client, tmp_path):
@@ -431,6 +435,7 @@ async def test_flag_change_invalidates_pch(executable, tmp_path):
     uri, _ = await c1.open_and_wait(tmp_path / "main.cpp")
     assert_clean_compile(c1, uri)
     assert len(list_pch_files(tmp_path)) == 1
+    assert_no_anomaly(c1, tmp_path)
     await shutdown_client(c1)
 
     # Session 2: same preamble text, different flag — must not reuse.
@@ -441,4 +446,5 @@ async def test_flag_change_invalidates_pch(executable, tmp_path):
     assert len(list_pch_files(tmp_path)) == 2, (
         "A flag change must produce a second, separately keyed PCH"
     )
+    assert_no_anomaly(c2, tmp_path)
     await shutdown_client(c2)

--- a/tests/integration/features/test_guidance_diagnostics.py
+++ b/tests/integration/features/test_guidance_diagnostics.py
@@ -67,5 +67,6 @@ async def test_fallback_clean_no_guidance(executable, tmp_path):
     try:
         uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
         assert not guidance_diags(client, uri)
+        assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)

--- a/tests/integration/features/test_guidance_diagnostics.py
+++ b/tests/integration/features/test_guidance_diagnostics.py
@@ -1,0 +1,71 @@
+"""Guidance diagnostics for files compiled with guessed compile commands.
+
+When a file has no compilation database entry, clice compiles it with a
+synthesized fallback command. If that produces file-not-found errors, a
+file-top warning explains the situation; an exact CDB match never gets it.
+"""
+
+from lsprotocol.types import DiagnosticSeverity
+
+from tests.conftest import make_client, shutdown_client
+from tests.integration.utils import write_cdb
+from tests.integration.utils.assertions import assert_no_anomaly, guidance_messages
+
+GUIDANCE_CODE = "inferred-compile-command"
+
+BROKEN_INCLUDE = '#include "no_such_header.h"\nint main() { return 0; }\n'
+
+
+def guidance_diags(client, uri):
+    return [d for d in client.diagnostics.get(uri, []) if d.code == GUIDANCE_CODE]
+
+
+def file_not_found_diags(client, uri):
+    return [
+        d for d in client.diagnostics.get(uri, []) if d.code == "err_pp_file_not_found"
+    ]
+
+
+async def test_fallback_guidance_lifecycle(executable, tmp_path):
+    (tmp_path / "main.cpp").write_text(BROKEN_INCLUDE)
+
+    # Phase 1: no CDB — fallback command, broken include → guidance at the top.
+    client = await make_client(executable, tmp_path)
+    try:
+        uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+        assert file_not_found_diags(client, uri), "broken include should surface"
+        guidance = guidance_diags(client, uri)
+        assert len(guidance) == 1, f"expected one guidance diagnostic: {guidance}"
+        assert guidance[0].severity == DiagnosticSeverity.Warning
+        assert guidance[0].range.start.line == 0
+        assert guidance[0].source == "clice"
+        # The missing CDB is also announced via window/logMessage guidance.
+        assert any("compile_commands.json" in m for m in guidance_messages(client))
+        assert_no_anomaly(client, tmp_path)
+    finally:
+        await shutdown_client(client)
+
+    # Phase 2: provide a CDB and restart — the include error remains, the
+    # guidance diagnostic must disappear (exact CDB match never gets it).
+    write_cdb(tmp_path, ["main.cpp"])
+    client = await make_client(executable, tmp_path)
+    try:
+        uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+        assert file_not_found_diags(client, uri), "include is still broken"
+        assert not guidance_diags(client, uri), (
+            "CDB-matched files must not get the inferred-command guidance"
+        )
+        assert_no_anomaly(client, tmp_path)
+    finally:
+        await shutdown_client(client)
+
+
+async def test_fallback_clean_no_guidance(executable, tmp_path):
+    # A guessed command that works produces no guidance noise.
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    client = await make_client(executable, tmp_path)
+    try:
+        uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+        assert not guidance_diags(client, uri)
+    finally:
+        await shutdown_client(client)

--- a/tests/integration/features/test_guidance_diagnostics.py
+++ b/tests/integration/features/test_guidance_diagnostics.py
@@ -60,6 +60,29 @@ async def test_fallback_guidance_lifecycle(executable, tmp_path):
         await shutdown_client(client)
 
 
+async def test_fallback_applies_rule_appends(executable, tmp_path):
+    # Without a CDB, include paths supplied via clice.toml rules must reach
+    # the synthesized fallback command.
+    (tmp_path / "inc").mkdir()
+    (tmp_path / "inc" / "dep.h").write_text("#pragma once\nconstexpr int dep = 1;\n")
+    (tmp_path / "main.cpp").write_text('#include "dep.h"\nint main() { return dep; }\n')
+    include_dir = (tmp_path / "inc").as_posix()
+    (tmp_path / "clice.toml").write_text(
+        f'[[rules]]\npatterns = ["**/*.cpp"]\nappend = ["-I{include_dir}"]\n'
+    )
+
+    client = await make_client(executable, tmp_path)
+    try:
+        uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+        assert not file_not_found_diags(client, uri), (
+            "rule -I must reach the fallback command"
+        )
+        assert not guidance_diags(client, uri)
+        assert_no_anomaly(client, tmp_path)
+    finally:
+        await shutdown_client(client)
+
+
 async def test_fallback_clean_no_guidance(executable, tmp_path):
     # A guessed command that works produces no guidance noise.
     (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")

--- a/tests/integration/features/test_index.py
+++ b/tests/integration/features/test_index.py
@@ -4,9 +4,12 @@ CallHierarchy, TypeHierarchy, and WorkspaceSymbol."""
 import pytest
 from lsprotocol.types import (
     CallHierarchyIncomingCallsParams,
+    CallHierarchyItem,
     CallHierarchyOutgoingCallsParams,
     CallHierarchyPrepareParams,
     Position,
+    Range,
+    SymbolKind,
     TypeHierarchyPrepareParams,
     TypeHierarchySubtypesParams,
     TypeHierarchySupertypesParams,
@@ -72,6 +75,24 @@ async def test_call_hierarchy_prepare(client, workspace):
     assert len(result) > 0, f"prepareCallHierarchy returned empty, result={result}"
     assert result[0].name == "add", f"Expected 'add', got '{result[0].name}'"
 
+    client.close(uri)
+
+
+@pytest.mark.workspace("index_features")
+async def test_call_hierarchy_bogus_item(client, workspace):
+    """incomingCalls with an unresolvable item returns an error, not null."""
+    uri, _ = await client.open_and_wait(workspace / "main.cpp")
+    bogus = CallHierarchyItem(
+        name="ghost",
+        kind=SymbolKind.Function,
+        uri="file:///nonexistent/ghost.cpp",
+        range=Range(start=Position(0, 0), end=Position(0, 5)),
+        selection_range=Range(start=Position(0, 0), end=Position(0, 5)),
+    )
+    with pytest.raises(Exception, match="Failed to resolve call hierarchy item"):
+        await client.call_hierarchy_incoming_calls_async(
+            CallHierarchyIncomingCallsParams(item=bogus)
+        )
     client.close(uri)
 
 

--- a/tests/integration/features/test_server.py
+++ b/tests/integration/features/test_server.py
@@ -214,6 +214,13 @@ async def test_hover_on_unknown_file(client, workspace):
 
 
 @pytest.mark.workspace("hello_world")
+async def test_hover_out_of_range_position(client, workspace):
+    uri, _ = await client.open_and_wait(workspace / "main.cpp")
+    with pytest.raises(Exception, match="Invalid position"):
+        await client.hover_at(uri, 99999, 0)
+
+
+@pytest.mark.workspace("hello_world")
 async def test_all_features_after_compile_wait(client, workspace):
     """Exercise all feature requests after compilation completes."""
     uri, _ = await client.open_and_wait(workspace / "main.cpp")

--- a/tests/integration/features/test_server.py
+++ b/tests/integration/features/test_server.py
@@ -10,6 +10,7 @@ from lsprotocol.types import (
 )
 
 from tests.integration.utils import doc
+from tests.integration.utils.wait import SETTLE_TIME
 from tests.integration.utils.workspace import did_change
 
 
@@ -72,7 +73,7 @@ async def test_semantic_token_modifier_legend(client, workspace):
 @pytest.mark.workspace("hello_world")
 async def test_did_open_close_cycle(client, workspace):
     uri, _ = client.open(workspace / "main.cpp")
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(SETTLE_TIME)
     client.close(uri)
 
 
@@ -85,8 +86,8 @@ async def test_shutdown_exit(client, workspace):
 async def test_feature_requests_after_close(client, workspace):
     uri, _ = client.open(workspace / "main.cpp")
     client.close(uri)
-    result = await client.hover_at(uri, 0, 0)
-    assert result is None
+    with pytest.raises(Exception, match="Document not open"):
+        await client.hover_at(uri, 0, 0)
 
 
 @pytest.mark.workspace("hello_world")
@@ -96,7 +97,7 @@ async def test_incremental_change(client, workspace):
         content += f"\n// change {i}"
         did_change(client, uri, i + 1, content)
         await asyncio.sleep(0.05)
-    await asyncio.sleep(1)
+    await asyncio.sleep(SETTLE_TIME * 2)
     client.close(uri)
 
 
@@ -193,23 +194,23 @@ async def test_rapid_changes_stress(client, workspace):
     for i in range(20):
         content += f"\n// stress change {i}\n"
         did_change(client, uri, i + 1, content)
-    await asyncio.sleep(2)
+    await asyncio.sleep(SETTLE_TIME * 4)
     client.close(uri)
 
 
 @pytest.mark.workspace("hello_world")
 async def test_save_notification(client, workspace):
     uri, _ = client.open(workspace / "main.cpp")
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(SETTLE_TIME)
     client.text_document_did_save(DidSaveTextDocumentParams(text_document=doc(uri)))
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(SETTLE_TIME)
     client.close(uri)
 
 
 @pytest.mark.workspace("hello_world")
 async def test_hover_on_unknown_file(client, workspace):
-    result = await client.hover_at("file:///nonexistent/fake.cpp", 0, 0)
-    assert result is None
+    with pytest.raises(Exception, match="Document not open"):
+        await client.hover_at("file:///nonexistent/fake.cpp", 0, 0)
 
 
 @pytest.mark.workspace("hello_world")

--- a/tests/integration/features/test_server.py
+++ b/tests/integration/features/test_server.py
@@ -215,9 +215,21 @@ async def test_hover_on_unknown_file(client, workspace):
 
 @pytest.mark.workspace("hello_world")
 async def test_hover_out_of_range_position(client, workspace):
+    # Positions beyond the document clamp to the end of content (LSP spec).
     uri, _ = await client.open_and_wait(workspace / "main.cpp")
-    with pytest.raises(Exception, match="Invalid position"):
-        await client.hover_at(uri, 99999, 0)
+    await client.hover_at(uri, 99999, 0)
+
+
+@pytest.mark.workspace("hello_world")
+async def test_format_range_out_of_range(client, workspace):
+    # Range endpoints beyond the document clamp as well (forward_format path).
+    uri, _ = await client.open_and_wait(workspace / "main.cpp")
+    await client.format_range(
+        uri,
+        Range(
+            start=Position(line=0, character=999), end=Position(line=9999, character=0)
+        ),
+    )
 
 
 @pytest.mark.workspace("hello_world")

--- a/tests/integration/lifecycle/test_anomaly.py
+++ b/tests/integration/lifecycle/test_anomaly.py
@@ -1,0 +1,75 @@
+"""End-to-end check of the anomaly reporting machinery.
+
+Kills a worker process and verifies the master reports `[anomaly:worker_crash]`
+both via window/logMessage and in its log file — the same channels
+assert_no_anomaly() watches in every other test's teardown.
+"""
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import make_client, shutdown_client
+from tests.integration.utils import write_cdb
+from tests.integration.utils.assertions import (
+    anomalies_in_log_files,
+    anomalies_in_log_messages,
+)
+
+
+def child_pids(parent_pid: int) -> list[int]:
+    pids = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text()
+        except OSError:
+            continue
+        # /proc/<pid>/stat: pid (comm) state ppid ...
+        ppid = int(stat.rsplit(")", 1)[1].split()[1])
+        if ppid == parent_pid:
+            pids.append(int(entry.name))
+    return pids
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="worker discovery uses /proc")
+@pytest.mark.allow_anomaly
+async def test_worker_crash_reported(executable, tmp_path):
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    write_cdb(tmp_path, ["main.cpp"])
+
+    # Debug builds abort on anomalies by design; disable the trap so this
+    # test can observe the report-and-continue (Release) behavior everywhere.
+    os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
+    try:
+        client = await make_client(executable, tmp_path)
+    finally:
+        os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
+
+    try:
+        await client.open_and_wait(tmp_path / "main.cpp")
+
+        server_pid = client._server.pid
+        workers = child_pids(server_pid)
+        assert workers, "server should have spawned worker processes"
+        os.kill(workers[0], signal.SIGKILL)
+
+        for _ in range(50):
+            if "worker_crash" in anomalies_in_log_messages(client):
+                break
+            await asyncio.sleep(0.2)
+        assert "worker_crash" in anomalies_in_log_messages(client), (
+            f"expected worker_crash anomaly, got messages: "
+            f"{[m.message for m in client.log_messages]}"
+        )
+    finally:
+        await shutdown_client(client)
+
+    # The same marker must be greppable in the log files (this is what
+    # assert_no_anomaly relies on for worker-side anomalies).
+    assert any("worker_crash" in entry for entry in anomalies_in_log_files(tmp_path))

--- a/tests/integration/lifecycle/test_anomaly.py
+++ b/tests/integration/lifecycle/test_anomaly.py
@@ -54,10 +54,14 @@ async def test_worker_crash_reported(executable, tmp_path):
     try:
         await client.open_and_wait(tmp_path / "main.cpp")
 
-        server_pid = client._server.pid
+        server_pid = client.server.pid
         workers = child_pids(server_pid)
         assert workers, "server should have spawned worker processes"
-        os.kill(workers[0], signal.SIGKILL)
+        # SIGABRT: dies via the same signal path as clice's own Debug traps,
+        # exercises the crash handler, and is not intercepted by ASan
+        # (handle_abort=0), unlike SIGSEGV which ASan turns into its own
+        # report and a plain exit(1).
+        os.kill(workers[0], signal.SIGABRT)
 
         for _ in range(50):
             if "worker_crash" in anomalies_in_log_messages(client):
@@ -73,3 +77,21 @@ async def test_worker_crash_reported(executable, tmp_path):
     # The same marker must be greppable in the log files (this is what
     # assert_no_anomaly relies on for worker-side anomalies).
     assert any("worker_crash" in entry for entry in anomalies_in_log_files(tmp_path))
+
+    # The abort also exercises the crash handler: the worker's backtrace
+    # must land in its own log file — and ONLY there, never relayed into
+    # the master log.
+    logs_dir = tmp_path / ".clice" / "logs"
+    worker_texts = [
+        p.read_text(errors="replace")
+        for p in logs_dir.rglob("*.log")
+        if p.name != "master.log"
+    ]
+    assert any("CRASH STACK TRACE" in text for text in worker_texts), (
+        "worker crash backtrace should be written to its log file"
+    )
+    master_texts = [p.read_text(errors="replace") for p in logs_dir.rglob("master.log")]
+    assert master_texts and all(
+        "CRASH STACK TRACE" not in text and "Stack dump" not in text
+        for text in master_texts
+    ), "worker backtrace must not leak into the master log"

--- a/tests/integration/lifecycle/test_anomaly.py
+++ b/tests/integration/lifecycle/test_anomaly.py
@@ -1,6 +1,6 @@
 """End-to-end check of the anomaly reporting machinery.
 
-Kills a worker process and verifies the master reports `[anomaly:worker_crash]`
+Kills a worker process and verifies the master reports `[anomaly:WorkerCrash]`
 both via window/logMessage and in its log file — the same channels
 assert_no_anomaly() watches in every other test's teardown.
 """
@@ -64,11 +64,11 @@ async def test_worker_crash_reported(executable, tmp_path):
         os.kill(workers[0], signal.SIGABRT)
 
         for _ in range(50):
-            if "worker_crash" in anomalies_in_log_messages(client):
+            if "WorkerCrash" in anomalies_in_log_messages(client):
                 break
             await asyncio.sleep(0.2)
-        assert "worker_crash" in anomalies_in_log_messages(client), (
-            f"expected worker_crash anomaly, got messages: "
+        assert "WorkerCrash" in anomalies_in_log_messages(client), (
+            f"expected WorkerCrash anomaly, got messages: "
             f"{[m.message for m in client.log_messages]}"
         )
     finally:
@@ -76,7 +76,7 @@ async def test_worker_crash_reported(executable, tmp_path):
 
     # The same marker must be greppable in the log files (this is what
     # assert_no_anomaly relies on for worker-side anomalies).
-    assert any("worker_crash" in entry for entry in anomalies_in_log_files(tmp_path))
+    assert any("WorkerCrash" in entry for entry in anomalies_in_log_files(tmp_path))
 
     # The abort also exercises the crash handler: the worker's backtrace
     # must land in its own log file — and ONLY there, never relayed into

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -6,7 +6,9 @@ clean; otherwise an undeclared-identifier diagnostic surfaces.
 """
 
 import pytest
+from lsprotocol.types import DiagnosticSeverity
 
+from tests.conftest import make_client, shutdown_client
 from tests.integration.utils.assertions import (
     assert_clean_compile,
     assert_has_errors,
@@ -66,3 +68,61 @@ async def test_init_options_replaces_toml_rules(client, workspace):
 async def test_rules_pattern_mismatch(client, workspace):
     uri, _ = await client.open_and_wait(workspace / "main.cpp")
     assert_has_errors(client, uri, "Rule pattern should not have matched main.cpp")
+
+
+async def test_config_type_error_diagnostic(executable, tmp_path):
+    # Wrong value type → Error diagnostic on the clice.toml URI with the
+    # offending line/column; the config falls back to defaults.
+    (tmp_path / "clice.toml").write_text('[project]\nclang_tidy = "yes"\n')
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    client = await make_client(executable, tmp_path)
+    try:
+        toml_uri = client.path_to_uri(tmp_path / "clice.toml")
+        await client.wait_diagnostics(toml_uri, timeout=10)
+        diags = client.diagnostics[toml_uri]
+        assert len(diags) == 1, f"expected one config diagnostic: {diags}"
+        assert diags[0].severity == DiagnosticSeverity.Error
+        assert diags[0].range.start.line == 1  # clang_tidy is on line 2 (0-based 1)
+        assert "clang_tidy" in diags[0].message
+    finally:
+        await shutdown_client(client)
+
+
+async def test_config_unknown_key_diagnostic(executable, tmp_path):
+    # Typo'd key → Warning diagnostic; the rest of the config still applies.
+    (tmp_path / "clice.toml").write_text("[project]\nclang_tdy = true\n")
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    client = await make_client(executable, tmp_path)
+    try:
+        toml_uri = client.path_to_uri(tmp_path / "clice.toml")
+        await client.wait_diagnostics(toml_uri, timeout=10)
+        diags = client.diagnostics[toml_uri]
+        assert len(diags) == 1, f"expected one config diagnostic: {diags}"
+        assert diags[0].severity == DiagnosticSeverity.Warning
+        assert diags[0].range.start.line == 1
+        assert "clang_tdy" in diags[0].message
+    finally:
+        await shutdown_client(client)
+
+
+async def test_config_diagnostic_clears_after_fix(executable, tmp_path):
+    (tmp_path / "clice.toml").write_text('[project]\nclang_tidy = "yes"\n')
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    client = await make_client(executable, tmp_path)
+    try:
+        toml_uri = client.path_to_uri(tmp_path / "clice.toml")
+        await client.wait_diagnostics(toml_uri, timeout=10)
+        assert client.diagnostics[toml_uri], "broken config should be diagnosed"
+    finally:
+        await shutdown_client(client)
+
+    # Fix the config and restart — the new session publishes an empty list
+    # for the config URI so stale markers clear.
+    (tmp_path / "clice.toml").write_text("[project]\nclang_tidy = true\n")
+    client = await make_client(executable, tmp_path)
+    try:
+        toml_uri = client.path_to_uri(tmp_path / "clice.toml")
+        await client.wait_diagnostics(toml_uri, timeout=10)
+        assert client.diagnostics[toml_uri] == [], "fixed config must clear diagnostics"
+    finally:
+        await shutdown_client(client)

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -12,6 +12,7 @@ from tests.conftest import make_client, shutdown_client
 from tests.integration.utils.assertions import (
     assert_clean_compile,
     assert_has_errors,
+    assert_no_anomaly,
     get_errors,
 )
 
@@ -83,7 +84,9 @@ async def test_config_type_error_diagnostic(executable, tmp_path):
         assert len(diags) == 1, f"expected one config diagnostic: {diags}"
         assert diags[0].severity == DiagnosticSeverity.Error
         assert diags[0].range.start.line == 1  # clang_tidy is on line 2 (0-based 1)
+        assert diags[0].range.start.character > 0
         assert "clang_tidy" in diags[0].message
+        assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)
 
@@ -100,7 +103,9 @@ async def test_config_unknown_key_diagnostic(executable, tmp_path):
         assert len(diags) == 1, f"expected one config diagnostic: {diags}"
         assert diags[0].severity == DiagnosticSeverity.Warning
         assert diags[0].range.start.line == 1
+        assert diags[0].range.start.character > 0
         assert "clang_tdy" in diags[0].message
+        assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)
 
@@ -124,5 +129,6 @@ async def test_config_diagnostic_clears_after_fix(executable, tmp_path):
         toml_uri = client.path_to_uri(tmp_path / "clice.toml")
         await client.wait_diagnostics(toml_uri, timeout=10)
         assert client.diagnostics[toml_uri] == [], "fixed config must clear diagnostics"
+        assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -83,8 +83,6 @@ async def test_config_type_error_diagnostic(executable, tmp_path):
         diags = client.diagnostics[toml_uri]
         assert len(diags) == 1, f"expected one config diagnostic: {diags}"
         assert diags[0].severity == DiagnosticSeverity.Error
-        assert diags[0].range.start.line == 1  # clang_tidy is on line 2 (0-based 1)
-        assert diags[0].range.start.character > 0
         assert "clang_tidy" in diags[0].message
         assert_no_anomaly(client, tmp_path)
     finally:
@@ -102,8 +100,6 @@ async def test_config_unknown_key_diagnostic(executable, tmp_path):
         diags = client.diagnostics[toml_uri]
         assert len(diags) == 1, f"expected one config diagnostic: {diags}"
         assert diags[0].severity == DiagnosticSeverity.Warning
-        assert diags[0].range.start.line == 1
-        assert diags[0].range.start.character > 0
         assert "clang_tdy" in diags[0].message
         assert_no_anomaly(client, tmp_path)
     finally:

--- a/tests/integration/lifecycle/test_config.py
+++ b/tests/integration/lifecycle/test_config.py
@@ -72,8 +72,9 @@ async def test_rules_pattern_mismatch(client, workspace):
 
 
 async def test_config_type_error_diagnostic(executable, tmp_path):
-    # Wrong value type → Error diagnostic on the clice.toml URI with the
-    # offending line/column; the config falls back to defaults.
+    # Wrong value type → Error diagnostic on the clice.toml URI; the config
+    # falls back to defaults. (Line/column pinpointing awaits the kotatsu
+    # TOML error-location feature — see config_tests.cpp.)
     (tmp_path / "clice.toml").write_text('[project]\nclang_tidy = "yes"\n')
     (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
     client = await make_client(executable, tmp_path)
@@ -114,6 +115,7 @@ async def test_config_diagnostic_clears_after_fix(executable, tmp_path):
         toml_uri = client.path_to_uri(tmp_path / "clice.toml")
         await client.wait_diagnostics(toml_uri, timeout=10)
         assert client.diagnostics[toml_uri], "broken config should be diagnosed"
+        assert_no_anomaly(client, tmp_path)
     finally:
         await shutdown_client(client)
 

--- a/tests/integration/lifecycle/test_file_operation.py
+++ b/tests/integration/lifecycle/test_file_operation.py
@@ -13,13 +13,14 @@ from lsprotocol.types import (
 )
 
 from tests.integration.utils import doc
+from tests.integration.utils.wait import IDLE_TIMEOUT
 from tests.integration.utils.workspace import did_change
 
 
 @pytest.mark.workspace("hello_world")
 async def test_did_open(client, workspace):
     client.open(workspace / "main.cpp")
-    await asyncio.sleep(5)
+    await asyncio.sleep(IDLE_TIMEOUT)
 
 
 @pytest.mark.workspace("hello_world")
@@ -29,13 +30,13 @@ async def test_did_change(client, workspace):
         content += "\n"
         await asyncio.sleep(0.2)
         did_change(client, uri, i + 1, content)
-    await asyncio.sleep(5)
+    await asyncio.sleep(IDLE_TIMEOUT)
 
 
 @pytest.mark.workspace("clang_tidy")
 async def test_clang_tidy(client, workspace):
     client.open(workspace / "main.cpp")
-    await asyncio.sleep(5)
+    await asyncio.sleep(IDLE_TIMEOUT)
 
 
 @pytest.mark.workspace("hello_world")
@@ -56,7 +57,7 @@ async def test_hover_save_close(client, workspace):
         )
     )
     client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
-    closed_hover = await client.text_document_hover_async(
-        HoverParams(text_document=doc(uri), position=Position(line=0, character=0))
-    )
-    assert closed_hover is None
+    with pytest.raises(Exception, match="Document not open"):
+        await client.text_document_hover_async(
+            HoverParams(text_document=doc(uri), position=Position(line=0, character=0))
+        )

--- a/tests/integration/modules/test_modules.py
+++ b/tests/integration/modules/test_modules.py
@@ -14,6 +14,7 @@ from lsprotocol.types import (
 )
 
 from tests.integration.utils.assertions import assert_clean_compile, assert_has_errors
+from tests.integration.utils.wait import IDLE_TIMEOUT
 
 
 @pytest.mark.workspace("modules/single_module_no_deps")
@@ -267,7 +268,7 @@ async def test_circular_module_dependency(client, workspace):
     the server remains responsive by opening a non-cyclic file afterwards.
     """
     client.open(workspace / "cycle_a.cppm")
-    await asyncio.sleep(5.0)
+    await asyncio.sleep(IDLE_TIMEOUT)
 
     uri_ok, _ = await client.open_and_wait(workspace / "ok.cppm")
     diags = client.diagnostics.get(uri_ok, [])

--- a/tests/integration/stress/test_rapid_edit.py
+++ b/tests/integration/stress/test_rapid_edit.py
@@ -10,6 +10,7 @@ from lsprotocol.types import (
 )
 
 from tests.integration.utils import doc
+from tests.integration.utils.wait import SETTLE_TIME
 from tests.integration.utils.workspace import did_change
 
 
@@ -53,7 +54,7 @@ async def test_rapid_edits_with_hover(client, workspace):
         await asyncio.sleep(0.02)  # ~20ms between edits
 
     # Wait a moment for in-flight requests to settle.
-    await asyncio.sleep(1.0)
+    await asyncio.sleep(SETTLE_TIME * 2)
 
     # Final hover must succeed and return correct result.
     final_hover = await asyncio.wait_for(

--- a/tests/integration/utils/assertions.py
+++ b/tests/integration/utils/assertions.py
@@ -1,6 +1,57 @@
-"""Diagnostic assertion helpers for integration tests."""
+"""Diagnostic and anomaly assertion helpers for integration tests."""
+
+import re
+from pathlib import Path
 
 from lsprotocol.types import Diagnostic, DiagnosticSeverity
+
+ANOMALY_PATTERN = re.compile(r"\[anomaly:([a-z_]+)\]")
+
+
+def anomalies_in_log_messages(client) -> list[str]:
+    """Anomaly IDs from window/logMessage notifications (master process)."""
+    found = []
+    for msg in client.log_messages:
+        match = ANOMALY_PATTERN.search(msg.message)
+        if match:
+            found.append(match.group(1))
+    return found
+
+
+def anomalies_in_log_files(workspace: Path | None) -> list[str]:
+    """Anomaly IDs from master/worker log files under <workspace>/.clice/logs.
+
+    Workers don't forward logMessage in v1.0, so their anomalies are only
+    visible in their log files.
+    """
+    if workspace is None:
+        return []
+    logs_dir = Path(workspace) / ".clice" / "logs"
+    if not logs_dir.exists():
+        return []
+    found = []
+    for log_file in sorted(logs_dir.rglob("*.log")):
+        for line in log_file.read_text(errors="replace").splitlines():
+            match = ANOMALY_PATTERN.search(line)
+            if match:
+                found.append(f"{match.group(1)} ({log_file.name}: {line.strip()})")
+    return found
+
+
+def assert_no_anomaly(client, workspace: Path | None = None) -> None:
+    """Assert the session produced zero anomalies (client messages + logs).
+
+    Runs in every integration test teardown: anomalies are internal clice
+    bugs and must never occur on regular paths.
+    """
+    found = anomalies_in_log_messages(client)
+    found += anomalies_in_log_files(workspace)
+    assert not found, f"clice reported internal anomalies: {found}"
+
+
+def guidance_messages(client) -> list[str]:
+    """Guidance texts from window/logMessage notifications."""
+    return [msg.message for msg in client.log_messages if "[guidance]" in msg.message]
 
 
 def get_errors(diagnostics: list[Diagnostic]) -> list[Diagnostic]:

--- a/tests/integration/utils/assertions.py
+++ b/tests/integration/utils/assertions.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from lsprotocol.types import Diagnostic, DiagnosticSeverity
 
-ANOMALY_PATTERN = re.compile(r"\[anomaly:([a-z_]+)\]")
+ANOMALY_PATTERN = re.compile(r"\[anomaly:([A-Za-z]+)\]")
 
 
 def anomalies_in_log_messages(client) -> list[str]:

--- a/tests/integration/utils/client.py
+++ b/tests/integration/utils/client.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote
 from lsprotocol.types import (
     PROGRESS,
     TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS,
+    WINDOW_LOG_MESSAGE,
     WINDOW_WORK_DONE_PROGRESS_CREATE,
     ClientCapabilities,
     CodeActionContext,
@@ -27,6 +28,7 @@ from lsprotocol.types import (
     InitializeParams,
     InitializeResult,
     InitializedParams,
+    LogMessageParams,
     Position,
     ProgressParams,
     PublishDiagnosticsParams,
@@ -51,9 +53,11 @@ class CliceClient(BaseLanguageClient):
         super().__init__("clice-test-client", "0.1.0")
         self.diagnostics: dict[str, list[Diagnostic]] = {}
         self.diagnostics_events: dict[str, asyncio.Event] = {}
+        self.log_messages: list[LogMessageParams] = []
         self.progress_tokens: list[str] = []
         self.progress_events: list[dict] = []
         self.init_result: InitializeResult | None = None
+        self.workspace: Path | None = None
 
         @self.feature(TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
         def on_diagnostics(params: PublishDiagnosticsParams) -> None:
@@ -66,6 +70,10 @@ class CliceClient(BaseLanguageClient):
             for key in (raw_uri, normalized):
                 if key in self.diagnostics_events:
                     self.diagnostics_events[key].set()
+
+        @self.feature(WINDOW_LOG_MESSAGE)
+        def on_log_message(params: LogMessageParams) -> None:
+            self.log_messages.append(params)
 
         @self.feature(WINDOW_WORK_DONE_PROGRESS_CREATE)
         def on_create_progress(params: WorkDoneProgressCreateParams) -> None:
@@ -110,6 +118,7 @@ class CliceClient(BaseLanguageClient):
         result = await self.initialize_async(params)
         self.initialized(InitializedParams())
         self.init_result = result
+        self.workspace = workspace
         return result
 
     # ── Server process control ───────────────────────────────────────

--- a/tests/integration/utils/wait.py
+++ b/tests/integration/utils/wait.py
@@ -9,6 +9,11 @@ from lsprotocol.types import (
     WorkspaceSymbolParams,
 )
 
+# Standard timing constants — use these instead of hardcoded sleep values.
+MTIME_GRANULARITY = 1.1  # Filesystem mtime precision (1s on some FSes, +0.1 margin)
+SETTLE_TIME = 0.5  # Time for the server to stabilize after an operation
+IDLE_TIMEOUT = 5.0  # Idle soak time in lifecycle tests
+
 
 async def wait_for_recompile(client, uri: str, *, timeout: float = 60.0) -> None:
     """Trigger recompilation via hover and wait for fresh diagnostics.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,3 +5,4 @@ filterwarnings =
 markers =
     workspace
     init_options
+    allow_anomaly

--- a/tests/replay.py
+++ b/tests/replay.py
@@ -149,6 +149,8 @@ async def replay_one(
     init_ids: set[int | str] = set()
     init_errors: list[str] = []
 
+    anomalies: list[str] = []
+
     async def reader_loop():
         try:
             while True:
@@ -156,6 +158,11 @@ async def replay_one(
                 if msg is None:
                     break
                 msg_id, method = msg.get("id"), msg.get("method")
+                if method == "window/logMessage":
+                    text = msg.get("params", {}).get("message", "")
+                    if "[anomaly:" in text:
+                        anomalies.append(text)
+                        print(f"  ANOMALY: {text}")
                 if msg_id is not None and method is not None:
                     resp = SERVER_REQUEST_DEFAULTS.get(method)
                     await write_lsp_message(
@@ -322,6 +329,12 @@ async def replay_one(
             except (ValueError, AttributeError):
                 pass
         print(f"  result: CRASH (exit={returncode}{sig}, {elapsed:.1f}s)")
+        print_stderr()
+        return False
+
+    if anomalies:
+        # Anomalies are internal clice bugs; a replay session must be clean.
+        print(f"  result: FAIL ({len(anomalies)} anomaly report(s), {elapsed:.1f}s)")
         print_stderr()
         return False
 

--- a/tests/unit/command/command_tests.cpp
+++ b/tests/unit/command/command_tests.cpp
@@ -160,6 +160,28 @@ TEST_CASE(DefaultFallback) {
     ASSERT_EQ(h_results.front().to_argv()[0], "clang"sv);
 };
 
+TEST_CASE(FallbackAppliesAppend) {
+    /// Config rule appends must reach the synthesized fallback command:
+    /// users without a CDB rely on them to supply include paths.
+    CompilationDatabase database;
+    auto options = quiet_options();
+    std::vector<std::string> append = {"-I/opt/include"};
+    options.append = append;
+
+    auto results = database.lookup("unknown.cpp", options);
+    auto argv = results.front().to_argv();
+    ASSERT_EQ(argv.size(), 4U);
+    ASSERT_EQ(argv[0], "clang++"sv);
+    ASSERT_EQ(argv[1], "-std=c++20"sv);
+    ASSERT_EQ(argv[2], "-I/opt/include"sv);
+
+    /// The plain-clang branch applies them too.
+    auto c_argv = database.lookup("unknown.c", options).front().to_argv();
+    ASSERT_EQ(c_argv.size(), 3U);
+    ASSERT_EQ(c_argv[0], "clang"sv);
+    ASSERT_EQ(c_argv[1], "-I/opt/include"sv);
+};
+
 TEST_CASE(MultiCommand) {
     /// A file can have multiple compilation commands (e.g. different configs).
     CompilationDatabase database;

--- a/tests/unit/feature/position_map_tests.cpp
+++ b/tests/unit/feature/position_map_tests.cpp
@@ -9,7 +9,7 @@ namespace {
 TEST_SUITE(PositionMap) {
 
 TEST_CASE(OutOfRangeAnomaly) {
-    /// Production trigger for the position_map_fail anomaly: the checked
+    /// Production trigger for the PositionMapFail anomaly: the checked
     /// feature-layer converters report internally produced offsets that
     /// cannot be mapped back to a position.
     logging::reset_anomaly_for_testing();

--- a/tests/unit/feature/position_map_tests.cpp
+++ b/tests/unit/feature/position_map_tests.cpp
@@ -1,0 +1,38 @@
+#include "test/test.h"
+#include "feature/feature.h"
+#include "support/anomaly.h"
+
+namespace clice::testing {
+
+namespace {
+
+TEST_SUITE(PositionMap) {
+
+TEST_CASE(OutOfRangeAnomaly) {
+    /// Production trigger for the position_map_fail anomaly: the checked
+    /// feature-layer converters report internally produced offsets that
+    /// cannot be mapped back to a position.
+    logging::reset_anomaly_for_testing();
+    std::vector<logging::AnomalyId> trapped;
+    logging::set_anomaly_trap_for_testing([&](logging::AnomalyId id) { trapped.push_back(id); });
+
+    feature::LineMap map("int x;\n");
+    EXPECT_FALSE(feature::to_position(map, 100).has_value());
+    EXPECT_FALSE(feature::to_range(map, {0, 100}).has_value());
+
+    ASSERT_EQ(trapped.size(), 2u);
+    EXPECT_EQ(trapped[0], logging::AnomalyId::PositionMapFail);
+    EXPECT_EQ(trapped[1], logging::AnomalyId::PositionMapFail);
+
+    /// In-range conversions stay silent.
+    EXPECT_TRUE(feature::to_range(map, {0, 5}).has_value());
+    EXPECT_EQ(trapped.size(), 2u);
+
+    logging::reset_anomaly_for_testing();
+}
+
+};  // TEST_SUITE(PositionMap)
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -386,7 +386,6 @@ TEST_CASE(SyntaxIssueHasLocation) {
     EXPECT_FALSE(result.has_value());
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
-    EXPECT_EQ(issues[0].line, 1u);
 }
 
 TEST_CASE(TypeIssueHasLocation) {
@@ -397,8 +396,6 @@ TEST_CASE(TypeIssueHasLocation) {
     EXPECT_FALSE(result.has_value());
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
-    EXPECT_EQ(issues[0].line, 2u);
-    EXPECT_EQ(issues[0].column, 14u);  // the "yes" value node
     EXPECT_NE(issues[0].message.find("clang_tidy"), std::string::npos);
 }
 
@@ -407,12 +404,9 @@ TEST_CASE(UnknownKeyIssueWarns) {
     tmp.touch("clice.toml", "[project]\nclang_tdy = true\n");
     std::vector<ConfigIssue> issues;
     auto result = Config::load(tmp.path("clice.toml"), tmp.root.str(), &issues);
-    // Unknown keys do not reject the config — it still loads.
     EXPECT_TRUE(result.has_value());
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Warning);
-    EXPECT_EQ(issues[0].line, 2u);
-    EXPECT_EQ(issues[0].column, 13u);  // the value node of the unknown key
     EXPECT_NE(issues[0].message.find("clang_tdy"), std::string::npos);
 }
 

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -398,6 +398,7 @@ TEST_CASE(TypeIssueHasLocation) {
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
     EXPECT_EQ(issues[0].line, 2u);
+    EXPECT_EQ(issues[0].column, 14u);  // the "yes" value node
     EXPECT_NE(issues[0].message.find("clang_tidy"), std::string::npos);
 }
 
@@ -411,6 +412,7 @@ TEST_CASE(UnknownKeyIssueWarns) {
     ASSERT_EQ(issues.size(), 1u);
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Warning);
     EXPECT_EQ(issues[0].line, 2u);
+    EXPECT_EQ(issues[0].column, 13u);  // the value node of the unknown key
     EXPECT_NE(issues[0].message.find("clang_tdy"), std::string::npos);
 }
 

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -378,6 +378,42 @@ TEST_CASE(TomlErrorLocated) {
     EXPECT_FALSE(result.has_value());
 }
 
+TEST_CASE(SyntaxIssueHasLocation) {
+    TempDir tmp;
+    tmp.touch("clice.toml", "[project\nclang_tidy = true\n");
+    std::vector<ConfigIssue> issues;
+    auto result = Config::load(tmp.path("clice.toml"), tmp.root.str(), &issues);
+    EXPECT_FALSE(result.has_value());
+    ASSERT_EQ(issues.size(), 1u);
+    EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
+    EXPECT_EQ(issues[0].line, 1u);
+}
+
+TEST_CASE(TypeIssueHasLocation) {
+    TempDir tmp;
+    tmp.touch("clice.toml", "[project]\nclang_tidy = \"yes\"\n");
+    std::vector<ConfigIssue> issues;
+    auto result = Config::load(tmp.path("clice.toml"), tmp.root.str(), &issues);
+    EXPECT_FALSE(result.has_value());
+    ASSERT_EQ(issues.size(), 1u);
+    EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
+    EXPECT_EQ(issues[0].line, 2u);
+    EXPECT_NE(issues[0].message.find("clang_tidy"), std::string::npos);
+}
+
+TEST_CASE(UnknownKeyIssueWarns) {
+    TempDir tmp;
+    tmp.touch("clice.toml", "[project]\nclang_tdy = true\n");
+    std::vector<ConfigIssue> issues;
+    auto result = Config::load(tmp.path("clice.toml"), tmp.root.str(), &issues);
+    // Unknown keys do not reject the config — it still loads.
+    EXPECT_TRUE(result.has_value());
+    ASSERT_EQ(issues.size(), 1u);
+    EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Warning);
+    EXPECT_EQ(issues[0].line, 2u);
+    EXPECT_NE(issues[0].message.find("clang_tdy"), std::string::npos);
+}
+
 TEST_CASE(WorkspaceMalformedFallback) {
     // load_from_workspace must fall back to defaults when clice.toml is malformed,
     // not propagate the failure.

--- a/tests/unit/server/config_tests.cpp
+++ b/tests/unit/server/config_tests.cpp
@@ -378,7 +378,10 @@ TEST_CASE(TomlErrorLocated) {
     EXPECT_FALSE(result.has_value());
 }
 
-TEST_CASE(SyntaxIssueHasLocation) {
+// FIXME: assert ConfigIssue::line/column once kotatsu's TOML decoder exposes
+// error locations (feature 60661c1 on the unmerged kotatsu branch); the
+// plumbing here already forwards rich_error.location when present.
+TEST_CASE(SyntaxIssueReported) {
     TempDir tmp;
     tmp.touch("clice.toml", "[project\nclang_tidy = true\n");
     std::vector<ConfigIssue> issues;
@@ -388,7 +391,7 @@ TEST_CASE(SyntaxIssueHasLocation) {
     EXPECT_EQ(issues[0].severity, ConfigIssue::Severity::Error);
 }
 
-TEST_CASE(TypeIssueHasLocation) {
+TEST_CASE(TypeIssueReported) {
     TempDir tmp;
     tmp.touch("clice.toml", "[project]\nclang_tidy = \"yes\"\n");
     std::vector<ConfigIssue> issues;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -2,6 +2,7 @@
 #include "server/protocol/worker.h"
 #include "server/worker/worker_pool.h"
 #include "server/worker_test_helpers.h"
+#include "support/anomaly.h"
 
 #include "kota/async/async.h"
 
@@ -15,9 +16,14 @@ struct WorkerPoolFixture {
     std::vector<WorkerCrashInfo> crash_reports;
 
     WorkerPoolFixture() : pool(loop) {
+        logging::set_anomaly_trap_for_testing([](logging::AnomalyId) {});
         pool.on_crash = [this](const WorkerCrashInfo& info) {
             crash_reports.push_back(info);
         };
+    }
+
+    ~WorkerPoolFixture() {
+        logging::reset_anomaly_for_testing();
     }
 
     void add_stateless(bool alive = true, bool busy = false, bool low = true) {

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -631,7 +631,7 @@ TEST_CASE(StatefulLostDocuments) {
 }
 
 TEST_CASE(CrashReportsAnomaly) {
-    /// Production trigger for the worker_crash anomaly: process_crash is the
+    /// Production trigger for the WorkerCrash anomaly: process_crash is the
     /// exact site the pool reports from.
     WorkerPoolFixture f;
     f.add_stateless(true, false);
@@ -646,7 +646,7 @@ TEST_CASE(CrashReportsAnomaly) {
 }
 
 TEST_CASE(SpawnFailReportsAnomaly) {
-    /// Production trigger for the worker_spawn_fail anomaly.
+    /// Production trigger for the WorkerSpawnFail anomaly.
     WorkerPoolFixture f;
 
     std::vector<logging::AnomalyId> trapped;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -630,6 +630,47 @@ TEST_CASE(StatefulLostDocuments) {
     }
 }
 
+TEST_CASE(CrashReportsAnomaly) {
+    /// Production trigger for the worker_crash anomaly: process_crash is the
+    /// exact site the pool reports from.
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+
+    std::vector<logging::AnomalyId> trapped;
+    logging::set_anomaly_trap_for_testing([&](logging::AnomalyId id) { trapped.push_back(id); });
+
+    f.simulate_crash(0, false, 0, 11);
+
+    ASSERT_EQ(trapped.size(), 1u);
+    EXPECT_EQ(trapped[0], logging::AnomalyId::WorkerCrash);
+}
+
+TEST_CASE(SpawnFailReportsAnomaly) {
+    /// Production trigger for the worker_spawn_fail anomaly.
+    WorkerPoolFixture f;
+
+    std::vector<logging::AnomalyId> trapped;
+    logging::set_anomaly_trap_for_testing([&](logging::AnomalyId id) { trapped.push_back(id); });
+
+    WorkerPoolOptions opts;
+    opts.self_path = "/nonexistent/clice-binary";
+    opts.stateless_count = 1;
+    opts.stateful_count = 0;
+    EXPECT_FALSE(f.pool.start(opts));
+
+    ASSERT_EQ(trapped.size(), 1u);
+    EXPECT_EQ(trapped[0], logging::AnomalyId::WorkerSpawnFail);
+}
+
+TEST_CASE(OperationalErrorCodes) {
+    /// Dispatch failures marked operational must never classify as anomalies.
+    using worker::protocol::Error;
+    EXPECT_TRUE(worker::is_operational_error(Error{worker::dispatch_errc::cancelled, "x"}));
+    EXPECT_TRUE(
+        worker::is_operational_error(Error{worker::dispatch_errc::worker_unavailable, "x"}));
+    EXPECT_FALSE(worker::is_operational_error(Error{"plain failure"}));
+}
+
 TEST_CASE(CrashInfoSignal) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);

--- a/tests/unit/support/anomaly_tests.cpp
+++ b/tests/unit/support/anomaly_tests.cpp
@@ -1,0 +1,147 @@
+#include <string>
+#include <vector>
+
+#include "test/test.h"
+#include "support/anomaly.h"
+#include "support/logging.h"
+
+namespace clice::testing {
+namespace {
+
+using logging::AnomalyId;
+using logging::NotifyLevel;
+
+/// RAII fixture: capture the notify hook and trap, restore globals afterwards.
+struct AnomalyCapture {
+    std::vector<std::pair<NotifyLevel, std::string>> notified;
+    std::vector<AnomalyId> trapped;
+    logging::Level saved_level;
+
+    AnomalyCapture() : saved_level(logging::options.level) {
+        logging::reset_anomaly_for_testing();
+        logging::set_notify_hook([this](NotifyLevel level, std::string_view message) {
+            notified.emplace_back(level, std::string(message));
+        });
+        logging::set_anomaly_trap_for_testing([this](AnomalyId id) { trapped.push_back(id); });
+    }
+
+    ~AnomalyCapture() {
+        logging::set_notify_hook(nullptr);
+        logging::reset_anomaly_for_testing();
+        logging::options.level = saved_level;
+    }
+};
+
+TEST_SUITE(Anomaly) {
+
+TEST_CASE(MarkerAndNotify) {
+    AnomalyCapture capture;
+
+    LOG_ANOMALY(PchBuildFail, "stale build for {}", "main.cpp");
+
+    ASSERT_EQ(capture.notified.size(), 1u);
+    auto& [level, message] = capture.notified.front();
+    EXPECT_EQ(level, NotifyLevel::Error);
+    EXPECT_EQ(message, "[anomaly:pch_build_fail] stale build for main.cpp");
+}
+
+TEST_CASE(TrapInvokedPerReport) {
+    /// The trap fires once per reported (non-suppressed) anomaly. In Debug
+    /// builds the default trap aborts the process; the override used here is
+    /// the mock point that lets us observe it in any build type.
+    AnomalyCapture capture;
+
+    LOG_ANOMALY(WorkerCrash, "worker {} died", 1);
+    LOG_ANOMALY(WorkerCrash, "worker {} died", 2);
+
+    ASSERT_EQ(capture.trapped.size(), 2u);
+    EXPECT_EQ(capture.trapped[0], AnomalyId::WorkerCrash);
+}
+
+TEST_CASE(RateLimitSuppresses) {
+    AnomalyCapture capture;
+
+    for(std::uint32_t i = 0; i < logging::anomaly_report_limit + 5; ++i) {
+        LOG_ANOMALY(CompileFail, "occurrence {}", i);
+    }
+
+    EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit);
+    EXPECT_EQ(capture.trapped.size(), logging::anomaly_report_limit);
+}
+
+TEST_CASE(RateLimitIsPerId) {
+    AnomalyCapture capture;
+
+    for(std::uint32_t i = 0; i < logging::anomaly_report_limit + 5; ++i) {
+        LOG_ANOMALY(CompileFail, "occurrence {}", i);
+    }
+    LOG_ANOMALY(PcmBuildFail, "different id still reports");
+
+    EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit + 1);
+}
+
+TEST_CASE(SuppressedArgsNotEvaluated) {
+    /// Locks the lazy-evaluation contract: once the rate limit gate fails,
+    /// the format arguments must not be evaluated at all.
+    AnomalyCapture capture;
+
+    int evaluations = 0;
+    auto observe = [&evaluations] {
+        ++evaluations;
+        return 42;
+    };
+
+    for(std::uint32_t i = 0; i < logging::anomaly_report_limit + 5; ++i) {
+        LOG_ANOMALY(PositionMapFail, "value {}", observe());
+    }
+
+    EXPECT_EQ(evaluations, static_cast<int>(logging::anomaly_report_limit));
+}
+
+TEST_CASE(LevelGateSkipsEvaluation) {
+    AnomalyCapture capture;
+    logging::options.level = logging::Level::off;
+
+    int evaluations = 0;
+    auto observe = [&evaluations] {
+        ++evaluations;
+        return 42;
+    };
+    LOG_ANOMALY(PchBuildFail, "value {}", observe());
+
+    EXPECT_EQ(evaluations, 0);
+    EXPECT_EQ(capture.notified.size(), 0u);
+    EXPECT_EQ(capture.trapped.size(), 0u);
+}
+
+TEST_CASE(GuidanceMarkerAndLevel) {
+    AnomalyCapture capture;
+
+    LOG_GUIDANCE("no compilation database found in {}", "/tmp/ws");
+
+    ASSERT_EQ(capture.notified.size(), 1u);
+    auto& [level, message] = capture.notified.front();
+    EXPECT_EQ(level, NotifyLevel::Warning);
+    EXPECT_EQ(message, "[guidance] no compilation database found in /tmp/ws");
+    EXPECT_EQ(capture.trapped.size(), 0u);
+}
+
+TEST_CASE(GuidanceLazyAtLevel) {
+    AnomalyCapture capture;
+    logging::options.level = logging::Level::off;
+
+    int evaluations = 0;
+    auto observe = [&evaluations] {
+        ++evaluations;
+        return 1;
+    };
+    LOG_GUIDANCE("value {}", observe());
+
+    EXPECT_EQ(evaluations, 0);
+    EXPECT_EQ(capture.notified.size(), 0u);
+}
+
+};  // TEST_SUITE(Anomaly)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/support/anomaly_tests.cpp
+++ b/tests/unit/support/anomaly_tests.cpp
@@ -69,7 +69,7 @@ TEST_CASE(RateLimitSuppresses) {
     EXPECT_EQ(capture.trapped.size(), logging::anomaly_report_limit);
 }
 
-TEST_CASE(RateLimitIsPerId) {
+TEST_CASE(RateLimitPerId) {
     AnomalyCapture capture;
 
     for(std::uint32_t i = 0; i < logging::anomaly_report_limit + 5; ++i) {
@@ -139,6 +139,34 @@ TEST_CASE(GuidanceLazyAtLevel) {
 
     EXPECT_EQ(evaluations, 0);
     EXPECT_EQ(capture.notified.size(), 0u);
+}
+
+TEST_CASE(MarkerNamesStable) {
+    /// Every id fires through the macro once and produces its wire marker.
+    /// Integration tests grep these exact strings — keep them stable.
+    AnomalyCapture capture;
+
+    LOG_ANOMALY(PchBuildFail, "x");
+    LOG_ANOMALY(PcmBuildFail, "x");
+    LOG_ANOMALY(CompileFail, "x");
+    LOG_ANOMALY(WorkerRequestFail, "x");
+    LOG_ANOMALY(WorkerCrash, "x");
+    LOG_ANOMALY(WorkerSpawnFail, "x");
+    LOG_ANOMALY(PositionMapFail, "x");
+
+    ASSERT_EQ(capture.notified.size(), logging::anomaly_id_count);
+    const char* expected[] = {
+        "pch_build_fail",
+        "pcm_build_fail",
+        "compile_fail",
+        "worker_request_fail",
+        "worker_crash",
+        "worker_spawn_fail",
+        "position_map_fail",
+    };
+    for(std::size_t i = 0; i < logging::anomaly_id_count; ++i) {
+        EXPECT_EQ(capture.notified[i].second, std::format("[anomaly:{}] x", expected[i]));
+    }
 }
 
 };  // TEST_SUITE(Anomaly)

--- a/tests/unit/support/anomaly_tests.cpp
+++ b/tests/unit/support/anomaly_tests.cpp
@@ -11,7 +11,7 @@ namespace {
 using logging::AnomalyId;
 using logging::NotifyLevel;
 
-/// RAII fixture: capture the notify hook and trap, restore globals afterwards.
+/// RAII fixture: install test hooks and clear them on destruction.
 struct AnomalyCapture {
     std::vector<std::pair<NotifyLevel, std::string>> notified;
     std::vector<AnomalyId> trapped;

--- a/tests/unit/support/anomaly_tests.cpp
+++ b/tests/unit/support/anomaly_tests.cpp
@@ -37,12 +37,12 @@ TEST_SUITE(Anomaly) {
 TEST_CASE(MarkerAndNotify) {
     AnomalyCapture capture;
 
-    LOG_ANOMALY(PchBuildFail, "stale build for {}", "main.cpp");
+    LOG_ANOMALY(PCHBuildFail, "stale build for {}", "main.cpp");
 
     ASSERT_EQ(capture.notified.size(), 1u);
     auto& [level, message] = capture.notified.front();
     EXPECT_EQ(level, NotifyLevel::Error);
-    EXPECT_EQ(message, "[anomaly:pch_build_fail] stale build for main.cpp");
+    EXPECT_EQ(message, "[anomaly:PCHBuildFail] stale build for main.cpp");
 }
 
 TEST_CASE(TrapInvokedPerReport) {
@@ -78,9 +78,9 @@ TEST_CASE(RateLimitPerId) {
     for(std::uint32_t i = 0; i < logging::anomaly_report_limit + 5; ++i) {
         LOG_ANOMALY(CompileFail, "occurrence {}", i);
     }
-    LOG_ANOMALY(PcmBuildFail, "different id still reports");
+    LOG_ANOMALY(PCMBuildFail, "different id still reports");
 
-    /// CompileFail reports + its suppression notice + the PcmBuildFail report.
+    /// CompileFail reports + its suppression notice + the PCMBuildFail report.
     EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit + 2);
 }
 
@@ -111,7 +111,7 @@ TEST_CASE(LevelGateSkipsEvaluation) {
         ++evaluations;
         return 42;
     };
-    LOG_ANOMALY(PchBuildFail, "value {}", observe());
+    LOG_ANOMALY(PCHBuildFail, "value {}", observe());
 
     EXPECT_EQ(evaluations, 0);
     EXPECT_EQ(capture.notified.size(), 0u);
@@ -150,8 +150,8 @@ TEST_CASE(MarkerNamesStable) {
     /// Integration tests grep these exact strings — keep them stable.
     AnomalyCapture capture;
 
-    LOG_ANOMALY(PchBuildFail, "x");
-    LOG_ANOMALY(PcmBuildFail, "x");
+    LOG_ANOMALY(PCHBuildFail, "x");
+    LOG_ANOMALY(PCMBuildFail, "x");
     LOG_ANOMALY(CompileFail, "x");
     LOG_ANOMALY(WorkerRequestFail, "x");
     LOG_ANOMALY(WorkerCrash, "x");
@@ -160,13 +160,13 @@ TEST_CASE(MarkerNamesStable) {
 
     ASSERT_EQ(capture.notified.size(), logging::anomaly_id_count);
     const char* expected[] = {
-        "pch_build_fail",
-        "pcm_build_fail",
-        "compile_fail",
-        "worker_request_fail",
-        "worker_crash",
-        "worker_spawn_fail",
-        "position_map_fail",
+        "PCHBuildFail",
+        "PCMBuildFail",
+        "CompileFail",
+        "WorkerRequestFail",
+        "WorkerCrash",
+        "WorkerSpawnFail",
+        "PositionMapFail",
     };
     for(std::size_t i = 0; i < logging::anomaly_id_count; ++i) {
         EXPECT_EQ(capture.notified[i].second, std::format("[anomaly:{}] x", expected[i]));

--- a/tests/unit/support/anomaly_tests.cpp
+++ b/tests/unit/support/anomaly_tests.cpp
@@ -65,7 +65,10 @@ TEST_CASE(RateLimitSuppresses) {
         LOG_ANOMALY(CompileFail, "occurrence {}", i);
     }
 
-    EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit);
+    /// The client sees the reports plus one final suppression notice; the
+    /// trap fires only for real reports.
+    ASSERT_EQ(capture.notified.size(), logging::anomaly_report_limit + 1);
+    EXPECT_NE(capture.notified.back().second.find("report limit"), std::string::npos);
     EXPECT_EQ(capture.trapped.size(), logging::anomaly_report_limit);
 }
 
@@ -77,7 +80,8 @@ TEST_CASE(RateLimitPerId) {
     }
     LOG_ANOMALY(PcmBuildFail, "different id still reports");
 
-    EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit + 1);
+    /// CompileFail reports + its suppression notice + the PcmBuildFail report.
+    EXPECT_EQ(capture.notified.size(), logging::anomaly_report_limit + 2);
 }
 
 TEST_CASE(SuppressedArgsNotEvaluated) {

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -98,9 +98,10 @@ struct Tester {
     /// interested file. Shared by feature tests that compare protocol results
     /// against annotation ranges.
     LocalSourceRange to_local_range(const kota::ipc::protocol::Range& range) {
-        feature::PositionMapper converter(unit->interested_content(),
-                                          feature::PositionEncoding::UTF8);
-        return LocalSourceRange(*converter.to_offset(range.start), *converter.to_offset(range.end));
+        feature::LineMap map(unit->interested_content(),
+                             unit->line_starts(),
+                             feature::PositionEncoding::UTF8);
+        return LocalSourceRange(*map.to_offset(range.start), *map.to_offset(range.end));
     }
 
     void clear();

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -10,6 +10,7 @@
 #include "command/command.h"
 #include "command/toolchain.h"
 #include "compile/compilation.h"
+#include "feature/feature.h"
 #include "support/logging.h"
 
 namespace clice::testing {
@@ -92,6 +93,15 @@ struct Tester {
     llvm::ArrayRef<std::uint32_t> nameless_points(llvm::StringRef file = "");
 
     LocalSourceRange range(llvm::StringRef name = "", llvm::StringRef file = "");
+
+    /// Convert a protocol range back to byte offsets in the compiled unit's
+    /// interested file. Shared by feature tests that compare protocol results
+    /// against annotation ranges.
+    LocalSourceRange to_local_range(const kota::ipc::protocol::Range& range) {
+        feature::PositionMapper converter(unit->interested_content(),
+                                          feature::PositionEncoding::UTF8);
+        return LocalSourceRange(*converter.to_offset(range.start), *converter.to_offset(range.end));
+    }
 
     void clear();
 };

--- a/tests/unit/test/tester.h
+++ b/tests/unit/test/tester.h
@@ -96,12 +96,22 @@ struct Tester {
 
     /// Convert a protocol range back to byte offsets in the compiled unit's
     /// interested file. Shared by feature tests that compare protocol results
-    /// against annotation ranges.
+    /// against annotation ranges. An unmappable range is a test bug — fail
+    /// loudly instead of dereferencing an empty optional.
     LocalSourceRange to_local_range(const kota::ipc::protocol::Range& range) {
         feature::LineMap map(unit->interested_content(),
                              unit->line_starts(),
                              feature::PositionEncoding::UTF8);
-        return LocalSourceRange(*map.to_offset(range.start), *map.to_offset(range.end));
+        auto begin = map.to_offset(range.start);
+        auto end = map.to_offset(range.end);
+        if(!begin || !end) {
+            LOG_FATAL("to_local_range: unmappable range {}:{}-{}:{}",
+                      range.start.line,
+                      range.start.character,
+                      range.end.line,
+                      range.end.character);
+        }
+        return LocalSourceRange(*begin, *end);
     }
 
     void clear();


### PR DESCRIPTION
## Background

Server-side error feedback is the operability foundation for v1.0 (roadmap: server task 3 "error handling & logging"). Before this PR, internal failures died silently in logs (or as silent `null` responses), users got no signal when their setup was broken, and there was no structured way to profile the server on real codebases. This PR supersedes #436 (reimplemented on current main rather than rebased — it predates the #437/#447/#449 restructures).

## Feedback channels

**Anomaly (soft assertions, `src/support/anomaly.h`)** — `LOG_ANOMALY(id, fmt, ...)` for internal states that must be unreachable when clice works correctly. Debug builds abort after logging (the CI Debug matrix and local dev catch bugs earliest; `CLICE_ANOMALY_NO_TRAP` exists for tests); Release logs `[anomaly:<id>]`, pushes `window/logMessage` (master) and continues. Per-ID rate limit with a final suppression notice; the gate runs **before** format arguments are evaluated (lazy contract locked by unit tests with side-effecting args). IDs: `PCHBuildFail`, `PCMBuildFail`, `CompileFail`, `WorkerRequestFail`, `WorkerCrash`, `WorkerSpawnFail`, `PositionMapFail` (markers are the enumerator names, rendered by the reflective enum formatter and pinned by `MarkerNamesStable`).

Situations reachable by user input or normal operation are deliberately **not** anomalies. That split is structural: worker build failures carry `BuildResult.has_user_errors`, and master-side dispatch failures carry `dispatch_errc` codes (`cancelled` for memory-pressure preemption, `worker_unavailable` for crash/restart windows) so `is_operational_error()` keeps them out of the anomaly channel.

**Guidance** — `LOG_GUIDANCE(...)` (`[guidance]` + Warning logMessage) for user-actionable situations: no compile_commands.json, invalid initializationOptions, config problems.

**LSP errors instead of silent null** — feature requests on closed documents → `Document not open`; unresolvable call/type hierarchy items → error; reversed ranges → `InvalidParams`; empty hierarchy/workspace-symbol results return `[]` instead of `null`. Out-of-range positions **clamp** per the LSP spec (character → line end, line → end of content) instead of erroring.

**Guidance diagnostics** — `fill_compile_args()` returns a `CommandSource` (`CDBExact`/`IncludeGraph`/`Inferred` (reserved)/`Fallback`) and emits a per-file decision log (tiers tried, tier hit, args hash). When a *guessed* command produces file-not-found errors, the publish merges a file-top Warning explaining it (code `inferred-compile-command`, linking the quick-start guide). Exact CDB matches never get it. Config rule appends now reach synthesized fallback commands, so `-I` rules work without a CDB.

**clice.toml diagnostics** — parse/type errors (Error, defaults apply) and unknown keys (Warning via a strict second decode pass, config still applies) are published on the config file's URI. Line/column ranges wait for the kotatsu TOML location feature (FIXMEs mark the re-enable points); until then diagnostics anchor at the file top.

## Logging system

- **Design doc in `logging.h`**: channel selection is decision-oriented — pick by *who must act and whether it is clice's fault*. Levels, perf topics and process ownership are specified there.
- **`LOG_PERF(topic, ...)`** emits greppable `[perf:<topic>] key=value` lines for profiling on real codebases: `startup` (CDB load, dep scan, index load), `index` (per-file index/merge timings, run summary, save), `cache` (PCH/PCM hit/miss with reason, evictions), `request` (per-request `wait_ms`/`total_ms` for query/build/format/compile).
- **Per-process log files**: workers log only to their own `<session>/<worker>.log` (no stderr mirror), so the master log no longer duplicates worker output. Worker stderr is reserved for unexpected third-party output (sanitizers, libc asserts), relayed line-by-line into the master log by the pool.
- **Crash backtraces** land in the owning process's log file (`install_crash_handler`, covers SIGABRT so `LOG_FATAL` and Debug anomaly traps too); a worker's backtrace goes *only* to its own log, verified by an integration test that SIGABRTs a worker and asserts the trace stays out of the master log.
- **Startup flow** is fully logged: master banner (pid/mode/workspace), config source, session log dir, worker pool summary, CDB/dep-scan/index-load timings.

## Notable fixes uncovered along the way

- `CompilationDatabase::lookup()` synthesizes a command for unknown files, so the old `results.empty()` checks were dead: the automatic include-graph header-context tier was unreachable, and headers without entries silently compiled as bare `clang`. Tier selection now uses `has_entry()`; background indexing skips Fallback-sourced files.
- initializationOptions now overlay **before** `apply_defaults()`: a client-provided `cache_dir` previously didn't propagate into the derived `logging_dir`/`index_dir`.
- Six unchecked `*map.to_range()` dereferences (empty-optional UB) in feature code converted to checked helpers reporting `PositionMapFail`.
- Anomaly notify/trap hooks are mutex-synchronized (copy under lock, invoke outside), making reporting safe from any thread.

## Test infrastructure

- `CliceClient` records `window/logMessage`; **`assert_no_anomaly()` runs in every integration teardown** (all fixtures and `make_client` sessions), scanning notifications and master/worker log files even when shutdown fails. `tests/replay.py` fails a smoke trace on any anomaly push.
- E2E: guidance-diagnostic lifecycle (no CDB → appears; add CDB + restart → gone while the include error stays), fallback rule-append (no CDB + clice.toml `-I` rule → clean compile), clice.toml error/unknown-key/clear scenarios, worker SIGABRT → `WorkerCrash` anomaly + backtrace ownership, closed/unknown documents via `pytest.raises`, position/range clamping.
- Unit triggers for `PositionMapFail`, `WorkerCrash`, `WorkerSpawnFail`; `dispatch_errc` classification; fallback append; lazy-evaluation and rate-limit contracts.
- Named timing constants (`MTIME_GRANULARITY`/`SETTLE_TIME`/`IDLE_TIMEOUT`) replace hardcoded sleeps; yield-based workspace cleanup; log dump on test failure.

## Out of scope

Module-cycle guidance diagnostics wait for the module refactor; kotatsu TOML line/column re-enable after the kotatsu-side PR merges; worker logMessage forwarding and request-correlation IDs belong to the worker-pool follow-up.

## Test plan

- [x] RelWithDebInfo: 732 unit / 187 integration / 3 smoke — all green locally
- [x] Debug: 732 unit / 187 integration / 3 smoke — all green locally (anomalies abort in Debug, so this run is the "zero anomalies on regular paths" acceptance)
- [x] `pixi run format` clean; two rounds of 3 parallel review subagents (correctness / style / tests) — all findings fixed or triaged
- [x] Full CI matrix green (Linux/macOS/Windows native, aarch64/x64/arm64 cross, editor test)

Closes #436 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
