### PR TITLE
refactor(server): clean up Session lifetime model

### DIFF
--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -652,23 +652,19 @@ void Compiler::record_deps(Session& session, llvm::ArrayRef<std::string> deps) {
 /// Called lazily by forward_query() / forward_build() before every
 /// feature request (hover, semantic tokens, etc.). Guarantees that when it
 /// returns true the stateful worker assigned to `path_id` holds an up-to-date
-kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
-                                   std::shared_ptr<Session::PendingCompile> pc) {
-    if(!sess || sess->closed) {
-        pc->done.set();
-        co_return;
-    }
+kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
+    auto pc = session->compiling;
+    auto pid = session->path_id;
+    auto gen = session->generation;
 
-    auto pid = sess->path_id;
     auto finish_compile = [&]() {
-        if(!sess->closed && sess->compiling == pc) {
-            sess->compiling.reset();
+        if(session->compiling == pc) {
+            session->compiling.reset();
         }
         LOG_INFO("ensure_compiled: finish path_id={}", pid);
         pc->done.set();
     };
 
-    auto gen = sess->generation;
     LOG_INFO("ensure_compiled: starting compile path_id={} gen={}", pid, gen);
 
     auto file_path = std::string(workspace.path_pool.resolve(pid));
@@ -677,14 +673,14 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
 
     worker::CompileParams params;
     params.path = file_path;
-    params.version = sess->version;
-    params.text = sess->text;
-    if(!fill_compile_args(file_path, params.directory, params.arguments, sess.get())) {
+    params.version = session->version;
+    params.text = session->text;
+    if(!fill_compile_args(file_path, params.directory, params.arguments, session.get())) {
         finish_compile();
         co_return;
     }
 
-    bool deps_ok = co_await ensure_deps(*sess,
+    bool deps_ok = co_await ensure_deps(*session,
                                         params.directory,
                                         params.arguments,
                                         params.pch,
@@ -697,14 +693,9 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
         co_return;
     }
 
-    if(sess->closed) {
-        pc->done.set();
-        co_return;
-    }
-
-    if(sess->generation != gen) {
+    if(session->generation != gen) {
         LOG_INFO("ensure_compiled: superseded before send ({} vs {}) for {}",
-                 sess->generation,
+                 session->generation,
                  gen,
                  uri_str);
         finish_compile();
@@ -713,14 +704,9 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
 
     auto result = co_await pool.send_stateful(pid, params);
 
-    if(sess->closed) {
-        pc->done.set();
-        co_return;
-    }
-
-    if(sess->generation != gen) {
+    if(session->generation != gen) {
         LOG_INFO("ensure_compiled: generation mismatch ({} vs {}) for {}",
-                 sess->generation,
+                 session->generation,
                  gen,
                  uri_str);
         finish_compile();
@@ -734,21 +720,21 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
         co_return;
     }
 
-    sess->ast_dirty = false;
+    session->ast_dirty = false;
     pc->succeeded = true;
-    record_deps(*sess, result.value().deps);
+    record_deps(*session, result.value().deps);
 
     if(!result.value().tu_index_data.empty()) {
         auto tu_index = index::TUIndex::from(result.value().tu_index_data.data());
         OpenFileIndex ofi;
         ofi.file_index = std::move(tu_index.main_file_index);
         ofi.symbols = std::move(tu_index.symbols);
-        ofi.content = sess->text;
+        ofi.content = session->text;
         ofi.mapper.emplace(ofi.content, lsp::PositionEncoding::UTF16);
-        sess->file_index = std::move(ofi);
+        session->file_index = std::move(ofi);
     }
 
-    auto version = sess->version;
+    auto version = session->version;
     finish_compile();
 
     publish_diagnostics(uri_str, version, result.value().diagnostics);
@@ -779,29 +765,29 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
 /// Compiler's task_group; subsequent ones wait on the shared event.
 /// The spawned task is not cancelled by LSP $/cancelRequest, preventing
 /// the race where cancellation wakes all waiters and they all start compiles.
-kota::task<bool> Compiler::ensure_compiled(Session& session) {
-    auto path_id = session.path_id;
+kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
+    auto path_id = session->path_id;
 
     LOG_DEBUG("ensure_compiled: path_id={} version={} gen={} ast_dirty={}",
               path_id,
-              session.version,
-              session.generation,
-              session.ast_dirty);
+              session->version,
+              session->generation,
+              session->ast_dirty);
 
-    if(!session.ast_dirty) {
-        if(!is_stale(session)) {
+    if(!session->ast_dirty) {
+        if(!is_stale(*session)) {
             co_return true;
         }
-        session.ast_dirty = true;
+        session->ast_dirty = true;
     }
 
     // If an up-to-date compile is already in flight, wait for it.
     // This co_await may be cancelled by LSP $/cancelRequest — that's fine,
     // it just means this particular feature request is abandoned.  The
     // detached compile task keeps running independently.
-    while(session.compiling) {
-        auto pending = session.compiling;
-        if(pending->generation != session.generation && !pending->deps_done) {
+    while(session->compiling) {
+        auto pending = session->compiling;
+        if(pending->generation != session->generation && !pending->deps_done) {
             // The in-flight compile is stale (user edited since it started)
             // and still holds interest in the module graph — supersede it.
             // A stale compile already past its dependency phase is left to
@@ -811,21 +797,21 @@ kota::task<bool> Compiler::ensure_compiled(Session& session) {
             break;
         }
         co_await pending->done.wait();
-        if(!session.ast_dirty)
+        if(!session->ast_dirty)
             co_return true;
     }
 
-    auto superseded = session.compiling;
+    auto superseded = session->compiling;
     auto pending_compile = std::make_shared<Session::PendingCompile>();
-    pending_compile->generation = session.generation;
-    session.compiling = pending_compile;
+    pending_compile->generation = session->generation;
+    session->compiling = pending_compile;
 
-    LOG_INFO("ensure_compiled: launching compile path_id={} gen={}", path_id, session.generation);
+    LOG_INFO("ensure_compiled: launching compile path_id={} gen={}", path_id, session->generation);
 
     // Spawn the replacement before cancelling the superseded compile: the new
     // round acquires its module-dependency interest synchronously, so shared
     // dependencies never see their interest drop to zero across the swap.
-    compile_tasks.spawn(run_compile(session.shared_from_this(), pending_compile));
+    compile_tasks.spawn(run_compile(session));
 
     if(superseded) {
         superseded->deps_scope.cancel();
@@ -835,23 +821,23 @@ kota::task<bool> Compiler::ensure_compiled(Session& session) {
     // by LSP $/cancelRequest, the detached task continues unaffected.
     co_await pending_compile->done.wait();
 
-    co_return !session.ast_dirty;
+    co_return !session->ast_dirty;
 }
 
 Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
-                                            Session& session,
+                                            std::shared_ptr<Session> session,
                                             std::optional<protocol::Position> position,
                                             std::optional<protocol::Range> range) {
-    auto guard = session.shared_from_this();
-    auto path_id = session.path_id;
+    auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
-    auto text = session.text;
+    auto gen = session->generation;
+    auto text = session->text;
 
     if(!co_await ensure_compiled(session)) {
         co_return serde_raw{"null"};
     }
 
-    if(session.closed || session.ast_dirty) {
+    if(session->generation != gen) {
         co_return serde_raw{"null"};
     }
 
@@ -885,25 +871,25 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 
 Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
                                             const protocol::Position& position,
-                                            Session& session) {
-    auto guard = session.shared_from_this();
-    auto path_id = session.path_id;
+                                            std::shared_ptr<Session> session) {
+    auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto gen = session->generation;
 
     worker::BuildParams wp;
     wp.kind = kind;
     wp.file = path;
-    wp.version = session.version;
-    wp.text = session.text;
-    if(!fill_compile_args(path, wp.directory, wp.arguments, &session)) {
+    wp.version = session->version;
+    wp.text = session->text;
+    if(!fill_compile_args(path, wp.directory, wp.arguments, session.get())) {
         co_return serde_raw{};
     }
 
-    if(!co_await ensure_deps(session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
+    if(!co_await ensure_deps(*session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
         co_return serde_raw{};
     }
 
-    if(session.closed) {
+    if(session->generation != gen) {
         co_return serde_raw{};
     }
 
@@ -920,15 +906,15 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     co_return std::move(result.value().result_json);
 }
 
-Compiler::RawResult Compiler::forward_format(Session& session,
+Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
                                              std::optional<protocol::Range> range) {
-    auto path_id = session.path_id;
+    auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
 
     worker::BuildParams wp;
     wp.kind = worker::BuildKind::Format;
     wp.file = path;
-    wp.text = session.text;
+    wp.text = session->text;
 
     if(range) {
         lsp::PositionMapper mapper(wp.text, lsp::PositionEncoding::UTF16);
@@ -947,14 +933,14 @@ Compiler::RawResult Compiler::forward_format(Session& session,
 }
 
 Compiler::RawResult Compiler::handle_completion(const protocol::Position& position,
-                                                Session& session) {
-    auto path_id = session.path_id;
+                                                std::shared_ptr<Session> session) {
+    auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
 
-    lsp::PositionMapper mapper(session.text, lsp::PositionEncoding::UTF16);
+    lsp::PositionMapper mapper(session->text, lsp::PositionEncoding::UTF16);
     auto offset = mapper.to_offset(position);
     if(offset) {
-        auto pctx = detect_completion_context(session.text, *offset);
+        auto pctx = detect_completion_context(session->text, *offset);
         if(pctx.kind == CompletionContext::IncludeQuoted ||
            pctx.kind == CompletionContext::IncludeAngled) {
             std::string directory;
@@ -1001,7 +987,7 @@ Compiler::RawResult Compiler::handle_completion(const protocol::Position& positi
         }
     }
 
-    co_return co_await forward_build(worker::BuildKind::Completion, position, session);
+    co_return co_await forward_build(worker::BuildKind::Completion, position, std::move(session));
 }
 
 }  // namespace clice

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -729,7 +729,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         OpenFileIndex ofi;
         ofi.file_index = std::move(tu_index.main_file_index);
         ofi.symbols = std::move(tu_index.symbols);
-        ofi.content = session->text;
+        ofi.content = params.text;
         ofi.mapper.emplace(ofi.content, lsp::PositionEncoding::UTF16);
         session->file_index = std::move(ofi);
     }

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -27,11 +27,8 @@ using serde_raw = kota::codec::RawValue;
 
 /// Detect whether the cursor is inside a preamble directive (include/import).
 
-Compiler::Compiler(kota::event_loop& loop,
-                   Workspace& workspace,
-                   WorkerPool& pool,
-                   llvm::DenseMap<std::uint32_t, Session>& sessions) :
-    loop(loop), workspace(workspace), pool(pool), sessions(sessions) {}
+Compiler::Compiler(kota::event_loop& loop, Workspace& workspace, WorkerPool& pool) :
+    loop(loop), workspace(workspace), pool(pool) {}
 
 Compiler::~Compiler() {
     workspace.cancel_all();
@@ -318,12 +315,7 @@ std::optional<HeaderFileContext> Compiler::resolve_header_context(std::uint32_t 
         auto next_filename = llvm::sys::path::filename(next_path);
 
         // Prefer in-memory document text over disk content.
-        // Use the session if this file matches the session's path, otherwise
-        // fall back to disk.
         std::string content;
-        // Note: we don't have the sessions map here, so we always read from disk
-        // for intermediate chain files.  The session parameter only covers the
-        // header file itself (the target), not intermediate files in the chain.
         auto buf = llvm::MemoryBuffer::getFile(cur_path);
         if(!buf) {
             LOG_WARN("resolve_header_context: cannot read {}", cur_path);
@@ -660,22 +652,17 @@ void Compiler::record_deps(Session& session, llvm::ArrayRef<std::string> deps) {
 /// Called lazily by forward_query() / forward_build() before every
 /// feature request (hover, semantic tokens, etc.). Guarantees that when it
 /// returns true the stateful worker assigned to `path_id` holds an up-to-date
-kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::PendingCompile> pc) {
-    auto find_session = [&]() -> Session* {
-        auto it = sessions.find(pid);
-        return it != sessions.end() ? &it->second : nullptr;
-    };
-
-    auto* sess = find_session();
-    if(!sess) {
+kota::task<> Compiler::run_compile(std::shared_ptr<Session> sess,
+                                   std::shared_ptr<Session::PendingCompile> pc) {
+    if(!sess || sess->closed) {
         pc->done.set();
         co_return;
     }
 
+    auto pid = sess->path_id;
     auto finish_compile = [&]() {
-        auto* s = find_session();
-        if(s && s->compiling == pc) {
-            s->compiling.reset();
+        if(!sess->closed && sess->compiling == pc) {
+            sess->compiling.reset();
         }
         LOG_INFO("ensure_compiled: finish path_id={}", pid);
         pc->done.set();
@@ -692,7 +679,7 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
     params.path = file_path;
     params.version = sess->version;
     params.text = sess->text;
-    if(!fill_compile_args(file_path, params.directory, params.arguments, sess)) {
+    if(!fill_compile_args(file_path, params.directory, params.arguments, sess.get())) {
         finish_compile();
         co_return;
     }
@@ -710,15 +697,11 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
         co_return;
     }
 
-    sess = find_session();
-    if(!sess) {
+    if(sess->closed) {
         pc->done.set();
         co_return;
     }
 
-    // Superseded while preparing dependencies — don't send the stale text:
-    // the replacement compile may already have sent newer text, and the
-    // worker applies compiles in arrival order without a version check.
     if(sess->generation != gen) {
         LOG_INFO("ensure_compiled: superseded before send ({} vs {}) for {}",
                  sess->generation,
@@ -730,8 +713,7 @@ kota::task<> Compiler::run_compile(std::uint32_t pid, std::shared_ptr<Session::P
 
     auto result = co_await pool.send_stateful(pid, params);
 
-    sess = find_session();
-    if(!sess) {
+    if(sess->closed) {
         pc->done.set();
         co_return;
     }
@@ -843,7 +825,7 @@ kota::task<bool> Compiler::ensure_compiled(Session& session) {
     // Spawn the replacement before cancelling the superseded compile: the new
     // round acquires its module-dependency interest synchronously, so shared
     // dependencies never see their interest drop to zero across the swap.
-    compile_tasks.spawn(run_compile(path_id, pending_compile));
+    compile_tasks.spawn(run_compile(session.shared_from_this(), pending_compile));
 
     if(superseded) {
         superseded->deps_scope.cancel();
@@ -860,18 +842,16 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
                                             Session& session,
                                             std::optional<protocol::Position> position,
                                             std::optional<protocol::Range> range) {
+    auto guard = session.shared_from_this();
     auto path_id = session.path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
-    // Cache text before co_await — session reference may dangle if didClose
-    // erases the entry from the sessions map during suspension.
     auto text = session.text;
 
     if(!co_await ensure_compiled(session)) {
         co_return serde_raw{"null"};
     }
 
-    auto sit = sessions.find(path_id);
-    if(sit == sessions.end() || sit->second.ast_dirty) {
+    if(session.closed || session.ast_dirty) {
         co_return serde_raw{"null"};
     }
 
@@ -906,14 +886,13 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
                                             const protocol::Position& position,
                                             Session& session) {
+    auto guard = session.shared_from_this();
     auto path_id = session.path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
 
     worker::BuildParams wp;
     wp.kind = kind;
     wp.file = path;
-    // Cache session fields before co_await — session reference may dangle
-    // if didClose erases the entry from the sessions map during suspension.
     wp.version = session.version;
     wp.text = session.text;
     if(!fill_compile_args(path, wp.directory, wp.arguments, &session)) {
@@ -924,8 +903,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
         co_return serde_raw{};
     }
 
-    // After co_await, verify session still exists.
-    if(sessions.find(path_id) == sessions.end()) {
+    if(session.closed) {
         co_return serde_raw{};
     }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -767,11 +767,12 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 /// the race where cancellation wakes all waiters and they all start compiles.
 kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
     auto path_id = session->path_id;
+    auto gen = session->generation;
 
     LOG_DEBUG("ensure_compiled: path_id={} version={} gen={} ast_dirty={}",
               path_id,
               session->version,
-              session->generation,
+              gen,
               session->ast_dirty);
 
     if(!session->ast_dirty) {
@@ -799,6 +800,12 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
         co_await pending->done.wait();
         if(!session->ast_dirty)
             co_return true;
+    }
+
+    // If we fell through (not superseding) and the generation changed while
+    // we were waiting, the session was closed or replaced — don't compile.
+    if(!session->compiling && session->generation != gen) {
+        co_return false;
     }
 
     auto superseded = session->compiling;

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -67,7 +67,7 @@ public:
 
     /// Compile an open file's AST if dirty.  On success, updates session's
     /// file_index, pch_ref, ast_deps, and publishes diagnostics.
-    kota::task<bool> ensure_compiled(Session& session);
+    kota::task<bool> ensure_compiled(std::shared_ptr<Session> session);
 
     using RawResult = kota::task<kota::codec::RawValue, kota::ipc::Error>;
 
@@ -76,7 +76,7 @@ public:
     /// goto-definition), pass a Position.  For range-sensitive queries
     /// (inlay hints), pass a Range.
     RawResult forward_query(worker::QueryKind kind,
-                            Session& session,
+                            std::shared_ptr<Session> session,
                             std::optional<protocol::Position> position = {},
                             std::optional<protocol::Range> range = {});
 
@@ -84,14 +84,16 @@ public:
     /// Sends the full buffer content and compile arguments.
     RawResult forward_build(worker::BuildKind kind,
                             const protocol::Position& position,
-                            Session& session);
+                            std::shared_ptr<Session> session);
 
     /// Forward a formatting request to a stateless worker.
-    RawResult forward_format(Session& session, std::optional<protocol::Range> range = {});
+    RawResult forward_format(std::shared_ptr<Session> session,
+                             std::optional<protocol::Range> range = {});
 
     /// Handle completion requests.  Detects preamble context (include/import)
     /// and serves those locally; delegates code completion to a stateless worker.
-    RawResult handle_completion(const protocol::Position& position, Session& session);
+    RawResult handle_completion(const protocol::Position& position,
+                                std::shared_ptr<Session> session);
 
     /// Send an empty diagnostics notification to clear stale markers in the editor.
     void clear_diagnostics(const std::string& uri);
@@ -103,8 +105,7 @@ public:
     kota::task<> stop();
 
 private:
-    kota::task<> run_compile(std::shared_ptr<Session> session,
-                             std::shared_ptr<Session::PendingCompile> pc);
+    kota::task<> run_compile(std::shared_ptr<Session> session);
 
     /// @param scope  When set, cancels the module-dependency wait if this
     ///               compile round is superseded by a newer one.

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -19,7 +19,6 @@
 #include "kota/ipc/lsp/protocol.h"
 #include "kota/ipc/peer.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -49,10 +48,7 @@ std::string uri_to_path(const std::string& uri);
 ///   - Background indexing scheduling — handled by Indexer
 class Compiler {
 public:
-    Compiler(kota::event_loop& loop,
-             Workspace& workspace,
-             WorkerPool& pool,
-             llvm::DenseMap<std::uint32_t, Session>& sessions);
+    Compiler(kota::event_loop& loop, Workspace& workspace, WorkerPool& pool);
 
     void set_peer(kota::ipc::JsonPeer* p) {
         peer = p;
@@ -107,7 +103,8 @@ public:
     kota::task<> stop();
 
 private:
-    kota::task<> run_compile(std::uint32_t path_id, std::shared_ptr<Session::PendingCompile> pc);
+    kota::task<> run_compile(std::shared_ptr<Session> session,
+                             std::shared_ptr<Session::PendingCompile> pc);
 
     /// @param scope  When set, cancels the module-dependency wait if this
     ///               compile round is superseded by a newer one.
@@ -143,7 +140,6 @@ private:
     kota::ipc::JsonPeer* peer = nullptr;
     Workspace& workspace;
     WorkerPool& pool;
-    llvm::DenseMap<std::uint32_t, Session>& sessions;
     kota::task_group<> compile_tasks{loop};
 };
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -187,16 +187,19 @@ bool Indexer::need_update(llvm::StringRef file_path) {
 }
 
 bool Indexer::find_symbol_info(index::SymbolHash hash, std::string& name, SymbolKind& kind) const {
-    for(auto& [_, session]: sessions) {
-        if(!session.file_index)
-            continue;
-        auto it = session.file_index->symbols.find(hash);
-        if(it != session.file_index->symbols.end()) {
+    bool found = false;
+    for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
+        auto it = ofi.symbols.find(hash);
+        if(it != ofi.symbols.end()) {
             name = it->second.name;
             kind = it->second.kind;
-            return true;
+            found = true;
+            return false;
         }
-    }
+        return true;
+    });
+    if(found)
+        return true;
     auto it = workspace.project_index.symbols.find(hash);
     if(it != workspace.project_index.symbols.end()) {
         name = it->second.name;
@@ -273,17 +276,16 @@ std::vector<protocol::Location> Indexer::query_relations(llvm::StringRef path,
         }
     }
 
-    for(auto& [id, sess]: sessions) {
-        if(!sess.file_index)
-            continue;
+    for_each_overlay([&](std::uint32_t id, const OpenFileIndex& ofi) -> bool {
         auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
         if(!uri)
-            continue;
-        sess.file_index->find_relations(hit.hash, kind, [&](const auto&, protocol::Range range) {
+            return true;
+        ofi.find_relations(hit.hash, kind, [&](const auto&, protocol::Range range) {
             locations.push_back({uri->str(), range});
             return true;
         });
-    }
+        return true;
+    });
 
     return locations;
 }
@@ -305,23 +307,19 @@ std::optional<SymbolInfo> Indexer::lookup_symbol(const std::string& uri,
 }
 
 std::optional<protocol::Location> Indexer::find_definition_location(index::SymbolHash hash) {
-    // Open file indices first (fresher data for actively-edited files).
-    for(auto& [id, sess]: sessions) {
-        if(!sess.file_index)
-            continue;
+    std::optional<protocol::Location> overlay_result;
+    for_each_overlay([&](std::uint32_t id, const OpenFileIndex& ofi) -> bool {
         auto uri = lsp::URI::from_file_path(std::string(workspace.path_pool.resolve(id)));
         if(!uri)
-            continue;
-        std::optional<protocol::Location> result;
-        sess.file_index->find_relations(hash,
-                                        RelationKind::Definition,
-                                        [&](const auto&, protocol::Range range) {
-                                            result = protocol::Location{uri->str(), range};
-                                            return false;
-                                        });
-        if(result)
-            return result;
-    }
+            return true;
+        ofi.find_relations(hash, RelationKind::Definition, [&](const auto&, protocol::Range range) {
+            overlay_result = protocol::Location{uri->str(), range};
+            return false;
+        });
+        return !overlay_result.has_value();
+    });
+    if(overlay_result)
+        return overlay_result;
 
     // Fall back to ProjectIndex reference files.
     auto sym_it = workspace.project_index.symbols.find(hash);
@@ -388,14 +386,13 @@ void Indexer::collect_grouped_relations(
             });
         }
     }
-    for(auto& [_, sess]: sessions) {
-        if(!sess.file_index)
-            continue;
-        sess.file_index->find_relations(hash, kind, [&](const auto& r, protocol::Range range) {
+    for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
+        ofi.find_relations(hash, kind, [&](const auto& r, protocol::Range range) {
             target_ranges[r.target_symbol].push_back(range);
             return true;
         });
-    }
+        return true;
+    });
 }
 
 void Indexer::collect_unique_targets(index::SymbolHash hash,
@@ -419,12 +416,10 @@ void Indexer::collect_unique_targets(index::SymbolHash hash,
             });
         }
     }
-    for(auto& [_, sess]: sessions) {
-        if(!sess.file_index)
-            continue;
-        auto rel_it = sess.file_index->file_index.relations.find(hash);
-        if(rel_it == sess.file_index->file_index.relations.end())
-            continue;
+    for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
+        auto rel_it = ofi.file_index.relations.find(hash);
+        if(rel_it == ofi.file_index.relations.end())
+            return true;
         for(auto& r: rel_it->second) {
             if(r.kind & kind) {
                 if(seen.insert(r.target_symbol).second) {
@@ -432,7 +427,8 @@ void Indexer::collect_unique_targets(index::SymbolHash hash,
                 }
             }
         }
-    }
+        return true;
+    });
 }
 
 /// Resolve a symbol hash into a SymbolInfo with definition location.
@@ -464,34 +460,39 @@ static std::string extract_line(llvm::StringRef content, std::uint32_t offset) {
 }
 
 std::optional<Indexer::DefinitionText> Indexer::get_definition_text(index::SymbolHash hash) {
-    for(auto& [id, sess]: sessions) {
-        if(!sess.file_index || !sess.file_index->mapper)
-            continue;
-        auto it = sess.file_index->file_index.relations.find(hash);
-        if(it == sess.file_index->file_index.relations.end())
-            continue;
+    std::optional<DefinitionText> overlay_result;
+    for_each_overlay([&](std::uint32_t id, const OpenFileIndex& ofi) -> bool {
+        if(!ofi.mapper)
+            return true;
+        auto it = ofi.file_index.relations.find(hash);
+        if(it == ofi.file_index.relations.end())
+            return true;
         for(auto& rel: it->second) {
             if(rel.kind.value() != RelationKind::Definition)
                 continue;
             auto def_range = std::bit_cast<LocalSourceRange>(rel.target_symbol);
             if(def_range.begin >= def_range.end)
                 continue;
-            llvm::StringRef content = sess.file_index->content;
+            llvm::StringRef content = ofi.content;
             if(def_range.end > content.size())
                 continue;
-            auto start = sess.file_index->mapper->to_position(def_range.begin);
-            auto end = sess.file_index->mapper->to_position(def_range.end);
+            auto start = ofi.mapper->to_position(def_range.begin);
+            auto end = ofi.mapper->to_position(def_range.end);
             if(!start || !end)
                 continue;
-            return DefinitionText{
+            overlay_result = DefinitionText{
                 .file = std::string(workspace.path_pool.resolve(id)),
                 .start_line = static_cast<int>(start->line) + 1,
                 .end_line = static_cast<int>(end->line) + 1,
                 .text =
                     std::string(content.substr(def_range.begin, def_range.end - def_range.begin)),
             };
+            return false;
         }
-    }
+        return true;
+    });
+    if(overlay_result)
+        return overlay_result;
 
     auto sym_it = workspace.project_index.symbols.find(hash);
     if(sym_it == workspace.project_index.symbols.end())
@@ -568,19 +569,19 @@ std::vector<Indexer::ReferenceWithContext> Indexer::collect_references(index::Sy
         }
     }
 
-    for(auto& [id, sess]: sessions) {
-        if(!sess.file_index || !sess.file_index->mapper)
-            continue;
-        auto it = sess.file_index->file_index.relations.find(hash);
-        if(it == sess.file_index->file_index.relations.end())
-            continue;
+    for_each_overlay([&](std::uint32_t id, const OpenFileIndex& ofi) -> bool {
+        if(!ofi.mapper)
+            return true;
+        auto it = ofi.file_index.relations.find(hash);
+        if(it == ofi.file_index.relations.end())
+            return true;
         auto file_path = workspace.path_pool.resolve(id);
-        llvm::StringRef content = sess.file_index->content;
+        llvm::StringRef content = ofi.content;
 
         for(auto& rel: it->second) {
             if(rel.kind != kind)
                 continue;
-            auto start = sess.file_index->mapper->to_position(rel.range.begin);
+            auto start = ofi.mapper->to_position(rel.range.begin);
             if(!start)
                 continue;
             results.push_back(ReferenceWithContext{
@@ -589,7 +590,8 @@ std::vector<Indexer::ReferenceWithContext> Indexer::collect_references(index::Sy
                 .context = extract_line(content, rel.range.begin),
             });
         }
-    }
+        return true;
+    });
 
     return results;
 }
@@ -695,14 +697,12 @@ std::vector<protocol::SymbolInformation> Indexer::search_symbols(llvm::StringRef
         seen.insert(hash);
     }
 
-    for(auto& [_, sess]: sessions) {
+    for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
         if(results.size() >= max_results)
-            break;
-        if(!sess.file_index)
-            continue;
-        for(auto& [hash, symbol]: sess.file_index->symbols) {
+            return false;
+        for(auto& [hash, symbol]: ofi.symbols) {
             if(results.size() >= max_results)
-                break;
+                return false;
             if(seen.contains(hash))
                 continue;
             if(!is_indexable_kind(symbol.kind) || symbol.name.empty())
@@ -720,7 +720,8 @@ std::vector<protocol::SymbolInformation> Indexer::search_symbols(llvm::StringRef
             results.push_back(std::move(info));
             seen.insert(hash);
         }
-    }
+        return true;
+    });
     return results;
 }
 
@@ -813,7 +814,7 @@ void Indexer::schedule() {
 kota::task<> Indexer::index_one(std::uint32_t server_path_id) {
     auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
 
-    if(sessions.contains(server_path_id))
+    if(is_open && is_open(server_path_id))
         co_return;
 
     if(!need_update(file_path))
@@ -922,7 +923,7 @@ kota::task<> Indexer::run_background_indexing() {
 
         auto server_path_id = index_queue[index_queue_pos++];
         auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
-        if(sessions.contains(server_path_id) || !need_update(file_path)) {
+        if((is_open && is_open(server_path_id)) || !need_update(file_path)) {
             ++completed;
             continue;
         }

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -55,14 +55,18 @@ struct SymbolInfo {
 ///   - Document lifecycle — handled by MasterServer
 class Indexer {
 public:
+    /// Visitor for iterating open-file overlays.  Returns false to stop early.
+    using OverlayVisitor =
+        std::function<bool(std::uint32_t server_path_id, const OpenFileIndex& index)>;
+
     Indexer(kota::event_loop& loop,
             Workspace& workspace,
-            llvm::DenseMap<std::uint32_t, Session>& sessions,
             WorkerPool& pool,
             Compiler& compiler,
-            std::function<bool(std::uint32_t)> is_file_open = {}) :
-        loop(loop), bg_tasks(loop), workspace(workspace), sessions(sessions), pool(pool),
-        compiler(compiler), is_file_open(std::move(is_file_open)) {}
+            std::function<bool(std::uint32_t)> is_open = {},
+            std::function<void(OverlayVisitor)> each_overlay = {}) :
+        loop(loop), bg_tasks(loop), workspace(workspace), pool(pool), compiler(compiler),
+        is_open(std::move(is_open)), each_overlay(std::move(each_overlay)) {}
 
     /// Set the LSP peer for progress reporting.  Must be called before
     /// schedule() if progress notifications are desired.
@@ -189,6 +193,25 @@ public:
     /// Cancel background indexing and wait for all tasks to settle.
     kota::task<> stop();
 
+    /// Iterate all open-file overlays via the callback set at construction.
+    void for_each_overlay(OverlayVisitor visitor) const {
+        if(each_overlay)
+            each_overlay(std::move(visitor));
+    }
+
+    /// Get the overlay for a specific server-level path_id (nullptr if not open).
+    const OpenFileIndex* get_overlay(std::uint32_t server_path_id) const {
+        const OpenFileIndex* result = nullptr;
+        for_each_overlay([&](std::uint32_t id, const OpenFileIndex& ofi) -> bool {
+            if(id == server_path_id) {
+                result = &ofi;
+                return false;
+            }
+            return true;
+        });
+        return result;
+    }
+
     /// Whether background indexing is currently idle (no active or queued work).
     bool is_idle() const {
         return !indexing_active && index_queue_pos >= index_queue.size();
@@ -240,21 +263,27 @@ private:
 
     /// Check whether a project-level path_id has an active Session.
     bool is_proj_path_open(std::uint32_t proj_path_id) const {
-        return is_file_open && is_file_open(proj_path_id);
+        if(!is_open)
+            return false;
+        auto path = workspace.project_index.path_pool.path(proj_path_id);
+        auto it = workspace.path_pool.cache.find(path);
+        if(it == workspace.path_pool.cache.end())
+            return false;
+        return is_open(it->second);
     }
 
 private:
     kota::event_loop& loop;
     kota::task_group<> bg_tasks;
     Workspace& workspace;
-    llvm::DenseMap<std::uint32_t, Session>& sessions;
     WorkerPool& pool;
     Compiler& compiler;
 
-    /// Callback that checks if a *project-level* path_id has an active
-    /// Session.  Set by the owner (e.g. MasterServer) to bridge the
-    /// server-path-id-keyed sessions map to project-level path_ids.
-    std::function<bool(std::uint32_t)> is_file_open;
+    /// Checks if a server-level path_id has an open Session.
+    std::function<bool(std::uint32_t)> is_open;
+
+    /// Iterates all open-file overlays (OpenFileIndex from live compilations).
+    std::function<void(OverlayVisitor)> each_overlay;
 
     /// LSP peer for progress reporting (optional, not owned).
     kota::ipc::JsonPeer* peer = nullptr;

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -41,7 +41,6 @@ struct ResolvedSymbol {
 
 static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolParams& loc,
                                                    Workspace& workspace,
-                                                   llvm::DenseMap<std::uint32_t, Session>& sessions,
                                                    Indexer& indexer) {
     if(loc.symbol_id.has_value() && *loc.symbol_id != 0) {
         auto hash = static_cast<index::SymbolHash>(*loc.symbol_id);
@@ -102,12 +101,11 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
 
         for(auto& [hash, symbol]: workspace.project_index.symbols)
             try_symbol(hash, symbol);
-        for(auto& [_, sess]: sessions) {
-            if(!sess.file_index)
-                continue;
-            for(auto& [hash, symbol]: sess.file_index->symbols)
+        indexer.for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
+            for(auto& [hash, symbol]: ofi.symbols)
                 try_symbol(hash, symbol);
-        }
+            return true;
+        });
 
         if(!exact_matches.empty())
             return exact_matches;
@@ -120,16 +118,14 @@ static std::vector<ResolvedSymbol> resolve_locator(const agentic::ReadSymbolPara
 
         auto pool_it = workspace.path_pool.cache.find(path_str);
         auto server_id = pool_it != workspace.path_pool.cache.end() ? pool_it->second : ~0u;
-        auto* sess =
-            server_id != ~0u && sessions.contains(server_id) ? &sessions[server_id] : nullptr;
-        if(sess && sess->file_index) {
-            auto& fi = *sess->file_index;
-            if(fi.mapper) {
-                for(auto& [hash, rels]: fi.file_index.relations) {
+        if(server_id != ~0u) {
+            auto* ofi = indexer.get_overlay(server_id);
+            if(ofi && ofi->mapper) {
+                for(auto& [hash, rels]: ofi->file_index.relations) {
                     for(auto& rel: rels) {
                         if(rel.kind.value() != RelationKind::Definition)
                             continue;
-                        auto start = fi.mapper->to_position(rel.range.begin);
+                        auto start = ofi->mapper->to_position(rel.range.begin);
                         if(start && start->line == target_line) {
                             std::string name;
                             SymbolKind kind;
@@ -433,19 +429,18 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
 
         for(auto& [hash, symbol]: srv.workspace.project_index.symbols)
             try_symbol(hash, symbol);
-        for(auto& [_, sess]: srv.sessions) {
-            if(!sess.file_index)
-                continue;
-            for(auto& [hash, symbol]: sess.file_index->symbols)
+        srv.indexer.for_each_overlay([&](std::uint32_t, const OpenFileIndex& ofi) -> bool {
+            for(auto& [hash, symbol]: ofi.symbols)
                 try_symbol(hash, symbol);
-        }
+            return true;
+        });
 
         co_return result;
     });
 
     peer.on_request(
         [&srv](RequestContext&, const ReadSymbolParams& params) -> RequestResult<ReadSymbolParams> {
-            auto candidates = resolve_locator(params, srv.workspace, srv.sessions, srv.indexer);
+            auto candidates = resolve_locator(params, srv.workspace, srv.indexer);
             if(candidates.empty())
                 co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
             if(candidates.size() > 1) {
@@ -490,9 +485,9 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             if(pool_it == srv.workspace.path_pool.cache.end())
                 co_return result;
             auto server_id = pool_it->second;
-            auto sess_it = srv.sessions.find(server_id);
-            if(sess_it != srv.sessions.end() && sess_it->second.file_index) {
-                auto& fi = *sess_it->second.file_index;
+            auto* ofi = srv.indexer.get_overlay(server_id);
+            if(ofi) {
+                auto& fi = *ofi;
                 for(auto& [hash, rels]: fi.file_index.relations) {
                     for(auto& rel: rels) {
                         if(rel.kind.value() != RelationKind::Definition)
@@ -562,7 +557,6 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             auto candidates = resolve_locator(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
                 srv.workspace,
-                srv.sessions,
                 srv.indexer);
             if(candidates.empty())
                 co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
@@ -596,7 +590,6 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             auto candidates = resolve_locator(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
                 srv.workspace,
-                srv.sessions,
                 srv.indexer);
             if(candidates.empty())
                 co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
@@ -639,7 +632,6 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             auto candidates = resolve_locator(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
                 srv.workspace,
-                srv.sessions,
                 srv.indexer);
             if(candidates.empty())
                 co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});
@@ -708,7 +700,6 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
             auto candidates = resolve_locator(
                 ReadSymbolParams{params.name, params.path, params.line, params.symbol_id},
                 srv.workspace,
-                srv.sessions,
                 srv.indexer);
             if(candidates.empty())
                 co_return kota::outcome_error(kota::ipc::Error{"symbol not found"});

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -166,10 +166,10 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
 
-        auto& session = srv.open_session(path_id);
-        session.version = params.text_document.version;
-        session.text = params.text_document.text;
-        session.generation++;
+        auto session = srv.open_session(path_id);
+        session->version = params.text_document.version;
+        session->text = params.text_document.text;
+        session->generation++;
 
         LOG_DEBUG("didOpen: {} (v{})", path, params.text_document.version);
     });
@@ -182,7 +182,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
 
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             return;
 
@@ -247,7 +247,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document_position_params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(
@@ -261,7 +261,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(worker::QueryKind::SemanticTokens, *session);
@@ -272,7 +272,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto& srv = this->server;
             auto path = uri_to_path(params.text_document.uri);
             auto path_id = srv.workspace.path_pool.intern(path);
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
             co_return co_await srv.compiler.forward_query(worker::QueryKind::InlayHints,
@@ -286,7 +286,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(worker::QueryKind::FoldingRange, *session);
@@ -297,7 +297,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(worker::QueryKind::DocumentSymbol, *session);
@@ -308,7 +308,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto& srv = this->server;
             auto path = uri_to_path(params.text_document.uri);
             auto path_id = srv.workspace.path_pool.intern(path);
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
             auto result =
@@ -316,10 +316,9 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             if(!result.has_value())
                 co_return serde_raw{"null"};
             auto& links = result.value();
-            auto* session2 = srv.find_session(path_id);
-            if(session2 && session2->pch_ref) {
+            if(!session->closed && session->pch_ref) {
                 auto& pch_cache = srv.workspace.pch_cache;
-                auto pch_it = pch_cache.find(session2->pch_ref->path_id);
+                auto pch_it = pch_cache.find(session->pch_ref->path_id);
                 if(pch_it != pch_cache.end() && !pch_it->second.document_links_json.empty()) {
                     auto& pch_json = pch_it->second.document_links_json;
                     if(!links.data.empty() && links.data != "null" && links.data.size() > 2) {
@@ -339,7 +338,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto& srv = this->server;
             auto path = uri_to_path(params.text_document.uri);
             auto path_id = srv.workspace.path_pool.intern(path);
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
             co_return co_await srv.compiler.forward_query(worker::QueryKind::CodeAction, *session);
@@ -353,8 +352,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         };
         auto path = uri_to_path(uri);
         auto path_id = this->server.workspace.path_pool.intern(path);
-        auto* session = this->server.find_session(path_id);
-        return Result{std::move(path), path_id, session};
+        return Result{std::move(path), path_id, this->server.find_session(path_id).get()};
     };
 
     auto lookup_at = [this, resolve_uri](const std::string& uri, const protocol::Position& pos) {
@@ -391,7 +389,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(worker::QueryKind::GoToDefinition,
@@ -438,7 +436,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document_position_params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         auto pause = srv.indexer.scoped_pause();
@@ -453,7 +451,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto& srv = this->server;
             auto path = uri_to_path(params.text_document_position_params.text_document.uri);
             auto path_id = srv.workspace.path_pool.intern(path);
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
             auto pause = srv.indexer.scoped_pause();
@@ -469,7 +467,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto& srv = this->server;
             auto path = uri_to_path(params.text_document.uri);
             auto path_id = srv.workspace.path_pool.intern(path);
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
             auto pause = srv.indexer.scoped_pause();
@@ -481,7 +479,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto& srv = this->server;
         auto path = uri_to_path(params.text_document.uri);
         auto path_id = srv.workspace.path_pool.intern(path);
-        auto* session = srv.find_session(path_id);
+        auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
         auto pause = srv.indexer.scoped_pause();
@@ -656,7 +654,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto path_id = srv.workspace.path_pool.intern(path);
 
             ext::CurrentContextResult result;
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(session && session->active_context) {
                 auto ctx_path = srv.workspace.path_pool.resolve(*session->active_context);
                 auto ctx_uri_opt = lsp::URI::from_file_path(std::string(ctx_path));
@@ -689,7 +687,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
                 co_return to_raw(result);
             }
 
-            auto* session = srv.find_session(path_id);
+            auto session = srv.find_session(path_id);
             if(!session) {
                 result.success = false;
                 co_return to_raw(result);

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -252,7 +252,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(
             worker::QueryKind::Hover,
-            *session,
+            session,
             params.text_document_position_params.position);
     });
 
@@ -264,7 +264,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
-        co_return co_await srv.compiler.forward_query(worker::QueryKind::SemanticTokens, *session);
+        co_return co_await srv.compiler.forward_query(worker::QueryKind::SemanticTokens, session);
     });
 
     peer.on_request(
@@ -276,21 +276,21 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             if(!session)
                 co_return serde_raw{"null"};
             co_return co_await srv.compiler.forward_query(worker::QueryKind::InlayHints,
-                                                          *session,
+                                                          session,
                                                           {},
                                                           params.range);
         });
 
-    peer.on_request([this](RequestContext& ctx,
-                           const protocol::FoldingRangeParams& params) -> RawResult {
-        auto& srv = this->server;
-        auto path = uri_to_path(params.text_document.uri);
-        auto path_id = srv.workspace.path_pool.intern(path);
-        auto session = srv.find_session(path_id);
-        if(!session)
-            co_return serde_raw{"null"};
-        co_return co_await srv.compiler.forward_query(worker::QueryKind::FoldingRange, *session);
-    });
+    peer.on_request(
+        [this](RequestContext& ctx, const protocol::FoldingRangeParams& params) -> RawResult {
+            auto& srv = this->server;
+            auto path = uri_to_path(params.text_document.uri);
+            auto path_id = srv.workspace.path_pool.intern(path);
+            auto session = srv.find_session(path_id);
+            if(!session)
+                co_return serde_raw{"null"};
+            co_return co_await srv.compiler.forward_query(worker::QueryKind::FoldingRange, session);
+        });
 
     peer.on_request([this](RequestContext& ctx,
                            const protocol::DocumentSymbolParams& params) -> RawResult {
@@ -300,38 +300,37 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto session = srv.find_session(path_id);
         if(!session)
             co_return serde_raw{"null"};
-        co_return co_await srv.compiler.forward_query(worker::QueryKind::DocumentSymbol, *session);
+        co_return co_await srv.compiler.forward_query(worker::QueryKind::DocumentSymbol, session);
     });
 
-    peer.on_request(
-        [this](RequestContext& ctx, const protocol::DocumentLinkParams& params) -> RawResult {
-            auto& srv = this->server;
-            auto path = uri_to_path(params.text_document.uri);
-            auto path_id = srv.workspace.path_pool.intern(path);
-            auto session = srv.find_session(path_id);
-            if(!session)
-                co_return serde_raw{"null"};
-            auto result =
-                co_await srv.compiler.forward_query(worker::QueryKind::DocumentLink, *session);
-            if(!result.has_value())
-                co_return serde_raw{"null"};
-            auto& links = result.value();
-            if(!session->closed && session->pch_ref) {
-                auto& pch_cache = srv.workspace.pch_cache;
-                auto pch_it = pch_cache.find(session->pch_ref->path_id);
-                if(pch_it != pch_cache.end() && !pch_it->second.document_links_json.empty()) {
-                    auto& pch_json = pch_it->second.document_links_json;
-                    if(!links.data.empty() && links.data != "null" && links.data.size() > 2) {
-                        links.data.pop_back();
-                        links.data += ',';
-                        links.data.append(pch_json.begin() + 1, pch_json.end());
-                    } else {
-                        links.data = pch_json;
-                    }
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::DocumentLinkParams& params) -> RawResult {
+        auto& srv = this->server;
+        auto path = uri_to_path(params.text_document.uri);
+        auto path_id = srv.workspace.path_pool.intern(path);
+        auto session = srv.find_session(path_id);
+        if(!session)
+            co_return serde_raw{"null"};
+        auto result = co_await srv.compiler.forward_query(worker::QueryKind::DocumentLink, session);
+        if(!result.has_value())
+            co_return serde_raw{"null"};
+        auto& links = result.value();
+        if(session->pch_ref) {
+            auto& pch_cache = srv.workspace.pch_cache;
+            auto pch_it = pch_cache.find(session->pch_ref->path_id);
+            if(pch_it != pch_cache.end() && !pch_it->second.document_links_json.empty()) {
+                auto& pch_json = pch_it->second.document_links_json;
+                if(!links.data.empty() && links.data != "null" && links.data.size() > 2) {
+                    links.data.pop_back();
+                    links.data += ',';
+                    links.data.append(pch_json.begin() + 1, pch_json.end());
+                } else {
+                    links.data = pch_json;
                 }
             }
-            co_return std::move(links);
-        });
+        }
+        co_return std::move(links);
+    });
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::CodeActionParams& params) -> RawResult {
@@ -341,7 +340,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto session = srv.find_session(path_id);
             if(!session)
                 co_return serde_raw{"null"};
-            co_return co_await srv.compiler.forward_query(worker::QueryKind::CodeAction, *session);
+            co_return co_await srv.compiler.forward_query(worker::QueryKind::CodeAction, session);
         });
 
     auto resolve_uri = [this](const std::string& uri) {
@@ -393,7 +392,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         if(!session)
             co_return serde_raw{"null"};
         co_return co_await srv.compiler.forward_query(worker::QueryKind::GoToDefinition,
-                                                      *session,
+                                                      session,
                                                       pos);
     });
 
@@ -442,7 +441,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         auto pause = srv.indexer.scoped_pause();
         auto result =
             co_await srv.compiler.handle_completion(params.text_document_position_params.position,
-                                                    *session);
+                                                    session);
         co_return std::move(result);
     });
 
@@ -458,7 +457,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             auto result =
                 co_await srv.compiler.forward_build(worker::BuildKind::SignatureHelp,
                                                     params.text_document_position_params.position,
-                                                    *session);
+                                                    session);
             co_return std::move(result);
         });
 
@@ -471,7 +470,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
             if(!session)
                 co_return serde_raw{"null"};
             auto pause = srv.indexer.scoped_pause();
-            co_return co_await srv.compiler.forward_format(*session);
+            co_return co_await srv.compiler.forward_format(session);
         });
 
     peer.on_request([this](RequestContext& ctx,
@@ -483,7 +482,7 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         if(!session)
             co_return serde_raw{"null"};
         auto pause = srv.indexer.scoped_pause();
-        co_return co_await srv.compiler.forward_format(*session, params.range);
+        co_return co_await srv.compiler.forward_format(session, params.range);
     });
 
     peer.on_request(

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<Session> MasterServer::find_session(std::uint32_t path_id) {
 std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
     auto it = sessions.find(path_id);
     if(it != sessions.end()) {
-        it->second->closed = true;
+        it->second->generation++;
     }
     auto session = std::make_shared<Session>();
     session->path_id = path_id;
@@ -178,7 +178,7 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
 
     auto it = sessions.find(path_id);
     if(it != sessions.end()) {
-        it->second->closed = true;
+        it->second->generation++;
         sessions.erase(it);
     }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -45,9 +45,9 @@ MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
         compiler,
         [this](uint32_t server_path_id) { return sessions.contains(server_path_id); },
         [this](Indexer::OverlayVisitor visitor) {
-            for(auto& [id, sess_ptr]: sessions) {
-                if(sess_ptr && sess_ptr->file_index) {
-                    if(!visitor(id, *sess_ptr->file_index))
+            for(auto& [path_id, session]: sessions) {
+                if(session && session->file_index) {
+                    if(!visitor(path_id, *session->file_index))
                         break;
                 }
             }
@@ -199,10 +199,10 @@ void MasterServer::on_file_saved(std::uint32_t path_id) {
         }
     }
 
-    for(auto& [hdr_id, sess_ptr]: sessions) {
-        if(sess_ptr->header_context && sess_ptr->header_context->host_path_id == path_id) {
-            sess_ptr->header_context.reset();
-            sess_ptr->ast_dirty = true;
+    for(auto& [path_id, session]: sessions) {
+        if(session->header_context && session->header_context->host_path_id == path_id) {
+            session->header_context.reset();
+            session->ast_dirty = true;
         }
     }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -37,17 +37,21 @@ namespace lsp = kota::ipc::lsp;
 namespace protocol = kota::ipc::protocol;
 
 MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
-    loop(loop), pool(loop), compiler(loop, workspace, pool, sessions),
-    indexer(loop,
-            workspace,
-            sessions,
-            pool,
-            compiler,
-            [this](uint32_t proj_path_id) {
-                auto path = workspace.project_index.path_pool.path(proj_path_id);
-                auto server_id = workspace.path_pool.intern(path);
-                return sessions.contains(server_id);
-            }),
+    loop(loop), pool(loop), compiler(loop, workspace, pool),
+    indexer(
+        loop,
+        workspace,
+        pool,
+        compiler,
+        [this](uint32_t server_path_id) { return sessions.contains(server_path_id); },
+        [this](Indexer::OverlayVisitor visitor) {
+            for(auto& [id, sess_ptr]: sessions) {
+                if(sess_ptr && sess_ptr->file_index) {
+                    if(!visitor(id, *sess_ptr->file_index))
+                        break;
+                }
+            }
+        }),
     self_path(std::move(self_path)) {}
 
 MasterServer::~MasterServer() = default;
@@ -142,17 +146,19 @@ kota::task<> MasterServer::file_watcher_task() {
     }
 }
 
-Session* MasterServer::find_session(std::uint32_t path_id) {
+std::shared_ptr<Session> MasterServer::find_session(std::uint32_t path_id) {
     auto it = sessions.find(path_id);
-    return it != sessions.end() ? &it->second : nullptr;
+    return it != sessions.end() ? it->second : nullptr;
 }
 
-Session& MasterServer::open_session(std::uint32_t path_id) {
-    auto [it, inserted] = sessions.try_emplace(path_id);
-    auto& session = it->second;
-    if(!inserted)
-        session = Session{};
-    session.path_id = path_id;
+std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
+    auto it = sessions.find(path_id);
+    if(it != sessions.end()) {
+        it->second->closed = true;
+    }
+    auto session = std::make_shared<Session>();
+    session->path_id = path_id;
+    sessions[path_id] = session;
     return session;
 }
 
@@ -170,7 +176,11 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
     diag_params.diagnostics = {};
     peer.send_notification(diag_params);
 
-    sessions.erase(path_id);
+    auto it = sessions.find(path_id);
+    if(it != sessions.end()) {
+        it->second->closed = true;
+        sessions.erase(it);
+    }
 
     indexer.enqueue(path_id);
     indexer.schedule();
@@ -181,17 +191,18 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
 void MasterServer::on_file_saved(std::uint32_t path_id) {
     auto dirtied = workspace.on_file_saved(path_id);
     for(auto dirty_id: dirtied) {
-        if(auto* session = find_session(dirty_id)) {
+        auto session = find_session(dirty_id);
+        if(session) {
             session->ast_dirty = true;
         } else {
             indexer.enqueue(dirty_id);
         }
     }
 
-    for(auto& [hdr_id, session]: sessions) {
-        if(session.header_context && session.header_context->host_path_id == path_id) {
-            session.header_context.reset();
-            session.ast_dirty = true;
+    for(auto& [hdr_id, sess_ptr]: sessions) {
+        if(sess_ptr->header_context && sess_ptr->header_context->host_path_id == path_id) {
+            sess_ptr->header_context.reset();
+            sess_ptr->ast_dirty = true;
         }
     }
 

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -88,8 +88,8 @@ public:
     kota::task<> file_watcher_task();
     kota::task<> shutdown_and_cleanup();
 
-    Session* find_session(std::uint32_t path_id);
-    Session& open_session(std::uint32_t path_id);
+    std::shared_ptr<Session> find_session(std::uint32_t path_id);
+    std::shared_ptr<Session> open_session(std::uint32_t path_id);
     void close_session(std::uint32_t path_id, kota::ipc::JsonPeer& peer);
 
     void on_file_saved(std::uint32_t path_id);
@@ -107,7 +107,7 @@ private:
     kota::event_loop& loop;
 
     Workspace workspace;
-    llvm::DenseMap<std::uint32_t, Session> sessions;
+    llvm::DenseMap<std::uint32_t, std::shared_ptr<Session>> sessions;
     WorkerPool pool;
     Compiler compiler;
     Indexer indexer;

--- a/src/server/service/session.h
+++ b/src/server/service/session.h
@@ -22,7 +22,7 @@ namespace clice {
 /// file's translation unit and NEVER leak to Workspace or other Sessions.
 /// Sessions may READ from Workspace (e.g. to obtain PCH/PCM paths, module
 /// mappings, include graph) but all compilation results stay here.
-struct Session : std::enable_shared_from_this<Session> {
+struct Session {
     /// Path ID of this file in PathPool.  Set on creation, never changes.
     std::uint32_t path_id = 0;
 
@@ -32,17 +32,12 @@ struct Session : std::enable_shared_from_this<Session> {
     /// Current buffer content (may differ from disk until saved).
     std::string text;
 
-    /// Monotonic generation counter, incremented on every didChange.
+    /// Monotonic generation counter, incremented on every didChange and on close.
     /// Used to detect stale compilation results (ABA prevention).
     std::uint64_t generation = 0;
 
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;
-
-    /// Set when close_session() is called.  The Session object may outlive its
-    /// map entry because coroutines hold a shared_ptr; checking this flag lets
-    /// them detect that the file was closed without needing a map re-lookup.
-    bool closed = false;
 
     /// Non-null while a compilation is in flight for this file.
     /// Other queries wait on the event; the compilation task itself
@@ -51,7 +46,7 @@ struct Session : std::enable_shared_from_this<Session> {
         kota::event done;
         bool succeeded = false;
 
-        /// Generation snapshot at spawn; a later didChange supersedes this compile.
+        /// Revision snapshot at spawn; a later didChange supersedes this compile.
         std::uint64_t generation = 0;
 
         /// True once module dependencies are settled and the compile has moved

--- a/src/server/service/session.h
+++ b/src/server/service/session.h
@@ -22,7 +22,7 @@ namespace clice {
 /// file's translation unit and NEVER leak to Workspace or other Sessions.
 /// Sessions may READ from Workspace (e.g. to obtain PCH/PCM paths, module
 /// mappings, include graph) but all compilation results stay here.
-struct Session {
+struct Session : std::enable_shared_from_this<Session> {
     /// Path ID of this file in PathPool.  Set on creation, never changes.
     std::uint32_t path_id = 0;
 
@@ -38,6 +38,11 @@ struct Session {
 
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;
+
+    /// Set when close_session() is called.  The Session object may outlive its
+    /// map entry because coroutines hold a shared_ptr; checking this flag lets
+    /// them detect that the file was closed without needing a map re-lookup.
+    bool closed = false;
 
     /// Non-null while a compilation is in flight for this file.
     /// Other queries wait on the event; the compilation task itself

--- a/src/server/service/session.h
+++ b/src/server/service/session.h
@@ -46,7 +46,7 @@ struct Session {
         kota::event done;
         bool succeeded = false;
 
-        /// Revision snapshot at spawn; a later didChange supersedes this compile.
+        /// Generation snapshot at spawn; a later didChange supersedes this compile.
         std::uint64_t generation = 0;
 
         /// True once module dependencies are settled and the compile has moved


### PR DESCRIPTION
## Summary

- **Store sessions as `shared_ptr<Session>`** in the sessions map to prevent use-after-free when coroutines hold references across `co_await` while `DenseMap` reallocates or entries are erased by `didClose`.
- **Compiler takes `shared_ptr<Session>` by value** in all public coroutine methods (`ensure_compiled`, `forward_query`, `forward_build`, `forward_format`, `handle_completion`), expressing lifetime ownership in the type signature. The sessions map reference is removed from Compiler entirely.
- **Decouple Indexer from sessions map** — replace direct `DenseMap<uint32_t, Session>&` access with two callbacks (`is_open`, `each_overlay`), exposed as `for_each_overlay()` / `get_overlay()` helpers.
- **Unify staleness detection on `generation`** — bump generation on both `didChange` and `didClose`, making the `closed` flag unnecessary. All post-`co_await` checks use a snapshot-and-compare pattern (`session->generation != gen`).
- **Fix stale-compile-after-close bug** — `ensure_compiled` now checks generation after the wait loop exits, preventing it from spawning a compile for a session that was closed while waiting.
- **Fix missing staleness checks** — `forward_query` and `forward_build` now check generation after their respective `co_await` points (previously `forward_build` only checked session existence, missing edits; `forward_query` re-looked up the map instead of checking the held session).
- **Use `params.text` for overlay content** — `run_compile` stores the text snapshot taken before `co_await` into the `OpenFileIndex`, not the potentially-mutated `session->text`.

## Motivation

Sessions stored inline in `DenseMap` could be invalidated by container reallocation while async coroutines held `Session&` references across suspension points. The `closed` flag and `find_session()` re-lookups were ad-hoc mitigations that didn't cover all code paths. Moving to `shared_ptr` storage with generation-based staleness gives a single, uniform mechanism that is correct by construction.

## Test plan

- [x] All 621 unit tests pass
- [x] All 175 integration tests pass
- [x] All 3 smoke tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal session and compilation lifetime management to use shared pointers instead of external session maps, simplifying session access patterns throughout the compiler and indexer.
  * Updated indexing system to use overlay-based iteration for symbol and definition lookups, improving consistency and reliability of language server features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->