### PR TITLE
refactor(server): crash handling and scheduling tests for WorkerPool

### DIFF
--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -93,6 +93,7 @@ void Compiler::init_compile_graph() {
         auto file_path = std::string(workspace.path_pool.resolve(path_id));
 
         worker::BuildParams bp;
+        bp.priority = worker::Priority::High;
         bp.kind = worker::BuildKind::BuildPCM;
         bp.file = file_path;
         if(!fill_compile_args(file_path, bp.directory, bp.arguments))

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -93,7 +93,6 @@ void Compiler::init_compile_graph() {
         auto file_path = std::string(workspace.path_pool.resolve(path_id));
 
         worker::BuildParams bp;
-        bp.priority = worker::Priority::High;
         bp.kind = worker::BuildKind::BuildPCM;
         bp.file = file_path;
         if(!fill_compile_args(file_path, bp.directory, bp.arguments))

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -513,6 +513,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     // Build a new PCH via stateless worker.
     worker::BuildParams bp;
+    bp.priority = worker::Priority::High;
     bp.kind = worker::BuildKind::BuildPCH;
     bp.file = std::string(path);
     bp.directory = directory;
@@ -878,6 +879,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     auto gen = session->generation;
 
     worker::BuildParams wp;
+    wp.priority = worker::Priority::High;
     wp.kind = kind;
     wp.file = path;
     wp.version = session->version;
@@ -913,6 +915,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     auto path = std::string(workspace.path_pool.resolve(path_id));
 
     worker::BuildParams wp;
+    wp.priority = worker::Priority::High;
     wp.kind = worker::BuildKind::Format;
     wp.file = path;
     wp.text = session->text;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -904,6 +904,7 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     kota::task_group<> workers(loop);
+    kota::semaphore in_flight(32);
 
     while(index_queue_pos < index_queue.size()) {
         if(pause_depth > 0)
@@ -916,9 +917,11 @@ kota::task<> Indexer::run_background_indexing() {
             continue;
         }
 
+        co_await in_flight.acquire();
         ++dispatched;
         workers.spawn([&, server_path_id]() -> kota::task<> {
             co_await index_one(server_path_id);
+            in_flight.release();
             ++completed;
             if(progress) {
                 auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -870,32 +870,6 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id) {
     }
 }
 
-kota::task<> Indexer::monitor_resources() {
-    while(true) {
-        co_await kota::sleep(std::chrono::milliseconds(3000));
-
-        auto mem = kota::sys::memory();
-        if(mem.total == 0)
-            continue;
-
-        auto effective_total =
-            (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
-        auto ratio = static_cast<double>(mem.available) / static_cast<double>(effective_total);
-
-        if(ratio < 0.15 && max_concurrent > 1) {
-            --max_concurrent;
-            LOG_INFO("Index concurrency -> {} (memory pressure: {:.0f}% available)",
-                     max_concurrent,
-                     ratio * 100);
-        } else if(ratio > 0.30 && max_concurrent < baseline_concurrent) {
-            ++max_concurrent;
-            LOG_DEBUG("Index concurrency -> {} (memory OK: {:.0f}% available)",
-                      max_concurrent,
-                      ratio * 100);
-        }
-    }
-}
-
 kota::task<> Indexer::run_background_indexing() {
     if(index_idle_timer) {
         co_await index_idle_timer->wait();
@@ -908,9 +882,6 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     indexing_active = true;
-
-    kota::cancellation_source monitor_cancel;
-    bg_tasks.spawn(kota::with_token(monitor_resources(), monitor_cancel.token()));
 
     std::stable_partition(
         index_queue.begin() + index_queue_pos,
@@ -933,8 +904,6 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     kota::task_group<> workers(loop);
-    std::size_t in_flight = 0;
-    kota::event slot_available;
 
     while(index_queue_pos < index_queue.size()) {
         if(pause_depth > 0)
@@ -947,22 +916,14 @@ kota::task<> Indexer::run_background_indexing() {
             continue;
         }
 
-        while(in_flight >= max_concurrent) {
-            slot_available.reset();
-            co_await slot_available.wait();
-        }
-
-        ++in_flight;
         ++dispatched;
         workers.spawn([&, server_path_id]() -> kota::task<> {
             co_await index_one(server_path_id);
-            --in_flight;
             ++completed;
             if(progress) {
                 auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;
                 progress->report(std::format("{}/{} files", completed, total), pct);
             }
-            slot_available.set();
         }());
     }
 
@@ -971,8 +932,6 @@ kota::task<> Indexer::run_background_indexing() {
     if(progress) {
         progress->end(std::format("Indexed {} files", dispatched));
     }
-
-    monitor_cancel.cancel();
 
     indexing_active = false;
     LOG_INFO("Background indexing complete: {} files dispatched", dispatched);

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -830,7 +830,9 @@ void Indexer::schedule() {
     }
 }
 
-kota::task<> Indexer::index_one(std::uint32_t server_path_id) {
+kota::task<> Indexer::index_one(std::uint32_t server_path_id,
+                                std::size_t index,
+                                std::size_t total) {
     auto file_path = std::string(workspace.path_pool.resolve(server_path_id));
 
     if(is_open && is_open(server_path_id))
@@ -853,20 +855,26 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id) {
 
     workspace.fill_pcm_deps(params.pcms);
 
-    LOG_INFO("Background indexing: {}", file_path);
+    LOG_INFO("[{}/{}] Indexing {}", index, total, file_path);
 
     auto result = co_await pool.send_stateless(params);
     if(result.has_value() && result.value().success && !result.value().tu_index_data.empty()) {
-        LOG_INFO("Background indexing got TUIndex for {}: {} bytes",
+        LOG_INFO("[{}/{}] Indexed {}: {} bytes",
+                 index,
+                 total,
                  file_path,
                  result.value().tu_index_data.size());
         merge(result.value().tu_index_data.data(), result.value().tu_index_data.size());
     } else if(result.has_value() && !result.value().success) {
-        LOG_WARN("Background index failed for {}: {}", file_path, result.value().error);
+        LOG_WARN("[{}/{}] Index failed for {}: {}", index, total, file_path, result.value().error);
     } else if(result.has_value() && result.value().tu_index_data.empty()) {
-        LOG_WARN("Background index returned empty TUIndex for {}", file_path);
+        LOG_WARN("[{}/{}] Index returned empty TUIndex for {}", index, total, file_path);
     } else {
-        LOG_WARN("Background index IPC error for {}: {}", file_path, result.error().message);
+        LOG_WARN("[{}/{}] Index IPC error for {}: {}",
+                 index,
+                 total,
+                 file_path,
+                 result.error().message);
     }
 }
 
@@ -882,6 +890,8 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     indexing_active = true;
+    LOG_DEBUG("Background indexing: starting, {} files queued",
+              index_queue.size() - index_queue_pos);
 
     std::stable_partition(
         index_queue.begin() + index_queue_pos,
@@ -895,7 +905,9 @@ kota::task<> Indexer::run_background_indexing() {
     std::optional<lsp::ProgressReporter<kota::ipc::JsonPeer>> progress;
     if(peer) {
         progress.emplace(*peer, protocol::ProgressToken(std::string("clice/backgroundIndex")));
-        auto create_result = co_await progress->create();
+        // Timeout prevents indexing from hanging when the client never responds.
+        auto create_result =
+            co_await progress->create({.timeout = std::chrono::milliseconds(3000)});
         if(!create_result.has_error()) {
             progress->begin("Indexing", std::format("0/{} files", total), 0);
         } else {
@@ -917,8 +929,8 @@ kota::task<> Indexer::run_background_indexing() {
         }
 
         ++dispatched;
-        workers.spawn([&, server_path_id]() -> kota::task<> {
-            co_await index_one(server_path_id);
+        workers.spawn([&, server_path_id, n = dispatched]() -> kota::task<> {
+            co_await index_one(server_path_id, n, total);
             ++completed;
             if(progress) {
                 auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;
@@ -927,6 +939,7 @@ kota::task<> Indexer::run_background_indexing() {
         }());
     }
 
+    LOG_DEBUG("Background indexing: all {} tasks spawned, waiting for completion", dispatched);
     co_await workers.join();
 
     if(progress) {
@@ -934,7 +947,10 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     indexing_active = false;
-    LOG_INFO("Background indexing complete: {} files dispatched", dispatched);
+    auto skipped = total - dispatched;
+    LOG_INFO("Background indexing complete: {} dispatched, {} skipped (open/up-to-date)",
+             dispatched,
+             skipped);
     save(workspace.config.project.index_dir);
 }
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -904,7 +904,6 @@ kota::task<> Indexer::run_background_indexing() {
     }
 
     kota::task_group<> workers(loop);
-    kota::semaphore in_flight(32);
 
     while(index_queue_pos < index_queue.size()) {
         if(pause_depth > 0)
@@ -917,11 +916,9 @@ kota::task<> Indexer::run_background_indexing() {
             continue;
         }
 
-        co_await in_flight.acquire();
         ++dispatched;
         workers.spawn([&, server_path_id]() -> kota::task<> {
             co_await index_one(server_path_id);
-            in_flight.release();
             ++completed;
             if(progress) {
                 auto pct = total > 0 ? static_cast<std::uint32_t>(completed * 100 / total) : 100;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -102,13 +102,6 @@ public:
         return ScopedPause{*this};
     }
 
-    /// Set the maximum number of concurrent index tasks.
-    /// Also sets the baseline that dynamic adjustment will restore to.
-    void set_max_concurrency(std::size_t n) {
-        max_concurrent = std::max<std::size_t>(n, 1);
-        baseline_concurrent = max_concurrent;
-    }
-
     /// Add a file to the background indexing queue.
     void enqueue(std::uint32_t server_path_id);
 
@@ -295,10 +288,6 @@ private:
     bool indexing_scheduled = false;
     std::shared_ptr<kota::timer> index_idle_timer;
 
-    /// Concurrency control for background indexing.
-    std::size_t max_concurrent = 2;
-    std::size_t baseline_concurrent = 2;
-
     /// Pause/resume: when paused, new index tasks wait on this event.
     /// Uses a counter so nested pause/resume pairs work correctly.
     std::size_t pause_depth = 0;
@@ -306,7 +295,6 @@ private:
 
     kota::task<> run_background_indexing();
     kota::task<> index_one(std::uint32_t server_path_id);
-    kota::task<> monitor_resources();
 };
 
 }  // namespace clice

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -294,7 +294,7 @@ private:
     kota::event resume_event{true};
 
     kota::task<> run_background_indexing();
-    kota::task<> index_one(std::uint32_t server_path_id);
+    kota::task<> index_one(std::uint32_t server_path_id, std::size_t index, std::size_t total);
 };
 
 }  // namespace clice

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -79,6 +79,9 @@ enum class BuildKind : uint8_t {
 ///   - SignatureHelp: + text, version, offset, pch, pcms
 ///   - Format:        + text, format_range (optional)
 struct BuildParams {
+    // FIXME: BuildPCM dispatched via compile_graph defaults to Low, which can
+    // starve interactive dep-resolution (hover/completion) behind indexing.
+    // Consider routing module-dep builds as High when triggered by a user request.
     Priority priority = Priority::Low;
     BuildKind kind;
     std::string file;

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -57,6 +57,8 @@ struct CompileResult {
     std::string tu_index_data;
 };
 
+enum class Priority : uint8_t { High, Low };
+
 /// Kind of build task dispatched to a stateless worker.
 enum class BuildKind : uint8_t {
     BuildPCH,
@@ -77,6 +79,7 @@ enum class BuildKind : uint8_t {
 ///   - SignatureHelp: + text, version, offset, pch, pcms
 ///   - Format:        + text, format_range (optional)
 struct BuildParams {
+    Priority priority = Priority::Low;
     BuildKind kind;
     std::string file;
     std::string directory;

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -89,6 +89,8 @@ void MasterServer::initialize() {
     pool_opts.self_path = self_path;
     pool_opts.stateful_count = cfg.stateful_worker_count;
     pool_opts.stateless_count = cfg.stateless_worker_count;
+    pool_opts.min_stateless = cfg.min_stateless_worker_count;
+    pool_opts.max_stateless = cfg.max_stateless_worker_count;
     pool_opts.worker_memory_limit = cfg.worker_memory_limit;
     pool_opts.log_dir = session_log_dir;
     if(!pool.start(pool_opts)) {

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -102,8 +102,6 @@ void MasterServer::initialize() {
         indexer.schedule();
     };
 
-    indexer.set_max_concurrency(cfg.stateless_worker_count.value);
-
     load_workspace();
 }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -98,6 +98,15 @@ void MasterServer::initialize() {
 
     lifecycle = ServerLifecycle::Ready;
 
+    pool.on_crash = [this](const WorkerCrashInfo& info) {
+        if(!info.stateful)
+            return;
+        for(auto path_id: info.lost_documents) {
+            if(auto it = sessions.find(path_id); it != sessions.end())
+                it->second->ast_dirty = true;
+        }
+    };
+
     compiler.on_indexing_needed = [this]() {
         indexer.schedule();
     };

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -1,5 +1,7 @@
 #include "server/worker/stateless_worker.h"
 
+#include <cstdlib>
+
 #include "compile/compilation.h"
 #include "feature/feature.h"
 #include "index/tu_index.h"
@@ -291,6 +293,14 @@ static worker::BuildResult handle_format(const worker::BuildParams& params) {
 }
 
 int run_stateless_worker_mode(const std::string& worker_name, const std::string& log_dir) {
+    // Limit libuv thread pool to 1 thread so each stateless worker executes
+    // only one compilation at a time. Must be set before any kota::queue call.
+#ifdef _WIN32
+    _putenv_s("UV_THREADPOOL_SIZE", "1");
+#else
+    ::setenv("UV_THREADPOOL_SIZE", "1", 1);
+#endif
+
     logging::stderr_logger(worker_name, logging::options);
     if(!log_dir.empty()) {
         logging::file_logger(worker_name, log_dir, logging::options);

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -295,6 +295,8 @@ static worker::BuildResult handle_format(const worker::BuildParams& params) {
 int run_stateless_worker_mode(const std::string& worker_name, const std::string& log_dir) {
     // Limit libuv thread pool to 1 thread so each stateless worker executes
     // only one compilation at a time. Must be set before any kota::queue call.
+    // FIXME: return values of setenv/_putenv_s are unchecked; a failure would
+    // silently fall back to libuv's default pool size.
 #ifdef _WIN32
     _putenv_s("UV_THREADPOOL_SIZE", "1");
 #else

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -251,7 +251,7 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     } else {
         auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
         LOG_ERROR("Worker {} lost: {}", name, result.error().message());
-        exit_signal = SIGKILL;
+        exit_signal = 9;
     }
 
     if(process_crash(index, stateful, exit_code, exit_signal)) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -144,11 +144,21 @@ bool WorkerPool::start(const WorkerPoolOptions& opts) {
         });
     }
 
+    // Resolve auto max_stateless (0 = CPU cores).
+    if(options.max_stateless == 0)
+        options.max_stateless = kota::sys::parallelism();
+    if(options.min_stateless == 0)
+        options.min_stateless = 1;
+    options.min_stateless = std::min(options.min_stateless, options.stateless_count);
+    options.max_stateless = std::max(options.max_stateless, options.stateless_count);
+
     // Reserve one worker for high-priority requests by capping low-priority
     // concurrency to N-1. With a single worker this collapses to 1: both
     // priorities share it, and high wins only via queue ordering.
     max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
     low_limit = max_low_limit;
+
+    slot_cancel_sources.resize(stateless_workers.size());
 
     monitor_group.spawn(monitor_memory());
 
@@ -248,6 +258,29 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
 
     if(shutting_down)
         co_return;
+
+    // Intentional retirement (scale-down): skip crash processing and respawn.
+    if(!stateful && workers[index].retiring) {
+        LOG_INFO("Worker {} retired gracefully", workers[index].name);
+        workers[index].alive = false;
+        alive_stateless_count -= 1;
+        if(workers[index].busy) {
+            if(workers[index].low_priority)
+                low_busy_count -= 1;
+            workers[index].busy = false;
+            workers[index].low_priority = false;
+            stateless_busy_count -= 1;
+        }
+        if(workers[index].peer) {
+            workers[index].peer->close();
+            retired_peers.push_back(std::move(workers[index].peer));
+        }
+        max_low_limit =
+            alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
+        if(low_limit > max_low_limit)
+            low_limit = max_low_limit;
+        co_return;
+    }
 
     int exit_code = 0, exit_signal = 0;
     if(result.has_value()) {
@@ -490,11 +523,17 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
     if(worker_index >= stateless_workers.size() || !stateless_workers[worker_index].busy)
         return;
+    if(worker_index < slot_cancel_sources.size())
+        slot_cancel_sources[worker_index].reset();
     if(stateless_workers[worker_index].low_priority)
         low_busy_count -= 1;
     stateless_workers[worker_index].busy = false;
     stateless_workers[worker_index].low_priority = false;
     stateless_busy_count -= 1;
+    LOG_DEBUG("Release {} (busy={}, low_busy={})",
+              stateless_workers[worker_index].name,
+              stateless_busy_count,
+              low_busy_count);
     try_dispatch_pending();
 }
 
@@ -505,8 +544,6 @@ void WorkerPool::try_dispatch_pending() {
         while(!queue.empty() && idle > 0 && (!is_low || low_busy_count < low_limit)) {
             auto* next = queue.front();
             queue.pop_front();
-            // Clear queue pointer before signalling so the PendingStateless
-            // destructor won't attempt a redundant erase.
             next->queue = nullptr;
             auto idx = pick_idle_stateless();
             stateless_workers[idx].busy = true;
@@ -517,6 +554,12 @@ void WorkerPool::try_dispatch_pending() {
             idle -= 1;
             next->assigned_worker = idx;
             next->assigned_gen = stateless_workers[idx].restart_count;
+            LOG_DEBUG("Dispatch {} -> {} (busy={}, low_busy={}, idle={})",
+                      is_low ? "low" : "high",
+                      stateless_workers[idx].name,
+                      stateless_busy_count,
+                      low_busy_count,
+                      idle);
             next->ready.set();
         }
     };
@@ -542,7 +585,8 @@ void WorkerPool::fail_pending_requests() {
 
 std::size_t WorkerPool::pick_idle_stateless(std::size_t exclude) {
     for(std::size_t i = 0; i < stateless_workers.size(); ++i) {
-        if(i != exclude && stateless_workers[i].alive && !stateless_workers[i].busy)
+        if(i != exclude && stateless_workers[i].alive && !stateless_workers[i].busy &&
+           !stateless_workers[i].retiring)
             return i;
     }
     llvm_unreachable("pick_idle_stateless called with no idle workers");
@@ -550,7 +594,7 @@ std::size_t WorkerPool::pick_idle_stateless(std::size_t exclude) {
 
 kota::task<> WorkerPool::monitor_memory() {
     while(true) {
-        co_await kota::sleep(std::chrono::milliseconds(3000));
+        co_await kota::sleep(std::chrono::milliseconds(3000), loop);
         if(shutting_down)
             co_return;
 
@@ -562,22 +606,60 @@ kota::task<> WorkerPool::monitor_memory() {
             (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
         auto ratio = static_cast<double>(mem.available) / static_cast<double>(effective_total);
 
+        LOG_DEBUG(
+            "Memory: {:.0f}% available, low_limit={}/{}, busy={} (low={}), " "queued=hi:{}/lo:{}, alive={}, sat={}/idle={}",
+            ratio * 100,
+            low_limit,
+            max_low_limit,
+            stateless_busy_count,
+            low_busy_count,
+            high_queue.size(),
+            low_queue.size(),
+            alive_stateless_count,
+            saturated_cycles,
+            idle_cycles);
+
+        // Severe pressure: preempt low-priority in-flight requests.
+        if(ratio < 0.10 && low_busy_count > 0) {
+            cancel_low_priority_requests(low_busy_count);
+        }
+
+        // Inner loop: adjust low_limit with CUBIC-style fast recovery.
         if(ratio < 0.20 && low_limit > 1) {
             if(backoff_cooldown > 0) {
                 backoff_cooldown -= 1;
             } else {
+                if(w_max == 0 || low_limit > w_max)
+                    w_max = low_limit;
                 low_limit -= 1;
-                LOG_INFO("Stateless low_limit -> {} (memory pressure: {:.0f}% available)",
+                LOG_INFO("low_limit -> {} (memory pressure: {:.0f}% available)",
                          low_limit,
                          ratio * 100);
             }
         } else if(ratio > 0.40 && low_limit < max_low_limit) {
             backoff_cooldown = 0;
-            low_limit += 1;
-            LOG_DEBUG("Stateless low_limit -> {} (memory OK: {:.0f}% available)",
+            if(w_max > 0 && low_limit < w_max) {
+                auto gap = w_max - low_limit;
+                auto increment = std::max<std::size_t>(1, gap / 2);
+                low_limit = std::min(low_limit + increment, max_low_limit);
+            } else {
+                low_limit += 1;
+                if(low_limit >= max_low_limit)
+                    w_max = 0;
+            }
+            LOG_DEBUG("low_limit -> {} (memory OK: {:.0f}% available, w_max={})",
                       low_limit,
-                      ratio * 100);
+                      ratio * 100,
+                      w_max);
             try_dispatch_pending();
+        }
+
+        // Outer loop: dynamic scaling.
+        check_scaling();
+
+        // Severe pressure: also scale down immediately.
+        if(ratio < 0.10 && alive_stateless_count > options.min_stateless) {
+            retire_idle_worker();
         }
     }
 }
@@ -585,12 +667,115 @@ kota::task<> WorkerPool::monitor_memory() {
 void WorkerPool::apply_crash_backoff() {
     auto new_limit = std::max<std::size_t>(1, low_limit * 3 / 4);
     if(new_limit < low_limit) {
+        if(w_max == 0 || low_limit > w_max)
+            w_max = low_limit;
         low_limit = new_limit;
-        LOG_WARN("Stateless low_limit -> {} (worker crash AIMD backoff)", low_limit);
+        LOG_WARN("low_limit -> {} (worker crash AIMD backoff)", low_limit);
     }
-    // Suppress memory-pressure reductions for a few monitor cycles so
-    // crash backoff and memory throttling don't compound in the same window.
     backoff_cooldown = 3;
+}
+
+bool WorkerPool::scale_up_worker() {
+    if(alive_stateless_count >= options.max_stateless)
+        return false;
+
+    auto new_index = stateless_workers.size();
+    if(!spawn_worker(options.self_path, false, 0)) {
+        LOG_WARN("scale_up: spawn_worker failed");
+        return false;
+    }
+
+    slot_cancel_sources.push_back(nullptr);
+    monitor_group.spawn(monitor_worker(new_index, false));
+
+    max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
+    low_limit = max_low_limit;
+    w_max = 0;
+    try_dispatch_pending();
+
+    LOG_INFO("Scaled up: spawned {} (alive={})",
+             stateless_workers.back().name,
+             alive_stateless_count);
+    return true;
+}
+
+void WorkerPool::retire_idle_worker() {
+    if(alive_stateless_count <= options.min_stateless)
+        return;
+
+    std::size_t target = SIZE_MAX;
+    for(std::size_t i = stateless_workers.size(); i-- > 0;) {
+        auto& w = stateless_workers[i];
+        if(w.alive && !w.busy && !w.retiring) {
+            target = i;
+            break;
+        }
+    }
+
+    if(target == SIZE_MAX)
+        return;
+
+    auto& w = stateless_workers[target];
+    w.retiring = true;
+    w.peer->close_output();
+    w.proc.kill(SIGTERM);
+
+    LOG_INFO("Retiring worker {} (alive={})", w.name, alive_stateless_count);
+}
+
+void WorkerPool::check_scaling() {
+    bool has_queued = !high_queue.empty() || !low_queue.empty();
+
+    // The pool is saturated when all workers are busy with queued work, OR
+    // when low-priority slots are at capacity with low-priority work queued.
+    // The second condition handles the case where low_limit reserves a worker
+    // for high-priority requests: the reserved slot stays idle, so busy_count
+    // never equals alive_count, but the pool is effectively saturated for
+    // low-priority (indexing) work.
+    bool saturated = (stateless_busy_count == alive_stateless_count && has_queued) ||
+                     (low_busy_count >= low_limit && !low_queue.empty());
+
+    if(saturated) {
+        saturated_cycles += 1;
+        idle_cycles = 0;
+    } else if(stateless_busy_count == 0 && !has_queued) {
+        idle_cycles += 1;
+        saturated_cycles = 0;
+    } else {
+        saturated_cycles = 0;
+        idle_cycles = 0;
+    }
+
+    if(saturated_cycles >= scale_up_ticks) {
+        auto mem = kota::sys::memory();
+        auto effective =
+            (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
+        auto ratio = effective > 0 ? static_cast<double>(mem.available) / effective : 1.0;
+        if(ratio > 0.30) {
+            if(scale_up_worker())
+                saturated_cycles = 0;
+        }
+    }
+
+    if(idle_cycles >= scale_down_ticks) {
+        retire_idle_worker();
+        idle_cycles = 0;
+    }
+}
+
+void WorkerPool::cancel_low_priority_requests(std::size_t count) {
+    std::size_t cancelled = 0;
+    for(std::size_t i = 0; i < stateless_workers.size() && cancelled < count; ++i) {
+        auto& w = stateless_workers[i];
+        if(w.alive && w.busy && w.low_priority) {
+            if(i < slot_cancel_sources.size() && slot_cancel_sources[i]) {
+                slot_cancel_sources[i]->cancel();
+                ++cancelled;
+            }
+        }
+    }
+    if(cancelled > 0)
+        LOG_WARN("Cancelled {} low-priority requests (memory pressure)", cancelled);
 }
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -1,10 +1,12 @@
 #include "server/worker/worker_pool.h"
 
+#include <algorithm>
 #include <csignal>
 #include <string>
 
 #include "support/logging.h"
 
+#include "kota/async/io/system.h"
 #include "kota/ipc/transport.h"
 
 namespace clice {
@@ -104,6 +106,8 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
 
     auto& w = workers.back();
     w.alive = true;
+    if(!stateful)
+        ++alive_stateless_count;
     io_group.spawn(w.peer->run());
 
     return true;
@@ -138,6 +142,11 @@ bool WorkerPool::start(const WorkerPoolOptions& options) {
             }
         });
     }
+
+    max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
+    low_limit = max_low_limit;
+
+    monitor_group.spawn(monitor_memory());
 
     LOG_INFO("WorkerPool started: {} stateless, {} stateful workers",
              stateless_workers.size(),
@@ -258,8 +267,17 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
                   w.restart_count);
     }
 
-    if(stateful)
+    if(stateful) {
         clear_owner(index);
+    } else {
+        --alive_stateless_count;
+        if(w.busy) {
+            w.busy = false;
+            --stateless_busy_count;
+        }
+        on_worker_crash();
+        try_dispatch_pending();
+    }
 
     constexpr unsigned max_restarts = 5;
     if(w.restart_count >= max_restarts) {
@@ -323,8 +341,12 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
         .peer = std::move(peer),
         .owned_documents = 0,
         .alive = true,
+        .busy = false,
         .restart_count = old_restart_count,
     };
+
+    if(!stateful)
+        ++alive_stateless_count;
 
     auto& w = workers[index];
     io_group.spawn(w.peer->run());
@@ -340,6 +362,121 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
 
     LOG_INFO("Worker {} restarted (attempt {})", worker_name, old_restart_count);
     return true;
+}
+
+kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority) {
+    using P = worker::Priority;
+    auto can_proceed = [&]() {
+        auto idle = alive_stateless_count - stateless_busy_count;
+        if(idle == 0)
+            return false;
+        if(priority == P::High)
+            return true;
+        return stateless_busy_count < low_limit;
+    };
+
+    if(!can_proceed()) {
+        PendingStateless pending(priority);
+        if(priority == P::High)
+            high_queue.push_back(&pending);
+        else
+            low_queue.push_back(&pending);
+        co_await pending.ready.wait();
+        co_return pending.assigned_worker;
+    }
+
+    auto idx = pick_idle_stateless();
+    stateless_workers[idx].busy = true;
+    ++stateless_busy_count;
+
+    auto pid = stateless_workers[idx].proc.pid();
+    if(pid > 0) {
+        kota::sys::set_priority(priority == P::Low ? 10 : 0, pid);
+    }
+
+    co_return idx;
+}
+
+void WorkerPool::release_stateless_slot(std::size_t worker_index) {
+    stateless_workers[worker_index].busy = false;
+    --stateless_busy_count;
+    try_dispatch_pending();
+}
+
+void WorkerPool::try_dispatch_pending() {
+    auto idle = alive_stateless_count - stateless_busy_count;
+
+    while(!high_queue.empty() && idle > 0) {
+        auto* next = high_queue.front();
+        high_queue.pop_front();
+        auto idx = pick_idle_stateless();
+        stateless_workers[idx].busy = true;
+        ++stateless_busy_count;
+        --idle;
+        auto pid = stateless_workers[idx].proc.pid();
+        if(pid > 0)
+            kota::sys::set_priority(0, pid);
+        next->assigned_worker = idx;
+        next->ready.set();
+    }
+
+    while(!low_queue.empty() && idle > 0 && stateless_busy_count < low_limit) {
+        auto* next = low_queue.front();
+        low_queue.pop_front();
+        auto idx = pick_idle_stateless();
+        stateless_workers[idx].busy = true;
+        ++stateless_busy_count;
+        --idle;
+        auto pid = stateless_workers[idx].proc.pid();
+        if(pid > 0)
+            kota::sys::set_priority(10, pid);
+        next->assigned_worker = idx;
+        next->ready.set();
+    }
+}
+
+std::size_t WorkerPool::pick_idle_stateless() {
+    for(std::size_t i = 0; i < stateless_workers.size(); ++i) {
+        if(stateless_workers[i].alive && !stateless_workers[i].busy)
+            return i;
+    }
+    return 0;
+}
+
+kota::task<> WorkerPool::monitor_memory() {
+    while(true) {
+        co_await kota::sleep(std::chrono::milliseconds(3000));
+        if(shutting_down_)
+            co_return;
+
+        auto mem = kota::sys::memory();
+        if(mem.total == 0)
+            continue;
+
+        auto effective_total =
+            (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
+        auto ratio = static_cast<double>(mem.available) / static_cast<double>(effective_total);
+
+        if(ratio < 0.20 && low_limit > 1) {
+            --low_limit;
+            LOG_INFO("Stateless low_limit -> {} (memory pressure: {:.0f}% available)",
+                     low_limit,
+                     ratio * 100);
+        } else if(ratio > 0.40 && low_limit < max_low_limit) {
+            ++low_limit;
+            LOG_DEBUG("Stateless low_limit -> {} (memory OK: {:.0f}% available)",
+                      low_limit,
+                      ratio * 100);
+        }
+    }
+}
+
+void WorkerPool::on_worker_crash() {
+    auto new_limit = std::max<std::size_t>(1, low_limit * 3 / 4);
+    if(new_limit < low_limit) {
+        low_limit = new_limit;
+        LOG_WARN("Stateless low_limit -> {} (worker crash AIMD backoff)", low_limit);
+    }
 }
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -260,6 +260,8 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     if(process_crash(index, stateful, exit_code, exit_signal)) {
         if(!respawn_worker(index, stateful)) {
             LOG_ERROR("Worker {} respawn failed", workers[index].name);
+            if(!stateful && alive_stateless_count == 0)
+                fail_pending_requests();
         }
     }
 }
@@ -308,6 +310,16 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
             stateless_busy_count -= 1;
         }
         apply_crash_backoff();
+
+        // Permanently lost slot: shrink the ceiling so monitor_memory()
+        // can't raise low_limit above the surviving worker count.
+        if(!info.will_restart) {
+            max_low_limit =
+                alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
+            if(low_limit > max_low_limit)
+                low_limit = max_low_limit;
+        }
+
         // If no workers remain and none will restart, wake all waiters
         // with SIZE_MAX so they can return an error instead of hanging.
         if(alive_stateless_count == 0 && !info.will_restart)

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -475,6 +475,10 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
         if(exclude < stateless_workers.size() && stateless_workers[exclude].alive &&
            !stateless_workers[exclude].busy)
             idle -= 1;
+        // Don't count retiring workers — they are alive but won't accept work.
+        for(auto& w: stateless_workers)
+            if(w.retiring && w.alive && !w.busy)
+                idle -= 1;
         if(idle == 0)
             return false;
         if(priority == P::High)
@@ -544,7 +548,12 @@ void WorkerPool::release_stateless_slot(std::size_t worker_index) {
 }
 
 void WorkerPool::try_dispatch_pending() {
-    auto idle = alive_stateless_count - stateless_busy_count;
+    // Subtract retiring workers from idle count — they won't accept new work.
+    std::size_t retiring_idle = 0;
+    for(auto& w: stateless_workers)
+        if(w.retiring && w.alive && !w.busy)
+            retiring_idle += 1;
+    auto idle = alive_stateless_count - stateless_busy_count - retiring_idle;
 
     auto dispatch = [&](std::deque<PendingStateless*>& queue, bool is_low) {
         while(!queue.empty() && idle > 0 && (!is_low || low_busy_count < low_limit)) {
@@ -626,6 +635,8 @@ kota::task<> WorkerPool::monitor_memory() {
             idle_cycles);
 
         // Severe pressure: preempt low-priority in-flight requests.
+        // FIXME: cancelled Index requests are not requeued by the indexer,
+        // so those files will be skipped until the next indexing cycle.
         if(ratio < 0.10 && low_busy_count > 0) {
             cancel_low_priority_requests(low_busy_count);
         }
@@ -710,7 +721,13 @@ bool WorkerPool::scale_up_worker() {
 void WorkerPool::retire_idle_worker() {
     if(shutting_down)
         return;
-    if(alive_stateless_count <= options.min_stateless)
+    // Count workers already marked retiring (exit not yet observed by
+    // monitor_worker) to avoid retiring below min_stateless.
+    std::size_t pending_retires = 0;
+    for(auto& w: stateless_workers)
+        if(w.retiring && w.alive)
+            pending_retires += 1;
+    if(alive_stateless_count - pending_retires <= options.min_stateless)
         return;
 
     std::size_t target = SIZE_MAX;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -260,8 +260,16 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     if(process_crash(index, stateful, exit_code, exit_signal)) {
         if(!respawn_worker(index, stateful)) {
             LOG_ERROR("Worker {} respawn failed", workers[index].name);
-            if(!stateful && alive_stateless_count == 0)
-                fail_pending_requests();
+            if(!stateful) {
+                // Slot is effectively permanently dead — shrink ceiling
+                // so monitor_memory() can't raise low_limit above capacity.
+                max_low_limit =
+                    alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
+                if(low_limit > max_low_limit)
+                    low_limit = max_low_limit;
+                if(alive_stateless_count == 0)
+                    fail_pending_requests();
+            }
         }
     }
 }
@@ -433,8 +441,11 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 
     if(!can_proceed()) {
         // Enqueue and suspend until try_dispatch_pending() wakes us.
-        // PendingStateless destructor auto-removes from queue on cancellation.
+        // PendingStateless destructor handles cleanup on cancellation:
+        //   - still queued → removes from queue
+        //   - dispatched but cancelled before StatelessSlot → releases slot
         PendingStateless pending(priority);
+        pending.pool = this;
         if(priority == P::High) {
             high_queue.push_back(&pending);
             pending.queue = &high_queue;
@@ -443,6 +454,7 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
             pending.queue = &low_queue;
         }
         co_await pending.ready.wait();
+        pending.pool = nullptr;  // claimed — StatelessSlot will handle release
         co_return pending.assigned_worker;
     }
 

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -108,7 +108,7 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     auto& w = workers.back();
     w.alive = true;
     if(!stateful)
-        ++alive_stateless_count;
+        alive_stateless_count += 1;
     io_group.spawn(w.peer->run());
 
     return true;
@@ -193,7 +193,7 @@ std::size_t WorkerPool::assign_worker(std::uint32_t path_id) {
     // New assignment: pick the least-loaded worker
     auto selected = pick_least_loaded();
     owner[path_id] = selected;
-    stateful_workers[selected].owned_documents++;
+    stateful_workers[selected].owned_documents += 1;
     owner_lru.push_front(path_id);
     owner_lru_index[path_id] = owner_lru.begin();
     return selected;
@@ -218,7 +218,7 @@ void WorkerPool::remove_owner(std::uint32_t path_id) {
         return;
 
     auto worker_idx = it->second;
-    stateful_workers[worker_idx].owned_documents--;
+    stateful_workers[worker_idx].owned_documents -= 1;
     owner.erase(it);
 
     auto lru_it = owner_lru_index.find(path_id);
@@ -287,26 +287,33 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     info.exit_code = exit_code;
     info.exit_signal = exit_signal;
     info.restart_count = w.restart_count;
+    info.will_restart = w.restart_count < options_.max_restarts;
+
+    if(!info.will_restart) {
+        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options_.max_restarts);
+    }
 
     if(stateful) {
+        // Collect documents owned by this worker so the caller (on_crash)
+        // can mark them dirty for recompilation on the next request.
         for(auto& [path_id, widx]: owner) {
             if(widx == index)
                 info.lost_documents.push_back(path_id);
         }
         clear_owner(index);
     } else {
-        --alive_stateless_count;
+        alive_stateless_count -= 1;
         if(w.busy) {
             w.busy = false;
-            --stateless_busy_count;
+            stateless_busy_count -= 1;
         }
         apply_crash_backoff();
-        try_dispatch_pending();
-    }
-
-    info.will_restart = w.restart_count < options_.max_restarts;
-    if(!info.will_restart) {
-        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options_.max_restarts);
+        // If no workers remain and none will restart, wake all waiters
+        // with SIZE_MAX so they can return an error instead of hanging.
+        if(alive_stateless_count == 0 && !info.will_restart)
+            fail_pending_requests();
+        else
+            try_dispatch_pending();
     }
 
     if(on_crash)
@@ -372,11 +379,12 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     };
 
     if(!stateful)
-        ++alive_stateless_count;
+        alive_stateless_count += 1;
 
     auto& w = workers[index];
     io_group.spawn(w.peer->run());
 
+    // Dispatch pending requests now that a fresh worker is available.
     if(!stateful)
         try_dispatch_pending();
 
@@ -394,7 +402,14 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
 }
 
 kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority) {
+    // Fast-fail: no workers alive means no possibility of dispatch.
+    if(alive_stateless_count == 0)
+        co_return SIZE_MAX;
+
     using P = worker::Priority;
+    // High-priority proceeds whenever any worker is idle.
+    // Low-priority is additionally gated by low_limit to reserve
+    // capacity for high-priority requests.
     auto can_proceed = [&]() {
         auto idle = alive_stateless_count - stateless_busy_count;
         if(idle == 0)
@@ -405,6 +420,8 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
     };
 
     if(!can_proceed()) {
+        // Enqueue and suspend until try_dispatch_pending() wakes us.
+        // PendingStateless destructor auto-removes from queue on cancellation.
         PendingStateless pending(priority);
         if(priority == P::High) {
             high_queue.push_back(&pending);
@@ -419,46 +436,55 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 
     auto idx = pick_idle_stateless();
     stateless_workers[idx].busy = true;
-    ++stateless_busy_count;
-
-    auto pid = stateless_workers[idx].proc.pid();
-    if(pid > 0) {
-        kota::sys::set_priority(priority == P::Low ? 10 : 0, pid);
-    }
+    stateless_busy_count += 1;
 
     co_return idx;
 }
 
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
-    if(!stateless_workers[worker_index].busy)
+    if(worker_index >= stateless_workers.size() || !stateless_workers[worker_index].busy)
         return;
     stateless_workers[worker_index].busy = false;
-    --stateless_busy_count;
+    stateless_busy_count -= 1;
     try_dispatch_pending();
 }
 
 void WorkerPool::try_dispatch_pending() {
     auto idle = alive_stateless_count - stateless_busy_count;
 
-    auto dispatch = [&](std::deque<PendingStateless*>& queue, int nice, bool check_limit) {
+    auto dispatch = [&](std::deque<PendingStateless*>& queue, bool check_limit) {
         while(!queue.empty() && idle > 0 && (!check_limit || stateless_busy_count < low_limit)) {
             auto* next = queue.front();
             queue.pop_front();
+            // Clear queue pointer before signalling so the PendingStateless
+            // destructor won't attempt a redundant erase.
             next->queue = nullptr;
             auto idx = pick_idle_stateless();
             stateless_workers[idx].busy = true;
-            ++stateless_busy_count;
-            --idle;
-            auto pid = stateless_workers[idx].proc.pid();
-            if(pid > 0)
-                kota::sys::set_priority(nice, pid);
+            stateless_busy_count += 1;
+            idle -= 1;
             next->assigned_worker = idx;
             next->ready.set();
         }
     };
 
-    dispatch(high_queue, 0, false);
-    dispatch(low_queue, 10, true);
+    dispatch(high_queue, false);
+    dispatch(low_queue, true);
+}
+
+void WorkerPool::fail_pending_requests() {
+    // SIZE_MAX signals to send_stateless() that no worker was assigned.
+    auto drain = [](std::deque<PendingStateless*>& queue) {
+        while(!queue.empty()) {
+            auto* next = queue.front();
+            queue.pop_front();
+            next->queue = nullptr;
+            next->assigned_worker = SIZE_MAX;
+            next->ready.set();
+        }
+    };
+    drain(high_queue);
+    drain(low_queue);
 }
 
 std::size_t WorkerPool::pick_idle_stateless() {
@@ -485,16 +511,16 @@ kota::task<> WorkerPool::monitor_memory() {
 
         if(ratio < 0.20 && low_limit > 1) {
             if(backoff_cooldown > 0) {
-                --backoff_cooldown;
+                backoff_cooldown -= 1;
             } else {
-                --low_limit;
+                low_limit -= 1;
                 LOG_INFO("Stateless low_limit -> {} (memory pressure: {:.0f}% available)",
                          low_limit,
                          ratio * 100);
             }
         } else if(ratio > 0.40 && low_limit < max_low_limit) {
             backoff_cooldown = 0;
-            ++low_limit;
+            low_limit += 1;
             LOG_DEBUG("Stateless low_limit -> {} (memory OK: {:.0f}% available)",
                       low_limit,
                       ratio * 100);

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -68,9 +68,9 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     opts.args.push_back("--worker-name");
     opts.args.push_back(worker_name);
 
-    if(!log_dir_.empty()) {
+    if(!log_dir.empty()) {
         opts.args.push_back("--log-dir");
-        opts.args.push_back(log_dir_);
+        opts.args.push_back(log_dir);
     }
 
     opts.streams = {
@@ -114,9 +114,9 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     return true;
 }
 
-bool WorkerPool::start(const WorkerPoolOptions& options) {
-    options_ = options;
-    log_dir_ = options.log_dir;
+bool WorkerPool::start(const WorkerPoolOptions& opts) {
+    options = opts;
+    log_dir = opts.log_dir;
 
     stateless_workers.reserve(options.stateless_count);
     stateful_workers.reserve(options.stateful_count);
@@ -160,7 +160,7 @@ bool WorkerPool::start(const WorkerPoolOptions& options) {
 
 kota::task<> WorkerPool::stop() {
     LOG_INFO("WorkerPool stopping...");
-    shutting_down_ = true;
+    shutting_down = true;
     fail_pending_requests();
 
     for(auto& w: stateless_workers)
@@ -246,7 +246,7 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
 
     auto result = co_await workers[index].proc.wait();
 
-    if(shutting_down_)
+    if(shutting_down)
         co_return;
 
     int exit_code = 0, exit_signal = 0;
@@ -298,10 +298,10 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     info.exit_code = exit_code;
     info.exit_signal = exit_signal;
     info.restart_count = w.restart_count;
-    info.will_restart = w.restart_count < options_.max_restarts;
+    info.will_restart = w.restart_count < options.max_restarts;
 
     if(!info.will_restart) {
-        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options_.max_restarts);
+        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options.max_restarts);
     }
 
     if(stateful) {
@@ -356,18 +356,18 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     }
 
     kota::process::options opts;
-    opts.file = options_.self_path;
-    opts.args = {options_.self_path, "worker"};
+    opts.file = options.self_path;
+    opts.args = {options.self_path, "worker"};
     if(stateful) {
         opts.args.push_back("--stateful");
         opts.args.push_back("--memory-limit");
-        opts.args.push_back(std::to_string(options_.worker_memory_limit));
+        opts.args.push_back(std::to_string(options.worker_memory_limit));
     }
     opts.args.push_back("--worker-name");
     opts.args.push_back(worker_name);
-    if(!log_dir_.empty()) {
+    if(!log_dir.empty()) {
         opts.args.push_back("--log-dir");
-        opts.args.push_back(log_dir_);
+        opts.args.push_back(log_dir);
     }
     opts.streams = {
         kota::process::stdio::pipe(true, false),
@@ -535,7 +535,7 @@ std::size_t WorkerPool::pick_idle_stateless() {
 kota::task<> WorkerPool::monitor_memory() {
     while(true) {
         co_await kota::sleep(std::chrono::milliseconds(3000));
-        if(shutting_down_)
+        if(shutting_down)
             co_return;
 
         auto mem = kota::sys::memory();

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -315,7 +315,10 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     } else {
         alive_stateless_count -= 1;
         if(w.busy) {
+            if(w.low_priority)
+                low_busy_count -= 1;
             w.busy = false;
+            w.low_priority = false;
             stateless_busy_count -= 1;
         }
         apply_crash_backoff();
@@ -396,6 +399,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
         .owned_documents = 0,
         .alive = true,
         .busy = false,
+        .low_priority = false,
         .restart_count = old_restart_count,
     };
 
@@ -433,7 +437,7 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
             return false;
         if(priority == P::High)
             return true;
-        return stateless_busy_count < low_limit;
+        return low_busy_count < low_limit;
     };
 
     while(true) {
@@ -471,7 +475,10 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 
         auto idx = pick_idle_stateless();
         stateless_workers[idx].busy = true;
+        stateless_workers[idx].low_priority = (priority == P::Low);
         stateless_busy_count += 1;
+        if(priority == P::Low)
+            low_busy_count += 1;
 
         co_return idx;
     }
@@ -480,7 +487,10 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
     if(worker_index >= stateless_workers.size() || !stateless_workers[worker_index].busy)
         return;
+    if(stateless_workers[worker_index].low_priority)
+        low_busy_count -= 1;
     stateless_workers[worker_index].busy = false;
+    stateless_workers[worker_index].low_priority = false;
     stateless_busy_count -= 1;
     try_dispatch_pending();
 }
@@ -488,8 +498,8 @@ void WorkerPool::release_stateless_slot(std::size_t worker_index) {
 void WorkerPool::try_dispatch_pending() {
     auto idle = alive_stateless_count - stateless_busy_count;
 
-    auto dispatch = [&](std::deque<PendingStateless*>& queue, bool check_limit) {
-        while(!queue.empty() && idle > 0 && (!check_limit || stateless_busy_count < low_limit)) {
+    auto dispatch = [&](std::deque<PendingStateless*>& queue, bool is_low) {
+        while(!queue.empty() && idle > 0 && (!is_low || low_busy_count < low_limit)) {
             auto* next = queue.front();
             queue.pop_front();
             // Clear queue pointer before signalling so the PendingStateless
@@ -497,7 +507,10 @@ void WorkerPool::try_dispatch_pending() {
             next->queue = nullptr;
             auto idx = pick_idle_stateless();
             stateless_workers[idx].busy = true;
+            stateless_workers[idx].low_priority = is_low;
             stateless_busy_count += 1;
+            if(is_low)
+                low_busy_count += 1;
             idle -= 1;
             next->assigned_worker = idx;
             next->assigned_gen = stateless_workers[idx].restart_count;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -238,36 +238,57 @@ void WorkerPool::clear_owner(std::size_t worker_index) {
 
 kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     auto& workers = stateful ? stateful_workers : stateless_workers;
-    auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
 
     auto result = co_await workers[index].proc.wait();
-    auto& w = workers[index];
-    w.alive = false;
 
     if(shutting_down_)
         co_return;
 
+    int exit_code = 0, exit_signal = 0;
     if(result.has_value()) {
-        auto& exit = result.value();
-        if(exit.term_signal != 0) {
-            LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
-                      name,
-                      exit.term_signal,
-                      w.restart_count);
-        } else {
-            LOG_ERROR("Worker {} exited with code {} (restarts: {})",
-                      name,
-                      exit.status,
-                      w.restart_count);
-        }
+        exit_code = result.value().status;
+        exit_signal = result.value().term_signal;
     } else {
-        LOG_ERROR("Worker {} lost: {} (restarts: {})",
-                  name,
-                  result.error().message(),
-                  w.restart_count);
+        auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
+        LOG_ERROR("Worker {} lost: {}", name, result.error().message());
+        exit_signal = SIGKILL;
     }
 
+    if(process_crash(index, stateful, exit_code, exit_signal)) {
+        if(!respawn_worker(index, stateful)) {
+            auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
+            LOG_ERROR("Worker {} respawn failed", name);
+        }
+    }
+}
+
+bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal) {
+    auto& workers = stateful ? stateful_workers : stateless_workers;
+    auto& w = workers[index];
+    w.alive = false;
+
+    auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
+    if(exit_signal != 0) {
+        LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
+                  name,
+                  exit_signal,
+                  w.restart_count);
+    } else {
+        LOG_ERROR("Worker {} exited with code {} (restarts: {})", name, exit_code, w.restart_count);
+    }
+
+    WorkerCrashInfo info;
+    info.worker_index = index;
+    info.stateful = stateful;
+    info.exit_code = exit_code;
+    info.exit_signal = exit_signal;
+    info.restart_count = w.restart_count;
+
     if(stateful) {
+        for(auto& [path_id, widx]: owner) {
+            if(widx == index)
+                info.lost_documents.push_back(path_id);
+        }
         clear_owner(index);
     } else {
         --alive_stateless_count;
@@ -275,19 +296,19 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
             w.busy = false;
             --stateless_busy_count;
         }
-        on_worker_crash();
+        apply_crash_backoff();
         try_dispatch_pending();
     }
 
-    constexpr unsigned max_restarts = 5;
-    if(w.restart_count >= max_restarts) {
-        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", name, max_restarts);
-        co_return;
+    info.will_restart = w.restart_count < options_.max_restarts;
+    if(!info.will_restart) {
+        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", name, options_.max_restarts);
     }
 
-    if(!respawn_worker(index, stateful)) {
-        LOG_ERROR("Worker {} respawn failed", name);
-    }
+    if(on_crash)
+        on_crash(info);
+
+    return info.will_restart;
 }
 
 bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
@@ -351,6 +372,9 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     auto& w = workers[index];
     io_group.spawn(w.peer->run());
 
+    if(!stateful)
+        try_dispatch_pending();
+
     if(stateful) {
         w.peer->on_notification([this](const worker::EvictedParams& params) {
             if(on_evicted)
@@ -398,6 +422,8 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 }
 
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
+    if(!stateless_workers[worker_index].busy)
+        return;
     stateless_workers[worker_index].busy = false;
     --stateless_busy_count;
     try_dispatch_pending();
@@ -440,7 +466,7 @@ std::size_t WorkerPool::pick_idle_stateless() {
         if(stateless_workers[i].alive && !stateless_workers[i].busy)
             return i;
     }
-    return 0;
+    llvm_unreachable("pick_idle_stateless called with no idle workers");
 }
 
 kota::task<> WorkerPool::monitor_memory() {
@@ -471,7 +497,7 @@ kota::task<> WorkerPool::monitor_memory() {
     }
 }
 
-void WorkerPool::on_worker_crash() {
+void WorkerPool::apply_crash_backoff() {
     auto new_limit = std::max<std::size_t>(1, low_limit * 3 / 4);
     if(new_limit < low_limit) {
         low_limit = new_limit;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -426,13 +426,16 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     return true;
 }
 
-kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority) {
+kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority,
+                                                           std::size_t exclude) {
     using P = worker::Priority;
-    // High-priority proceeds whenever any worker is idle.
-    // Low-priority is additionally gated by low_limit to reserve
-    // capacity for high-priority requests.
     auto can_proceed = [&]() {
         auto idle = alive_stateless_count - stateless_busy_count;
+        // Don't count the excluded worker (failed peer whose crash
+        // hasn't been processed by monitor_worker yet).
+        if(exclude < stateless_workers.size() && stateless_workers[exclude].alive &&
+           !stateless_workers[exclude].busy)
+            idle -= 1;
         if(idle == 0)
             return false;
         if(priority == P::High)
@@ -537,9 +540,9 @@ void WorkerPool::fail_pending_requests() {
     drain(low_queue);
 }
 
-std::size_t WorkerPool::pick_idle_stateless() {
+std::size_t WorkerPool::pick_idle_stateless(std::size_t exclude) {
     for(std::size_t i = 0; i < stateless_workers.size(); ++i) {
-        if(stateless_workers[i].alive && !stateless_workers[i].busy)
+        if(i != exclude && stateless_workers[i].alive && !stateless_workers[i].busy)
             return i;
     }
     llvm_unreachable("pick_idle_stateless called with no idle workers");

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -173,15 +173,21 @@ kota::task<> WorkerPool::stop() {
     shutting_down = true;
     fail_pending_requests();
 
+    // Retired workers (scale-down) have their peer moved to retired_peers
+    // and their process already exited — skip them to avoid null deref / SEGV.
     for(auto& w: stateless_workers)
-        w.peer->close_output();
+        if(w.peer)
+            w.peer->close_output();
     for(auto& w: stateful_workers)
-        w.peer->close_output();
+        if(w.peer)
+            w.peer->close_output();
 
     for(auto& w: stateless_workers)
-        w.proc.kill(SIGTERM);
+        if(w.alive)
+            w.proc.kill(SIGTERM);
     for(auto& w: stateful_workers)
-        w.proc.kill(SIGTERM);
+        if(w.alive)
+            w.proc.kill(SIGTERM);
 
     co_await kota::when_all(monitor_group.join(), io_group.join());
 
@@ -676,6 +682,8 @@ void WorkerPool::apply_crash_backoff() {
 }
 
 bool WorkerPool::scale_up_worker() {
+    if(shutting_down)
+        return false;
     if(alive_stateless_count >= options.max_stateless)
         return false;
 
@@ -700,6 +708,8 @@ bool WorkerPool::scale_up_worker() {
 }
 
 void WorkerPool::retire_idle_worker() {
+    if(shutting_down)
+        return;
     if(alive_stateless_count <= options.min_stateless)
         return;
 
@@ -724,6 +734,8 @@ void WorkerPool::retire_idle_worker() {
 }
 
 void WorkerPool::check_scaling() {
+    if(shutting_down)
+        return;
     bool has_queued = !high_queue.empty() || !low_queue.empty();
 
     // The pool is saturated when all workers are busy with queued work, OR

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -161,6 +161,7 @@ bool WorkerPool::start(const WorkerPoolOptions& options) {
 kota::task<> WorkerPool::stop() {
     LOG_INFO("WorkerPool stopping...");
     shutting_down_ = true;
+    fail_pending_requests();
 
     for(auto& w: stateless_workers)
         w.peer->close_output();
@@ -422,10 +423,6 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
 }
 
 kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority) {
-    // Fast-fail: no workers alive means no possibility of dispatch.
-    if(alive_stateless_count == 0)
-        co_return SIZE_MAX;
-
     using P = worker::Priority;
     // High-priority proceeds whenever any worker is idle.
     // Low-priority is additionally gated by low_limit to reserve
@@ -439,30 +436,45 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
         return stateless_busy_count < low_limit;
     };
 
-    if(!can_proceed()) {
-        // Enqueue and suspend until try_dispatch_pending() wakes us.
-        // PendingStateless destructor handles cleanup on cancellation:
-        //   - still queued → removes from queue
-        //   - dispatched but cancelled before StatelessSlot → releases slot
-        PendingStateless pending(priority);
-        pending.pool = this;
-        if(priority == P::High) {
-            high_queue.push_back(&pending);
-            pending.queue = &high_queue;
-        } else {
-            low_queue.push_back(&pending);
-            pending.queue = &low_queue;
+    while(true) {
+        if(alive_stateless_count == 0)
+            co_return SIZE_MAX;
+
+        if(!can_proceed()) {
+            // Enqueue and suspend until try_dispatch_pending() wakes us.
+            // PendingStateless destructor handles cleanup on cancellation:
+            //   - still queued → removes from queue
+            //   - dispatched but cancelled before StatelessSlot → releases slot
+            PendingStateless pending(priority);
+            pending.pool = this;
+            if(priority == P::High) {
+                high_queue.push_back(&pending);
+                pending.queue = &high_queue;
+            } else {
+                low_queue.push_back(&pending);
+                pending.queue = &low_queue;
+            }
+            co_await pending.ready.wait();
+            pending.pool = nullptr;  // claimed — StatelessSlot will handle release
+
+            if(pending.assigned_worker == SIZE_MAX)
+                co_return SIZE_MAX;
+
+            // If the assigned worker crashed and was respawned between
+            // dispatch and resume, the slot is stale — loop to re-acquire.
+            auto idx = pending.assigned_worker;
+            if(stateless_workers[idx].restart_count != pending.assigned_gen)
+                continue;
+
+            co_return idx;
         }
-        co_await pending.ready.wait();
-        pending.pool = nullptr;  // claimed — StatelessSlot will handle release
-        co_return pending.assigned_worker;
+
+        auto idx = pick_idle_stateless();
+        stateless_workers[idx].busy = true;
+        stateless_busy_count += 1;
+
+        co_return idx;
     }
-
-    auto idx = pick_idle_stateless();
-    stateless_workers[idx].busy = true;
-    stateless_busy_count += 1;
-
-    co_return idx;
 }
 
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
@@ -488,6 +500,7 @@ void WorkerPool::try_dispatch_pending() {
             stateless_busy_count += 1;
             idle -= 1;
             next->assigned_worker = idx;
+            next->assigned_gen = stateless_workers[idx].restart_count;
             next->ready.set();
         }
     };
@@ -548,6 +561,7 @@ kota::task<> WorkerPool::monitor_memory() {
             LOG_DEBUG("Stateless low_limit -> {} (memory OK: {:.0f}% available)",
                       low_limit,
                       ratio * 100);
+            try_dispatch_pending();
         }
     }
 }

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -101,6 +101,7 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     workers.push_back(WorkerProcess{
         .proc = std::move(spawn.proc),
         .peer = std::move(peer),
+        .name = worker_name,
         .owned_documents = 0,
     });
 
@@ -143,6 +144,9 @@ bool WorkerPool::start(const WorkerPoolOptions& options) {
         });
     }
 
+    // Reserve one worker for high-priority requests by capping low-priority
+    // concurrency to N-1. With a single worker this collapses to 1: both
+    // priorities share it, and high wins only via queue ordering.
     max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
     low_limit = max_low_limit;
 
@@ -249,15 +253,13 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
         exit_code = result.value().status;
         exit_signal = result.value().term_signal;
     } else {
-        auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
-        LOG_ERROR("Worker {} lost: {}", name, result.error().message());
+        LOG_ERROR("Worker {} lost: {}", workers[index].name, result.error().message());
         exit_signal = 9;
     }
 
     if(process_crash(index, stateful, exit_code, exit_signal)) {
         if(!respawn_worker(index, stateful)) {
-            auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
-            LOG_ERROR("Worker {} respawn failed", name);
+            LOG_ERROR("Worker {} respawn failed", workers[index].name);
         }
     }
 }
@@ -267,14 +269,16 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     auto& w = workers[index];
     w.alive = false;
 
-    auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
     if(exit_signal != 0) {
         LOG_ERROR("Worker {} killed by signal {} (restarts: {})",
-                  name,
+                  w.name,
                   exit_signal,
                   w.restart_count);
     } else {
-        LOG_ERROR("Worker {} exited with code {} (restarts: {})", name, exit_code, w.restart_count);
+        LOG_ERROR("Worker {} exited with code {} (restarts: {})",
+                  w.name,
+                  exit_code,
+                  w.restart_count);
     }
 
     WorkerCrashInfo info;
@@ -302,7 +306,7 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
 
     info.will_restart = w.restart_count < options_.max_restarts;
     if(!info.will_restart) {
-        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", name, options_.max_restarts);
+        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options_.max_restarts);
     }
 
     if(on_crash)
@@ -360,6 +364,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     workers[index] = WorkerProcess{
         .proc = std::move(spawn.proc),
         .peer = std::move(peer),
+        .name = worker_name,
         .owned_documents = 0,
         .alive = true,
         .busy = false,
@@ -401,10 +406,13 @@ kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority prio
 
     if(!can_proceed()) {
         PendingStateless pending(priority);
-        if(priority == P::High)
+        if(priority == P::High) {
             high_queue.push_back(&pending);
-        else
+            pending.queue = &high_queue;
+        } else {
             low_queue.push_back(&pending);
+            pending.queue = &low_queue;
+        }
         co_await pending.ready.wait();
         co_return pending.assigned_worker;
     }
@@ -432,33 +440,25 @@ void WorkerPool::release_stateless_slot(std::size_t worker_index) {
 void WorkerPool::try_dispatch_pending() {
     auto idle = alive_stateless_count - stateless_busy_count;
 
-    while(!high_queue.empty() && idle > 0) {
-        auto* next = high_queue.front();
-        high_queue.pop_front();
-        auto idx = pick_idle_stateless();
-        stateless_workers[idx].busy = true;
-        ++stateless_busy_count;
-        --idle;
-        auto pid = stateless_workers[idx].proc.pid();
-        if(pid > 0)
-            kota::sys::set_priority(0, pid);
-        next->assigned_worker = idx;
-        next->ready.set();
-    }
+    auto dispatch = [&](std::deque<PendingStateless*>& queue, int nice, bool check_limit) {
+        while(!queue.empty() && idle > 0 && (!check_limit || stateless_busy_count < low_limit)) {
+            auto* next = queue.front();
+            queue.pop_front();
+            next->queue = nullptr;
+            auto idx = pick_idle_stateless();
+            stateless_workers[idx].busy = true;
+            ++stateless_busy_count;
+            --idle;
+            auto pid = stateless_workers[idx].proc.pid();
+            if(pid > 0)
+                kota::sys::set_priority(nice, pid);
+            next->assigned_worker = idx;
+            next->ready.set();
+        }
+    };
 
-    while(!low_queue.empty() && idle > 0 && stateless_busy_count < low_limit) {
-        auto* next = low_queue.front();
-        low_queue.pop_front();
-        auto idx = pick_idle_stateless();
-        stateless_workers[idx].busy = true;
-        ++stateless_busy_count;
-        --idle;
-        auto pid = stateless_workers[idx].proc.pid();
-        if(pid > 0)
-            kota::sys::set_priority(10, pid);
-        next->assigned_worker = idx;
-        next->ready.set();
-    }
+    dispatch(high_queue, 0, false);
+    dispatch(low_queue, 10, true);
 }
 
 std::size_t WorkerPool::pick_idle_stateless() {
@@ -484,11 +484,16 @@ kota::task<> WorkerPool::monitor_memory() {
         auto ratio = static_cast<double>(mem.available) / static_cast<double>(effective_total);
 
         if(ratio < 0.20 && low_limit > 1) {
-            --low_limit;
-            LOG_INFO("Stateless low_limit -> {} (memory pressure: {:.0f}% available)",
-                     low_limit,
-                     ratio * 100);
+            if(backoff_cooldown > 0) {
+                --backoff_cooldown;
+            } else {
+                --low_limit;
+                LOG_INFO("Stateless low_limit -> {} (memory pressure: {:.0f}% available)",
+                         low_limit,
+                         ratio * 100);
+            }
         } else if(ratio > 0.40 && low_limit < max_low_limit) {
+            backoff_cooldown = 0;
             ++low_limit;
             LOG_DEBUG("Stateless low_limit -> {} (memory OK: {:.0f}% available)",
                       low_limit,
@@ -503,6 +508,9 @@ void WorkerPool::apply_crash_backoff() {
         low_limit = new_limit;
         LOG_WARN("Stateless low_limit -> {} (worker crash AIMD backoff)", low_limit);
     }
+    // Suppress memory-pressure reductions for a few monitor cycles so
+    // crash backoff and memory throttling don't compound in the same window.
+    backoff_cooldown = 3;
 }
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -54,6 +54,12 @@ struct WorkerPoolOptions {
 
     /// Per-worker restart cap before the pool gives up on that slot.
     unsigned max_restarts = 2;
+
+    /// Dynamic scaling bounds for stateless workers.
+    /// min_stateless: floor — never retire below this count.
+    /// max_stateless: ceiling — never spawn above this count (0 = auto = CPU cores).
+    std::uint32_t min_stateless = 1;
+    std::uint32_t max_stateless = 0;
 };
 
 class WorkerPool {
@@ -113,6 +119,10 @@ private:
 
         /// How many times this slot has been respawned.
         unsigned restart_count = 0;
+
+        /// True when this worker is being intentionally shut down (scale-down),
+        /// as opposed to an unexpected crash.
+        bool retiring = false;
     };
 
     kota::event_loop& loop;
@@ -229,7 +239,8 @@ private:
 
     std::size_t pick_idle_stateless(std::size_t exclude = SIZE_MAX);
 
-    /// Periodically adjusts low_limit based on system memory pressure.
+    /// Periodically adjusts low_limit based on system memory pressure
+    /// and triggers dynamic scaling checks.
     kota::task<> monitor_memory();
 
     /// Handle worker crash: update state, fire on_crash callback.
@@ -238,6 +249,39 @@ private:
 
     /// AIMD multiplicative decrease on stateless concurrency limit.
     void apply_crash_backoff();
+
+    // --- Dynamic scaling ---
+
+    /// Spawn an additional stateless worker. Returns true on success.
+    bool scale_up_worker();
+
+    /// Find the highest-index idle worker above min_stateless, mark it
+    /// retiring, and close its output pipe + send SIGTERM.
+    void retire_idle_worker();
+
+    /// Evaluate scaling conditions and act (called from monitor_memory).
+    void check_scaling();
+
+    /// Cancel up to `count` in-flight low-priority requests to relieve
+    /// memory pressure.
+    void cancel_low_priority_requests(std::size_t count);
+
+    /// CUBIC-style fast recovery target: last low_limit before a reduction.
+    std::size_t w_max = 0;
+
+    /// Consecutive monitor ticks where all workers were busy with queued work.
+    unsigned saturated_cycles = 0;
+
+    /// Consecutive monitor ticks where workers were idle with no queued work.
+    unsigned idle_cycles = 0;
+
+    constexpr static unsigned scale_up_ticks = 5;
+    constexpr static unsigned scale_down_ticks = 10;
+
+    /// Per-slot cancellation source for in-flight low-priority requests.
+    /// Indexed by stateless worker index; null when no low-priority request
+    /// is in flight.
+    llvm::SmallVector<std::shared_ptr<kota::cancellation_source>> slot_cancel_sources;
 
     bool shutting_down = false;
 
@@ -294,10 +338,26 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         if(!stateless_workers[idx].alive)
             continue;
 
+        // For low-priority requests, install a cancellation source so
+        // monitor_memory() can preempt under severe memory pressure.
+        std::shared_ptr<kota::cancellation_source> preempt_src;
+        if(params.priority == worker::Priority::Low) {
+            preempt_src = std::make_shared<kota::cancellation_source>();
+            if(idx < slot_cancel_sources.size())
+                slot_cancel_sources[idx] = preempt_src;
+            if(!opts.token)
+                opts.token = preempt_src->token();
+        }
+
         auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
 
         if(result.has_value())
             co_return std::move(result);
+
+        // If deliberately cancelled by memory pressure, don't retry.
+        if(preempt_src && preempt_src->cancelled())
+            co_return kota::outcome_error(
+                kota::ipc::Error{"Request cancelled due to memory pressure"});
 
         // Transport error — retry on a different worker.
         exclude = idx;

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <list>
 #include <memory>
@@ -42,7 +43,7 @@ public:
                                         const Params& params,
                                         kota::ipc::request_options opts = {});
 
-    /// Send a request to a stateless worker with round-robin dispatch.
+    /// Send a request to a stateless worker with priority-aware scheduling.
     template <typename Params>
     RequestResult<Params> send_stateless(const Params& params,
                                          kota::ipc::request_options opts = {});
@@ -65,13 +66,13 @@ private:
         std::unique_ptr<kota::ipc::BincodePeer> peer;
         std::size_t owned_documents = 0;
         bool alive = true;
+        bool busy = false;
         unsigned restart_count = 0;
     };
 
     kota::event_loop& loop;
     llvm::SmallVector<WorkerProcess> stateless_workers;
     llvm::SmallVector<WorkerProcess> stateful_workers;
-    std::size_t next_stateless = 0;
 
     // Stateful worker routing: path_id -> worker index with LRU tracking
     llvm::DenseMap<std::uint32_t, std::size_t> owner;
@@ -81,6 +82,45 @@ private:
     std::size_t assign_worker(std::uint32_t path_id);
     void clear_owner(std::size_t worker_index);
     std::size_t pick_least_loaded();
+
+    // Priority-aware stateless scheduling
+    struct PendingStateless {
+        worker::Priority priority;
+        kota::event ready{};
+        std::size_t assigned_worker = 0;
+
+        explicit PendingStateless(worker::Priority p) : priority(p) {}
+    };
+
+    struct StatelessSlot {
+        WorkerPool& pool;
+        std::size_t worker_index;
+        bool released = false;
+
+        StatelessSlot(WorkerPool& p, std::size_t idx) : pool(p), worker_index(idx) {}
+
+        StatelessSlot(const StatelessSlot&) = delete;
+        StatelessSlot& operator=(const StatelessSlot&) = delete;
+
+        ~StatelessSlot() {
+            if(!released)
+                pool.release_stateless_slot(worker_index);
+        }
+    };
+
+    std::deque<PendingStateless*> high_queue;
+    std::deque<PendingStateless*> low_queue;
+    std::size_t stateless_busy_count = 0;
+    std::size_t alive_stateless_count = 0;
+    std::size_t low_limit = 0;
+    std::size_t max_low_limit = 0;
+
+    kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority);
+    void release_stateless_slot(std::size_t worker_index);
+    void try_dispatch_pending();
+    std::size_t pick_idle_stateless();
+    kota::task<> monitor_memory();
+    void on_worker_crash();
 
     bool shutting_down_ = false;
     kota::task_group<> monitor_group{loop};
@@ -117,16 +157,15 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     if(stateless_workers.empty()) {
         co_return kota::outcome_error(kota::ipc::Error{"No stateless workers available"});
     }
-    // Round-robin, skipping dead workers.
-    auto start = next_stateless;
-    for(std::size_t i = 0; i < stateless_workers.size(); ++i) {
-        auto idx = (start + i) % stateless_workers.size();
-        if(stateless_workers[idx].alive) {
-            next_stateless = (idx + 1) % stateless_workers.size();
-            co_return co_await stateless_workers[idx].peer->send_request(params, opts);
-        }
+
+    auto idx = co_await acquire_stateless_slot(params.priority);
+    StatelessSlot slot(*this, idx);
+
+    if(!stateless_workers[idx].alive) {
+        co_return kota::outcome_error(kota::ipc::Error{"Assigned stateless worker is down"});
     }
-    co_return kota::outcome_error(kota::ipc::Error{"All stateless workers are down"});
+
+    co_return co_await stateless_workers[idx].peer->send_request(params, opts);
 }
 
 template <typename Params>

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -215,7 +215,10 @@ private:
 
     /// Wait for an idle stateless worker. Returns SIZE_MAX when the pool
     /// is dead (all workers down, no restarts left).
-    kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority);
+    /// @param exclude  worker index to skip (e.g. a peer that just failed
+    ///                 but whose crash hasn't been processed yet).
+    kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority,
+                                                   std::size_t exclude = SIZE_MAX);
     void release_stateless_slot(std::size_t worker_index);
 
     /// Wake queued requests when a worker becomes available.
@@ -224,7 +227,7 @@ private:
     /// Wake all queued requests with SIZE_MAX (pool is dead).
     void fail_pending_requests();
 
-    std::size_t pick_idle_stateless();
+    std::size_t pick_idle_stateless(std::size_t exclude = SIZE_MAX);
 
     /// Periodically adjusts low_limit based on system memory pressure.
     kota::task<> monitor_memory();
@@ -278,9 +281,11 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         co_return kota::outcome_error(kota::ipc::Error{"No stateless workers available"});
     }
 
-    // Retry once: if the worker crashes mid-request, acquire a fresh slot.
+    // Retry once on transport error, excluding the failed peer so the
+    // retry doesn't hit the same dead worker before process_crash runs.
+    std::size_t exclude = SIZE_MAX;
     for(int attempt = 0; attempt < 2; ++attempt) {
-        auto idx = co_await acquire_stateless_slot(params.priority);
+        auto idx = co_await acquire_stateless_slot(params.priority, exclude);
         if(idx >= stateless_workers.size())
             co_return kota::outcome_error(kota::ipc::Error{"All stateless workers are down"});
 
@@ -291,13 +296,11 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
 
         auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
 
-        // Transport-level success: return (app errors are inside the value).
         if(result.has_value())
             co_return std::move(result);
 
-        // Transport error (broken pipe, etc.): always retry. The worker
-        // likely crashed but monitor_worker may not have run process_crash
-        // yet, so alive/restart_count can still look valid at this point.
+        // Transport error — retry on a different worker.
+        exclude = idx;
     }
     co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});
 }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -30,10 +30,18 @@ struct WorkerCrashInfo {
     std::size_t worker_index;
     bool stateful;
     int exit_code = 0;
+
+    /// Non-zero when the worker was killed by a signal (e.g. 9 = SIGKILL).
     int exit_signal = 0;
+
+    /// How many times this slot had restarted before this crash.
     unsigned restart_count;
+
+    /// Whether the pool will attempt to respawn this worker.
     bool will_restart;
-    /// For stateful workers: path_ids of documents that were owned by this worker.
+
+    /// Stateful only: path_ids of documents owned by the crashed worker.
+    /// The on_crash handler should mark these dirty for recompilation.
     llvm::SmallVector<std::uint32_t> lost_documents;
 };
 
@@ -43,6 +51,8 @@ struct WorkerPoolOptions {
     std::uint32_t stateful_count = 2;
     std::uint64_t worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB default
     std::string log_dir;
+
+    /// Per-worker restart cap before the pool gives up on that slot.
     unsigned max_restarts = 2;
 };
 
@@ -86,10 +96,19 @@ private:
     struct WorkerProcess {
         kota::process proc;
         std::unique_ptr<kota::ipc::BincodePeer> peer;
+
+        /// Display name for logging, e.g. "SL-0" or "SF-1".
         std::string name;
+
+        /// Stateful only: number of documents routed to this worker.
         std::size_t owned_documents = 0;
+
         bool alive = true;
+
+        /// Stateless only: true while a request is in-flight on this worker.
         bool busy = false;
+
+        /// How many times this slot has been respawned.
         unsigned restart_count = 0;
     };
 
@@ -97,20 +116,31 @@ private:
     llvm::SmallVector<WorkerProcess> stateless_workers;
     llvm::SmallVector<WorkerProcess> stateful_workers;
 
-    // Stateful worker routing: path_id -> worker index with LRU tracking
-    llvm::DenseMap<std::uint32_t, std::size_t> owner;
-    std::list<std::uint32_t> owner_lru;
+    // Stateful routing: each open document (path_id) is pinned to one worker.
+    // LRU tracks access order so stale assignments can be evicted.
+    llvm::DenseMap<std::uint32_t, std::size_t> owner;  // path_id -> worker index
+    std::list<std::uint32_t> owner_lru;                // most-recent at front
     llvm::DenseMap<std::uint32_t, std::list<std::uint32_t>::iterator> owner_lru_index;
 
     std::size_t assign_worker(std::uint32_t path_id);
     void clear_owner(std::size_t worker_index);
     std::size_t pick_least_loaded();
 
-    // Priority-aware stateless scheduling
+    /// A coroutine waiting for a stateless worker slot.  Lives on the coroutine
+    /// frame of acquire_stateless_slot(); the destructor auto-removes it from
+    /// the queue so cancellation never leaves a dangling pointer.
     struct PendingStateless {
         worker::Priority priority;
+
+        /// Signalled by try_dispatch_pending() when a worker becomes available.
         kota::event ready{};
+
+        /// Set by try_dispatch_pending() before signalling ready.
+        /// SIZE_MAX means the pool is dead and no worker was assigned.
         std::size_t assigned_worker = 0;
+
+        /// Points to whichever queue (high/low) this entry sits in; nullptr
+        /// once popped or if never enqueued.
         std::deque<PendingStateless*>* queue = nullptr;
 
         explicit PendingStateless(worker::Priority p) : priority(p) {}
@@ -124,6 +154,7 @@ private:
         }
     };
 
+    /// RAII guard that releases a stateless worker slot on scope exit.
     struct StatelessSlot {
         WorkerPool& pool;
         std::size_t worker_index;
@@ -138,18 +169,39 @@ private:
         }
     };
 
+    /// Pending requests waiting for a worker, split by priority.
+    /// High queue is drained first; low queue respects low_limit.
     std::deque<PendingStateless*> high_queue;
     std::deque<PendingStateless*> low_queue;
+
     std::size_t stateless_busy_count = 0;
     std::size_t alive_stateless_count = 0;
+
+    /// Max concurrent low-priority tasks.  Dynamically adjusted by
+    /// monitor_memory() and apply_crash_backoff().
     std::size_t low_limit = 0;
+
+    /// Ceiling for low_limit recovery (set once at start).
     std::size_t max_low_limit = 0;
+
+    /// Remaining monitor_memory cycles to skip after a crash backoff,
+    /// prevents crash AIMD and memory pressure from compounding.
     unsigned backoff_cooldown = 0;
 
+    /// Wait for an idle stateless worker. Returns SIZE_MAX when the pool
+    /// is dead (all workers down, no restarts left).
     kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority);
     void release_stateless_slot(std::size_t worker_index);
+
+    /// Wake queued requests when a worker becomes available.
     void try_dispatch_pending();
+
+    /// Wake all queued requests with SIZE_MAX (pool is dead).
+    void fail_pending_requests();
+
     std::size_t pick_idle_stateless();
+
+    /// Periodically adjusts low_limit based on system memory pressure.
     kota::task<> monitor_memory();
 
     /// Handle worker crash: update state, fire on_crash callback.
@@ -160,7 +212,11 @@ private:
     void apply_crash_backoff();
 
     bool shutting_down_ = false;
+
+    /// Runs monitor_worker() and monitor_memory() coroutines.
     kota::task_group<> monitor_group{loop};
+
+    /// Runs peer->run() and drain_stderr() coroutines.
     kota::task_group<> io_group{loop};
     WorkerPoolOptions options_;
     std::string log_dir_;
@@ -197,21 +253,25 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         co_return kota::outcome_error(kota::ipc::Error{"No stateless workers available"});
     }
 
-    // Try up to 2 times: if the worker crashes mid-request, retry on another.
+    // Retry once: if the worker crashes mid-request, acquire a fresh slot.
     for(int attempt = 0; attempt < 2; ++attempt) {
         auto idx = co_await acquire_stateless_slot(params.priority);
+        if(idx >= stateless_workers.size())
+            co_return kota::outcome_error(kota::ipc::Error{"All stateless workers are down"});
+
         StatelessSlot slot(*this, idx);
 
         if(!stateless_workers[idx].alive)
             continue;
 
+        // Snapshot restart_count to detect crash-and-respawn on the same slot:
+        // respawn_worker() reuses the index, so checking alive alone would
+        // see the NEW worker as alive and return the stale IPC error.
+        auto gen = stateless_workers[idx].restart_count;
         auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
 
-        // Success, or application-level error (worker still alive) — return as-is.
-        if(result.has_value() || stateless_workers[idx].alive)
+        if(result.has_value() || stateless_workers[idx].restart_count == gen)
             co_return std::move(result);
-
-        // Worker crashed during this request — retry on next iteration.
     }
     co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});
 }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -289,16 +289,15 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         if(!stateless_workers[idx].alive)
             continue;
 
-        auto gen = stateless_workers[idx].restart_count;
         auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
 
-        // Retry when the worker crashed: either restart_count changed
-        // (crash + respawn on same slot) or alive is false (crash without
-        // respawn, e.g. max_restarts exceeded but other workers remain).
-        bool same_process =
-            stateless_workers[idx].restart_count == gen && stateless_workers[idx].alive;
-        if(result.has_value() || same_process)
+        // Transport-level success: return (app errors are inside the value).
+        if(result.has_value())
             co_return std::move(result);
+
+        // Transport error (broken pipe, etc.): always retry. The worker
+        // likely crashed but monitor_worker may not have run process_crash
+        // yet, so alive/restart_count can still look valid at this point.
     }
     co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});
 }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -142,6 +142,9 @@ private:
         /// SIZE_MAX means the pool is dead and no worker was assigned.
         std::size_t assigned_worker = 0;
 
+        /// restart_count of the assigned worker at dispatch time.
+        unsigned assigned_gen = 0;
+
         /// Points to whichever queue (high/low) this entry sits in; nullptr
         /// once popped or if never enqueued.
         std::deque<PendingStateless*>* queue = nullptr;
@@ -160,7 +163,9 @@ private:
             if(queue) {
                 std::erase(*queue, this);
             } else if(assigned_worker != SIZE_MAX && pool) {
-                pool->release_stateless_slot(assigned_worker);
+                // Only release if the slot hasn't been crash-replaced.
+                if(pool->stateless_workers[assigned_worker].restart_count == assigned_gen)
+                    pool->release_stateless_slot(assigned_worker);
             }
         }
     };

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -43,7 +43,7 @@ struct WorkerPoolOptions {
     std::uint32_t stateful_count = 2;
     std::uint64_t worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB default
     std::string log_dir;
-    unsigned max_restarts = 5;
+    unsigned max_restarts = 2;
 };
 
 class WorkerPool {

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -108,6 +108,9 @@ private:
         /// Stateless only: true while a request is in-flight on this worker.
         bool busy = false;
 
+        /// Stateless only: true if the current in-flight request is low-priority.
+        bool low_priority = false;
+
         /// How many times this slot has been respawned.
         unsigned restart_count = 0;
     };
@@ -196,6 +199,7 @@ private:
     std::deque<PendingStateless*> low_queue;
 
     std::size_t stateless_busy_count = 0;
+    std::size_t low_busy_count = 0;
     std::size_t alive_stateless_count = 0;
 
     /// Max concurrent low-priority tasks.  Dynamically adjusted by

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -155,17 +155,22 @@ private:
     };
 
     /// RAII guard that releases a stateless worker slot on scope exit.
+    /// Captures restart_count at construction so that a crash-and-respawn
+    /// on the same index won't accidentally clear the new occupant's busy flag.
     struct StatelessSlot {
         WorkerPool& pool;
         std::size_t worker_index;
+        unsigned gen;
 
-        StatelessSlot(WorkerPool& p, std::size_t idx) : pool(p), worker_index(idx) {}
+        StatelessSlot(WorkerPool& p, std::size_t idx) :
+            pool(p), worker_index(idx), gen(p.stateless_workers[idx].restart_count) {}
 
         StatelessSlot(const StatelessSlot&) = delete;
         StatelessSlot& operator=(const StatelessSlot&) = delete;
 
         ~StatelessSlot() {
-            pool.release_stateless_slot(worker_index);
+            if(pool.stateless_workers[worker_index].restart_count == gen)
+                pool.release_stateless_slot(worker_index);
         }
     };
 
@@ -264,13 +269,15 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         if(!stateless_workers[idx].alive)
             continue;
 
-        // Snapshot restart_count to detect crash-and-respawn on the same slot:
-        // respawn_worker() reuses the index, so checking alive alone would
-        // see the NEW worker as alive and return the stale IPC error.
         auto gen = stateless_workers[idx].restart_count;
         auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
 
-        if(result.has_value() || stateless_workers[idx].restart_count == gen)
+        // Retry when the worker crashed: either restart_count changed
+        // (crash + respawn on same slot) or alive is false (crash without
+        // respawn, e.g. max_restarts exceeded but other workers remain).
+        bool same_process =
+            stateless_workers[idx].restart_count == gen && stateless_workers[idx].alive;
+        if(result.has_value() || same_process)
             co_return std::move(result);
     }
     co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -86,6 +86,7 @@ private:
     struct WorkerProcess {
         kota::process proc;
         std::unique_ptr<kota::ipc::BincodePeer> peer;
+        std::string name;
         std::size_t owned_documents = 0;
         bool alive = true;
         bool busy = false;
@@ -110,8 +111,17 @@ private:
         worker::Priority priority;
         kota::event ready{};
         std::size_t assigned_worker = 0;
+        std::deque<PendingStateless*>* queue = nullptr;
 
         explicit PendingStateless(worker::Priority p) : priority(p) {}
+
+        PendingStateless(const PendingStateless&) = delete;
+        PendingStateless& operator=(const PendingStateless&) = delete;
+
+        ~PendingStateless() {
+            if(queue)
+                std::erase(*queue, this);
+        }
     };
 
     struct StatelessSlot {
@@ -134,6 +144,7 @@ private:
     std::size_t alive_stateless_count = 0;
     std::size_t low_limit = 0;
     std::size_t max_low_limit = 0;
+    unsigned backoff_cooldown = 0;
 
     kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority);
     void release_stateless_slot(std::size_t worker_index);

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -340,6 +340,11 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
 
         // For low-priority requests, install a cancellation source so
         // monitor_memory() can preempt under severe memory pressure.
+        // FIXME: cancelling only aborts the IPC wait — the worker process
+        // continues compiling until it finishes. The slot is released here
+        // but the worker won't accept new work until the in-flight RPC
+        // completes, so the next request dispatched to it queues at the
+        // IPC layer. Not a correctness bug, but limits preemption efficacy.
         std::shared_ptr<kota::cancellation_source> preempt_src;
         if(params.priority == worker::Priority::Low) {
             preempt_src = std::make_shared<kota::cancellation_source>();

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -17,7 +17,25 @@
 
 namespace clice {
 
+namespace testing {
+
+struct WorkerPoolFixture;
+
+}
+
 using kota::ipc::RequestResult;
+
+/// Information about a worker crash, delivered via WorkerPool::on_crash.
+struct WorkerCrashInfo {
+    std::size_t worker_index;
+    bool stateful;
+    int exit_code = 0;
+    int exit_signal = 0;
+    unsigned restart_count;
+    bool will_restart;
+    /// For stateful workers: path_ids of documents that were owned by this worker.
+    llvm::SmallVector<std::uint32_t> lost_documents;
+};
 
 struct WorkerPoolOptions {
     std::string self_path;
@@ -25,6 +43,7 @@ struct WorkerPoolOptions {
     std::uint32_t stateful_count = 2;
     std::uint64_t worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB default
     std::string log_dir;
+    unsigned max_restarts = 5;
 };
 
 class WorkerPool {
@@ -55,6 +74,9 @@ public:
     /// Remove path_id from ownership tracking (e.g. when the master learns a
     /// document was evicted).
     void remove_owner(std::uint32_t path_id);
+
+    /// Callback invoked when a worker process crashes.
+    std::function<void(const WorkerCrashInfo&)> on_crash;
 
     /// Callback invoked when a stateful worker sends an EvictedParams notification.
     /// The master should translate the path to a path_id and call remove_owner().
@@ -95,7 +117,6 @@ private:
     struct StatelessSlot {
         WorkerPool& pool;
         std::size_t worker_index;
-        bool released = false;
 
         StatelessSlot(WorkerPool& p, std::size_t idx) : pool(p), worker_index(idx) {}
 
@@ -103,8 +124,7 @@ private:
         StatelessSlot& operator=(const StatelessSlot&) = delete;
 
         ~StatelessSlot() {
-            if(!released)
-                pool.release_stateless_slot(worker_index);
+            pool.release_stateless_slot(worker_index);
         }
     };
 
@@ -120,7 +140,13 @@ private:
     void try_dispatch_pending();
     std::size_t pick_idle_stateless();
     kota::task<> monitor_memory();
-    void on_worker_crash();
+
+    /// Handle worker crash: update state, fire on_crash callback.
+    /// Returns true if the worker should be restarted.
+    bool process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal);
+
+    /// AIMD multiplicative decrease on stateless concurrency limit.
+    void apply_crash_backoff();
 
     bool shutting_down_ = false;
     kota::task_group<> monitor_group{loop};
@@ -135,6 +161,8 @@ private:
     bool spawn_worker(const std::string& self_path, bool stateful, std::uint64_t memory_limit);
     bool respawn_worker(std::size_t index, bool stateful);
     kota::task<> monitor_worker(std::size_t index, bool stateful);
+
+    friend struct testing::WorkerPoolFixture;
 };
 
 template <typename Params>
@@ -158,14 +186,23 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
         co_return kota::outcome_error(kota::ipc::Error{"No stateless workers available"});
     }
 
-    auto idx = co_await acquire_stateless_slot(params.priority);
-    StatelessSlot slot(*this, idx);
+    // Try up to 2 times: if the worker crashes mid-request, retry on another.
+    for(int attempt = 0; attempt < 2; ++attempt) {
+        auto idx = co_await acquire_stateless_slot(params.priority);
+        StatelessSlot slot(*this, idx);
 
-    if(!stateless_workers[idx].alive) {
-        co_return kota::outcome_error(kota::ipc::Error{"Assigned stateless worker is down"});
+        if(!stateless_workers[idx].alive)
+            continue;
+
+        auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
+
+        // Success, or application-level error (worker still alive) — return as-is.
+        if(result.has_value() || stateless_workers[idx].alive)
+            co_return std::move(result);
+
+        // Worker crashed during this request — retry on next iteration.
     }
-
-    co_return co_await stateless_workers[idx].peer->send_request(params, opts);
+    co_return kota::outcome_error(kota::ipc::Error{"Stateless request failed after retries"});
 }
 
 template <typename Params>

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -127,8 +127,11 @@ private:
     std::size_t pick_least_loaded();
 
     /// A coroutine waiting for a stateless worker slot.  Lives on the coroutine
-    /// frame of acquire_stateless_slot(); the destructor auto-removes it from
-    /// the queue so cancellation never leaves a dangling pointer.
+    /// frame of acquire_stateless_slot(); the destructor handles two cancellation
+    /// scenarios:
+    ///   - Still queued (queue != nullptr): removes itself from the queue.
+    ///   - Dispatched but coroutine cancelled before StatelessSlot was created
+    ///     (pool != nullptr): releases the assigned slot to prevent leak.
     struct PendingStateless {
         worker::Priority priority;
 
@@ -143,14 +146,22 @@ private:
         /// once popped or if never enqueued.
         std::deque<PendingStateless*>* queue = nullptr;
 
+        /// Non-null while the slot hasn't been claimed by the coroutine.
+        /// Cleared after co_await returns so the destructor doesn't release
+        /// a slot that StatelessSlot now owns.
+        WorkerPool* pool = nullptr;
+
         explicit PendingStateless(worker::Priority p) : priority(p) {}
 
         PendingStateless(const PendingStateless&) = delete;
         PendingStateless& operator=(const PendingStateless&) = delete;
 
         ~PendingStateless() {
-            if(queue)
+            if(queue) {
                 std::erase(*queue, this);
+            } else if(assigned_worker != SIZE_MAX && pool) {
+                pool->release_stateless_slot(assigned_worker);
+            }
         }
     };
 

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -61,7 +61,7 @@ public:
     WorkerPool(kota::event_loop& loop) : loop(loop) {}
 
     /// Spawn all worker processes. Returns false on failure.
-    bool start(const WorkerPoolOptions& options);
+    bool start(const WorkerPoolOptions& opts);
 
     /// Gracefully stop all workers.
     kota::task<> stop();
@@ -232,15 +232,15 @@ private:
     /// AIMD multiplicative decrease on stateless concurrency limit.
     void apply_crash_backoff();
 
-    bool shutting_down_ = false;
+    bool shutting_down = false;
 
     /// Runs monitor_worker() and monitor_memory() coroutines.
     kota::task_group<> monitor_group{loop};
 
     /// Runs peer->run() and drain_stderr() coroutines.
     kota::task_group<> io_group{loop};
-    WorkerPoolOptions options_;
-    std::string log_dir_;
+    WorkerPoolOptions options;
+    std::string log_dir;
 
     /// Peers moved here during respawn so their coroutines can finish
     /// before the object is destroyed.

--- a/src/server/workspace/config.cpp
+++ b/src/server/workspace/config.cpp
@@ -70,6 +70,7 @@ void Config::apply_defaults(llvm::StringRef workspace_root) {
         auto cores = kota::sys::parallelism();
         p.stateless_worker_count = std::max(cores / 2, 2u);
     }
+    // min/max default to 0 meaning "auto" — resolved by WorkerPool::start().
     if(p.worker_memory_limit == 0)
         p.worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB
 

--- a/src/server/workspace/config.h
+++ b/src/server/workspace/config.h
@@ -38,6 +38,8 @@ struct ProjectConfig {
 
     defaulted<std::uint32_t> stateful_worker_count = {};
     defaulted<std::uint32_t> stateless_worker_count = {};
+    defaulted<std::uint32_t> min_stateless_worker_count = {};
+    defaulted<std::uint32_t> max_stateless_worker_count = {};
     defaulted<std::uint64_t> worker_memory_limit = {};
 };
 

--- a/tests/stress.py
+++ b/tests/stress.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Stress-test clice on a real project (LLVM, Linux, etc.).
+
+Usage:
+    # Full indexing test on LLVM (wait for completion):
+    pixi run python tests/stress.py /home/ykiko/workspace/llvm-project \
+        --executable build/RelWithDebInfo/bin/clice
+
+    # Time-limited run (just see how far it gets in 5 minutes):
+    pixi run python tests/stress.py /home/ykiko/workspace/llvm-project \
+        --executable build/RelWithDebInfo/bin/clice \
+        --timeout 300
+
+    # Custom worker limits:
+    pixi run python tests/stress.py /home/ykiko/workspace/llvm-project \
+        --executable build/RelWithDebInfo/bin/clice \
+        --max-stateless 16
+"""
+
+import argparse
+import asyncio
+import json
+import re
+import signal
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from tests.integration.utils.client import CliceClient
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Stress-test clice on a real project")
+    p.add_argument("project", help="Path to the project root")
+    p.add_argument(
+        "--executable",
+        default="build/RelWithDebInfo/bin/clice",
+        help="Path to clice binary",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=0,
+        help="Max seconds to run (0 = wait for indexing to finish)",
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=int,
+        default=30,
+        help="Seconds between log checks (default: 30)",
+    )
+    p.add_argument(
+        "--max-stateless",
+        type=int,
+        default=0,
+        help="Max stateless workers (0 = auto = CPU cores)",
+    )
+    p.add_argument(
+        "--min-stateless",
+        type=int,
+        default=0,
+        help="Min stateless workers (0 = default)",
+    )
+    p.add_argument(
+        "--log-dir", default="", help="Log directory (default: auto in /tmp)"
+    )
+    return p.parse_args()
+
+
+class LogAnalyzer:
+    """Parse clice master log and extract indexing/scaling events."""
+
+    # Patterns
+    RE_INDEXING = re.compile(r"\[(\d+)/(\d+)\] Indexing (.+)")
+    RE_INDEXED = re.compile(r"\[(\d+)/(\d+)\] Indexed (.+)")
+    RE_INDEX_FAILED = re.compile(
+        r"\[(\d+)/(\d+)\] Index (?:failed|IPC error|returned empty)"
+    )
+    RE_SCALE_UP = re.compile(r"Scaled up: spawned (\S+) \(alive=(\d+)\)")
+    RE_RETIRE = re.compile(r"Retiring worker (\S+)")
+    RE_RETIRED = re.compile(r"Worker (\S+) retired gracefully")
+    RE_POOL_STARTED = re.compile(r"WorkerPool started: (\d+) stateless, (\d+) stateful")
+    RE_LOW_LIMIT = re.compile(r"low_limit -> (\d+)")
+    RE_CANCEL = re.compile(r"Cancelled (\d+) low-priority requests")
+    RE_MEMORY = re.compile(
+        r"Memory: ([\d.]+)% available.*low_limit=(\d+)/(\d+).*busy=(\d+).*alive=(\d+).*sat=(\d+)/idle=(\d+)"
+    )
+    RE_BG_INDEX_START = re.compile(r"Background indexing: starting, (\d+) files queued")
+    RE_BG_INDEX_DONE = re.compile(r"Background indexing: queue exhausted")
+    RE_CRASH = re.compile(r"Worker (\S+) (?:killed by signal|exited with code)")
+
+    def __init__(self):
+        self.total_files = 0
+        self.indexed_count = 0
+        self.failed_count = 0
+        self.scale_up_events = []
+        self.scale_down_events = []
+        self.crashes = []
+        self.cancellations = []
+        self.pool_started = False
+        self.initial_stateless = 0
+        self.initial_stateful = 0
+        self.peak_alive = 0
+        self.indexing_complete = False
+        self.last_memory_pct = 0.0
+        self.last_alive = 0
+        self.last_busy = 0
+        self.lines_parsed = 0
+
+    def parse_file(self, path: Path):
+        if not path.exists():
+            return
+        with open(path) as f:
+            for line in f:
+                self.lines_parsed += 1
+                self._parse_line(line)
+
+    def parse_incremental(self, path: Path, offset: int) -> int:
+        if not path.exists():
+            return offset
+        with open(path) as f:
+            f.seek(offset)
+            for line in f:
+                self.lines_parsed += 1
+                self._parse_line(line)
+            return f.tell()
+
+    def _parse_line(self, line: str):
+        if m := self.RE_BG_INDEX_START.search(line):
+            self.total_files = max(self.total_files, int(m.group(1)))
+
+        if m := self.RE_INDEXED.search(line):
+            cur, total = int(m.group(1)), int(m.group(2))
+            self.indexed_count = max(self.indexed_count, cur)
+            self.total_files = max(self.total_files, total)
+
+        if m := self.RE_INDEX_FAILED.search(line):
+            self.failed_count += 1
+
+        if m := self.RE_INDEXING.search(line):
+            self.total_files = max(self.total_files, int(m.group(2)))
+
+        if self.RE_BG_INDEX_DONE.search(line):
+            self.indexing_complete = True
+
+        if m := self.RE_POOL_STARTED.search(line):
+            self.pool_started = True
+            self.initial_stateless = int(m.group(1))
+            self.initial_stateful = int(m.group(2))
+            self.peak_alive = self.initial_stateless
+
+        if m := self.RE_SCALE_UP.search(line):
+            name, alive = m.group(1), int(m.group(2))
+            self.scale_up_events.append(name)
+            self.last_alive = alive
+            self.peak_alive = max(self.peak_alive, alive)
+
+        if m := self.RE_RETIRE.search(line):
+            self.scale_down_events.append(m.group(1))
+
+        if m := self.RE_CRASH.search(line):
+            self.crashes.append(m.group(1))
+
+        if m := self.RE_CANCEL.search(line):
+            self.cancellations.append(int(m.group(1)))
+
+        if m := self.RE_MEMORY.search(line):
+            self.last_memory_pct = float(m.group(1))
+            self.last_alive = int(m.group(5))
+            self.last_busy = int(m.group(4))
+            self.peak_alive = max(self.peak_alive, self.last_alive)
+
+    def progress_str(self) -> str:
+        pct = (
+            (self.indexed_count / self.total_files * 100) if self.total_files > 0 else 0
+        )
+        status = "DONE" if self.indexing_complete else "indexing"
+        return (
+            f"[{status}] {self.indexed_count}/{self.total_files} ({pct:.1f}%) | "
+            f"alive={self.last_alive} busy={self.last_busy} peak={self.peak_alive} | "
+            f"mem={self.last_memory_pct:.0f}% | "
+            f"scale_up={len(self.scale_up_events)} scale_down={len(self.scale_down_events)} "
+            f"crashes={len(self.crashes)}"
+        )
+
+    def summary(self, elapsed: float) -> str:
+        lines = [
+            "=" * 70,
+            "STRESS TEST SUMMARY",
+            "=" * 70,
+            f"Duration:           {elapsed:.0f}s ({elapsed / 60:.1f} min)",
+            f"Total files:        {self.total_files}",
+            f"Indexed:            {self.indexed_count}",
+            f"Failed:             {self.failed_count}",
+            f"Indexing complete:  {'YES' if self.indexing_complete else 'NO'}",
+            "",
+            "Worker Scaling:",
+            f"  Initial workers:  {self.initial_stateless} stateless, {self.initial_stateful} stateful",
+            f"  Peak workers:     {self.peak_alive}",
+            f"  Scale-up events:  {len(self.scale_up_events)}",
+            f"  Scale-down events:{len(self.scale_down_events)}",
+            f"  Crashes:          {len(self.crashes)}",
+            f"  Cancellations:    {len(self.cancellations)}",
+        ]
+        if self.scale_up_events:
+            lines.append(f"  Scaled up:        {', '.join(self.scale_up_events)}")
+        if self.crashes:
+            lines.append(f"  Crashed workers:  {', '.join(self.crashes)}")
+        if self.indexed_count > 0 and elapsed > 0:
+            rate = self.indexed_count / elapsed
+            lines.append(f"\nIndexing rate:       {rate:.1f} files/s")
+            if self.total_files > 0 and not self.indexing_complete:
+                remaining = self.total_files - self.indexed_count
+                eta = remaining / rate if rate > 0 else float("inf")
+                lines.append(f"Estimated remaining:{eta:.0f}s ({eta / 60:.1f} min)")
+        lines.append("=" * 70)
+        return "\n".join(lines)
+
+
+def find_master_log(log_dir: Path) -> Path | None:
+    """Find the master log file in the log directory."""
+    if not log_dir.exists():
+        return None
+    for session_dir in sorted(log_dir.iterdir(), reverse=True):
+        if session_dir.is_dir():
+            master_log = session_dir / "master.log"
+            if master_log.exists():
+                return master_log
+    return None
+
+
+async def run_stress_test(args):
+    project = Path(args.project).resolve()
+    executable = Path(args.executable).resolve()
+
+    if not project.exists():
+        print(f"ERROR: Project directory not found: {project}", file=sys.stderr)
+        return 1
+    if not executable.exists():
+        print(f"ERROR: Executable not found: {executable}", file=sys.stderr)
+        return 1
+
+    if args.log_dir:
+        log_dir = Path(args.log_dir)
+    else:
+        log_dir = Path(tempfile.mkdtemp(prefix="clice-stress-"))
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = project / ".clice"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Project:    {project}")
+    print(f"Executable: {executable}")
+    print(f"Log dir:    {log_dir}")
+    print(
+        f"Timeout:    {args.timeout}s"
+        if args.timeout
+        else "Timeout:    none (wait for completion)"
+    )
+    print()
+
+    init_options = {
+        "project": {
+            "cache_dir": str(cache_dir),
+            "logging_dir": str(log_dir),
+            "enable_indexing": True,
+        }
+    }
+    if args.max_stateless > 0:
+        init_options["project"]["max_stateless_worker_count"] = args.max_stateless
+    if args.min_stateless > 0:
+        init_options["project"]["min_stateless_worker_count"] = args.min_stateless
+
+    client = CliceClient()
+    await client.start_io(str(executable), "server")
+
+    server = getattr(client, "_server", None)
+    start_time = time.monotonic()
+
+    try:
+        await client.initialize(project, initialization_options=init_options)
+        print("Server initialized, background indexing should start...")
+        print()
+
+        analyzer = LogAnalyzer()
+        log_offset = 0
+        poll_count = 0
+
+        while True:
+            await asyncio.sleep(args.poll_interval)
+            elapsed = time.monotonic() - start_time
+
+            # Check if server died
+            if server and server.returncode is not None:
+                print(
+                    f"\n!!! SERVER EXITED with code {server.returncode} after {elapsed:.0f}s !!!"
+                )
+                break
+
+            # Find and parse log
+            master_log = find_master_log(log_dir)
+            if master_log:
+                log_offset = analyzer.parse_incremental(master_log, log_offset)
+
+            poll_count += 1
+            print(f"[{elapsed:6.0f}s] {analyzer.progress_str()}")
+
+            if analyzer.indexing_complete:
+                print("\nIndexing complete!")
+                break
+
+            if args.timeout > 0 and elapsed >= args.timeout:
+                print(f"\nTimeout reached ({args.timeout}s)")
+                break
+
+    except KeyboardInterrupt:
+        elapsed = time.monotonic() - start_time
+        print(f"\nInterrupted after {elapsed:.0f}s")
+    except Exception as e:
+        elapsed = time.monotonic() - start_time
+        print(f"\nError after {elapsed:.0f}s: {e}")
+    finally:
+        elapsed = time.monotonic() - start_time
+
+        # Parse final state of logs
+        master_log = find_master_log(log_dir)
+        if master_log:
+            analyzer = LogAnalyzer()
+            analyzer.parse_file(master_log)
+
+        print()
+        print(analyzer.summary(elapsed))
+
+        # Graceful shutdown
+        print("\nShutting down server...")
+        try:
+            await asyncio.wait_for(client.shutdown_async(None), timeout=10.0)
+        except Exception:
+            pass
+        try:
+            client.exit(None)
+        except Exception:
+            pass
+        if server and server.returncode is None:
+            try:
+                await asyncio.wait_for(server.wait(), timeout=15.0)
+            except asyncio.TimeoutError:
+                server.kill()
+                await server.wait()
+
+        print(f"Log files: {log_dir}")
+        if master_log:
+            print(f"Master log: {master_log}")
+
+    return 0 if not analyzer.crashes else 1
+
+
+def main():
+    args = parse_args()
+    rc = asyncio.run(run_stress_test(args))
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -48,7 +48,7 @@ struct WorkerPoolFixture {
     }
 
     void set_max_restarts(unsigned n) {
-        pool.options_.max_restarts = n;
+        pool.options.max_restarts = n;
     }
 
     void set_restart_count(std::size_t idx, bool stateful, unsigned count) {

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -20,17 +20,21 @@ struct WorkerPoolFixture {
         };
     }
 
-    void add_stateless(bool alive = true, bool busy = false) {
+    void add_stateless(bool alive = true, bool busy = false, bool low = true) {
         auto idx = pool.stateless_workers.size();
         pool.stateless_workers.push_back(WorkerPool::WorkerProcess{});
         auto& w = pool.stateless_workers.back();
         w.name = "SL-" + std::to_string(idx);
         w.alive = alive;
         w.busy = busy;
+        w.low_priority = busy && low;
         if(alive)
             pool.alive_stateless_count += 1;
-        if(busy)
+        if(busy) {
             pool.stateless_busy_count += 1;
+            if(low)
+                pool.low_busy_count += 1;
+        }
     }
 
     void add_stateful(bool alive = true, std::size_t owned = 0) {
@@ -202,7 +206,8 @@ struct WorkerPoolFixture {
         pool.stateless_workers[idx].busy = true;
         pool.stateless_busy_count += 1;
         { WorkerPool::StatelessSlot slot(pool, idx); }
-        return !pool.stateless_workers[idx].busy && pool.stateless_busy_count == 0;
+        return !pool.stateless_workers[idx].busy && pool.stateless_busy_count == 0 &&
+               pool.low_busy_count == 0;
     }
 
     struct ReleaseResult {

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -913,9 +913,11 @@ TEST_CASE(CrashAndRestart) {
 
         f.kill_worker(0);
 
+        // Wait for respawn: PID must change (not just alive, which is
+        // true before the kill is processed).
         for(int i = 0; i < 50; ++i) {
             co_await kota::sleep(100);
-            if(f.worker_alive(0))
+            if(f.worker_alive(0) && f.worker_pid(0) != pid)
                 break;
         }
         EXPECT_TRUE(f.worker_alive(0));

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -200,7 +200,7 @@ struct WorkerPoolFixture {
 
     bool test_slot_raii(std::size_t idx) {
         pool.stateless_workers[idx].busy = true;
-        ++pool.stateless_busy_count;
+        pool.stateless_busy_count += 1;
         { WorkerPool::StatelessSlot slot(pool, idx); }
         return !pool.stateless_workers[idx].busy && pool.stateless_busy_count == 0;
     }
@@ -259,6 +259,18 @@ struct WorkerPoolFixture {
         pending->queue = &pool.high_queue;
         simulate_crash(0, false);
         return {pending->ready.is_set(), pending->assigned_worker};
+    }
+
+    bool test_slot_gen_guard() {
+        // Old StatelessSlot should NOT release a slot that was crash-replaced.
+        {
+            WorkerPool::StatelessSlot slot(pool, 0);
+            // Simulate respawn bumping restart_count.
+            pool.stateless_workers[0].restart_count = 1;
+            pool.stateless_workers[0].busy = true;
+        }
+        // Destructor saw mismatched gen → skipped release.
+        return pool.stateless_workers[0].busy && pool.stateless_busy_count == 1;
     }
 
     DispatchResult test_dispatch_clears_queue() {
@@ -820,6 +832,28 @@ TEST_CASE(DeadPoolDrainsPending) {
     EXPECT_TRUE(r.drained);
     EXPECT_EQ(r.assigned_worker, SIZE_MAX);
     EXPECT_EQ(f.high_queue_size(), 0u);
+}
+
+TEST_CASE(SlotGenGuard) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+    EXPECT_TRUE(f.test_slot_gen_guard());
+}
+
+TEST_CASE(MaxLowLimitClamped) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.add_stateless(true, false);
+    f.add_stateless(true, false);
+    f.set_limits(2, 2);
+    f.set_max_restarts(0);
+
+    f.simulate_crash(0, false);
+
+    // max_low_limit should shrink to alive-1 (or alive if 1).
+    EXPECT_EQ(f.max_low_limit(), 1u);
+    EXPECT_LE(f.low_limit(), f.max_low_limit());
 }
 
 };  // TEST_SUITE(WorkerPoolCrash)

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -1,0 +1,754 @@
+#include "test/test.h"
+#include "server/protocol/worker.h"
+#include "server/worker/worker_pool.h"
+#include "server/worker_test_helpers.h"
+
+#include "kota/async/async.h"
+
+namespace clice::testing {
+
+/// Test fixture with friend access to WorkerPool internals.
+struct WorkerPoolFixture {
+    kota::event_loop loop;
+    WorkerPool pool;
+
+    std::vector<WorkerCrashInfo> crash_reports;
+
+    WorkerPoolFixture() : pool(loop) {
+        pool.on_crash = [this](const WorkerCrashInfo& info) {
+            crash_reports.push_back(info);
+        };
+    }
+
+    void add_stateless(bool alive = true, bool busy = false) {
+        pool.stateless_workers.push_back(WorkerPool::WorkerProcess{});
+        auto& w = pool.stateless_workers.back();
+        w.alive = alive;
+        w.busy = busy;
+        if(alive)
+            ++pool.alive_stateless_count;
+        if(busy)
+            ++pool.stateless_busy_count;
+    }
+
+    void add_stateful(bool alive = true, std::size_t owned = 0) {
+        pool.stateful_workers.push_back(WorkerPool::WorkerProcess{});
+        auto& w = pool.stateful_workers.back();
+        w.alive = alive;
+        w.owned_documents = owned;
+    }
+
+    void set_limits(std::size_t low, std::size_t max_low) {
+        pool.low_limit = low;
+        pool.max_low_limit = max_low;
+    }
+
+    void set_max_restarts(unsigned n) {
+        pool.options_.max_restarts = n;
+    }
+
+    void set_restart_count(std::size_t idx, bool stateful, unsigned count) {
+        auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
+        workers[idx].restart_count = count;
+    }
+
+    std::size_t pick_least_loaded() {
+        return pool.pick_least_loaded();
+    }
+
+    std::size_t assign_worker(std::uint32_t path_id) {
+        return pool.assign_worker(path_id);
+    }
+
+    void remove_owner(std::uint32_t path_id) {
+        pool.remove_owner(path_id);
+    }
+
+    void clear_owner(std::size_t idx) {
+        pool.clear_owner(idx);
+    }
+
+    std::size_t pick_idle() {
+        return pool.pick_idle_stateless();
+    }
+
+    void apply_backoff() {
+        pool.apply_crash_backoff();
+    }
+
+    void release_slot(std::size_t idx) {
+        pool.release_stateless_slot(idx);
+    }
+
+    kota::task<std::size_t> acquire_slot(worker::Priority p) {
+        return pool.acquire_stateless_slot(p);
+    }
+
+    bool simulate_crash(std::size_t index, bool stateful, int exit_code = 0, int exit_signal = 9) {
+        return pool.process_crash(index, stateful, exit_code, exit_signal);
+    }
+
+    bool start(std::uint32_t stateless = 2, std::uint32_t stateful = 0) {
+        WorkerPoolOptions opts;
+        opts.self_path = clice_binary();
+        opts.stateless_count = stateless;
+        opts.stateful_count = stateful;
+        return pool.start(opts);
+    }
+
+    kota::task<> stop() {
+        return pool.stop();
+    }
+
+    template <typename F>
+    void run(F&& coro_factory) {
+        loop.schedule(coro_factory());
+        loop.run();
+    }
+
+    void kill_worker(std::size_t idx) {
+        pool.stateless_workers[idx].proc.kill(9);
+    }
+
+    std::size_t low_limit() const {
+        return pool.low_limit;
+    }
+
+    std::size_t alive_count() const {
+        return pool.alive_stateless_count;
+    }
+
+    std::size_t busy_count() const {
+        return pool.stateless_busy_count;
+    }
+
+    std::size_t stateful_owned(std::size_t idx) const {
+        return pool.stateful_workers[idx].owned_documents;
+    }
+
+    bool is_busy(std::size_t idx) const {
+        return pool.stateless_workers[idx].busy;
+    }
+
+    bool has_owner(std::uint32_t path_id) const {
+        return pool.owner.count(path_id);
+    }
+
+    std::size_t owner_of(std::uint32_t path_id) const {
+        return pool.owner.find(path_id)->second;
+    }
+
+    bool worker_alive(std::size_t idx) const {
+        return pool.stateless_workers[idx].alive;
+    }
+
+    int worker_pid(std::size_t idx) const {
+        return pool.stateless_workers[idx].proc.pid();
+    }
+
+    struct PriorityResult {
+        bool high_dispatched;
+        bool low_dispatched;
+    };
+
+    PriorityResult test_priority_dispatch(std::size_t release_idx) {
+        auto high = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        auto low = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low);
+        pool.high_queue.push_back(high.get());
+        pool.low_queue.push_back(low.get());
+        pool.release_stateless_slot(release_idx);
+        PriorityResult r{high->ready.is_set(), low->ready.is_set()};
+        pool.high_queue.clear();
+        pool.low_queue.clear();
+        return r;
+    }
+
+    std::size_t test_low_dispatch(std::size_t count) {
+        llvm::SmallVector<std::unique_ptr<WorkerPool::PendingStateless>> pending;
+        for(std::size_t i = 0; i < count; ++i) {
+            pending.push_back(
+                std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low));
+            pool.low_queue.push_back(pending.back().get());
+        }
+        pool.try_dispatch_pending();
+        std::size_t dispatched = 0;
+        for(auto& p: pending)
+            if(p->ready.is_set())
+                ++dispatched;
+        pool.low_queue.clear();
+        return dispatched;
+    }
+
+    bool test_slot_raii(std::size_t idx) {
+        pool.stateless_workers[idx].busy = true;
+        ++pool.stateless_busy_count;
+        { WorkerPool::StatelessSlot slot(pool, idx); }
+        return !pool.stateless_workers[idx].busy && pool.stateless_busy_count == 0;
+    }
+
+    struct ReleaseResult {
+        bool pending_before;
+        bool dispatched_after;
+    };
+
+    ReleaseResult test_release_dispatches() {
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        pool.high_queue.push_back(pending.get());
+        bool before = pending->ready.is_set();
+        pool.release_stateless_slot(0);
+        bool after = pending->ready.is_set();
+        pool.high_queue.clear();
+        return {before, after};
+    }
+};
+
+namespace {
+
+TEST_SUITE(WorkerPoolStateful) {
+
+TEST_CASE(PickLeastLoaded) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 5);
+    f.add_stateful(true, 2);
+    f.add_stateful(true, 8);
+    EXPECT_EQ(f.pick_least_loaded(), 1u);
+}
+
+TEST_CASE(SkipDeadWorkers) {
+    WorkerPoolFixture f;
+    f.add_stateful(false, 0);
+    f.add_stateful(true, 5);
+    f.add_stateful(true, 3);
+    EXPECT_EQ(f.pick_least_loaded(), 2u);
+}
+
+TEST_CASE(AssignNewPath) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+    auto idx = f.assign_worker(100);
+    EXPECT_EQ(f.stateful_owned(idx), 1u);
+    EXPECT_TRUE(f.has_owner(100));
+    EXPECT_EQ(f.owner_of(100), idx);
+}
+
+TEST_CASE(PathAffinity) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+    auto a = f.assign_worker(100);
+    auto b = f.assign_worker(100);
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(f.stateful_owned(a), 1u);
+}
+
+TEST_CASE(LoadBalancing) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+    auto a = f.assign_worker(100);
+    auto b = f.assign_worker(200);
+    EXPECT_NE(a, b);
+}
+
+TEST_CASE(RemoveOwner) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.assign_worker(100);
+    EXPECT_EQ(f.stateful_owned(0), 1u);
+    f.remove_owner(100);
+    EXPECT_EQ(f.stateful_owned(0), 0u);
+    EXPECT_FALSE(f.has_owner(100));
+}
+
+TEST_CASE(RemoveNonexistent) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.remove_owner(999);
+}
+
+TEST_CASE(ClearOwner) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+    f.assign_worker(100);
+    f.assign_worker(200);
+    f.assign_worker(300);
+    EXPECT_EQ(f.stateful_owned(0), 2u);
+    f.clear_owner(0);
+    EXPECT_EQ(f.stateful_owned(0), 0u);
+    EXPECT_FALSE(f.has_owner(100));
+    EXPECT_FALSE(f.has_owner(300));
+    EXPECT_TRUE(f.has_owner(200));
+}
+
+};  // TEST_SUITE(WorkerPoolStateful)
+
+TEST_SUITE(WorkerPoolScheduling) {
+
+TEST_CASE(PickIdleBasic) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.add_stateless(true, false);
+    f.add_stateless(true, false);
+    EXPECT_EQ(f.pick_idle(), 1u);
+}
+
+TEST_CASE(PickIdleSkipsDead) {
+    WorkerPoolFixture f;
+    f.add_stateless(false, false);
+    f.add_stateless(true, false);
+    EXPECT_EQ(f.pick_idle(), 1u);
+}
+
+TEST_CASE(AcquireHighImmediate) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.set_limits(2, 2);
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto idx = co_await f.acquire_slot(worker::Priority::High);
+        EXPECT_TRUE(f.is_busy(idx));
+        EXPECT_EQ(f.busy_count(), 1u);
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(AcquireLowImmediate) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_limits(1, 1);
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto idx = co_await f.acquire_slot(worker::Priority::Low);
+        EXPECT_TRUE(f.is_busy(idx));
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(HighBypassesLimit) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_limits(0, 0);
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto idx = co_await f.acquire_slot(worker::Priority::High);
+        EXPECT_TRUE(f.is_busy(idx));
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(HighDispatchedFirst) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+    auto r = f.test_priority_dispatch(0);
+    EXPECT_TRUE(r.high_dispatched);
+    EXPECT_FALSE(r.low_dispatched);
+}
+
+TEST_CASE(LowLimitEnforced) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.set_limits(1, 1);
+    EXPECT_EQ(f.test_low_dispatch(2), 1u);
+    EXPECT_EQ(f.busy_count(), 1u);
+}
+
+TEST_CASE(ReleaseDispatchesPending) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+    auto r = f.test_release_dispatches();
+    EXPECT_FALSE(r.pending_before);
+    EXPECT_TRUE(r.dispatched_after);
+}
+
+TEST_CASE(SlotRAIIRelease) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    EXPECT_TRUE(f.test_slot_raii(0));
+}
+
+TEST_CASE(ConcurrencyLimit) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.set_limits(1, 1);
+
+    int concurrent = 0;
+    int max_concurrent = 0;
+    bool done = false;
+
+    f.run([&]() -> kota::task<> {
+        kota::task_group<> group(f.loop);
+        auto work = [&]() -> kota::task<> {
+            auto idx = co_await f.acquire_slot(worker::Priority::Low);
+            ++concurrent;
+            if(concurrent > max_concurrent)
+                max_concurrent = concurrent;
+            co_await kota::sleep(10);
+            --concurrent;
+            f.release_slot(idx);
+        };
+        for(int i = 0; i < 3; ++i)
+            group.spawn(work());
+        co_await group.join();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+    EXPECT_EQ(max_concurrent, 1);
+}
+
+TEST_CASE(PriorityOrdering) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_limits(1, 1);
+
+    std::size_t order = 0;
+    std::size_t high_order = 0;
+    std::size_t low_order = 0;
+    bool done = false;
+
+    f.run([&]() -> kota::task<> {
+        kota::task_group<> group(f.loop);
+
+        auto initial = co_await f.acquire_slot(worker::Priority::Low);
+
+        auto high_work = [&]() -> kota::task<> {
+            auto idx = co_await f.acquire_slot(worker::Priority::High);
+            high_order = ++order;
+            f.release_slot(idx);
+        };
+        auto low_work = [&]() -> kota::task<> {
+            auto idx = co_await f.acquire_slot(worker::Priority::Low);
+            low_order = ++order;
+            f.release_slot(idx);
+        };
+
+        group.spawn(high_work());
+        group.spawn(low_work());
+
+        f.release_slot(initial);
+        co_await group.join();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+    EXPECT_TRUE(high_order < low_order);
+}
+
+};  // TEST_SUITE(WorkerPoolScheduling)
+
+TEST_SUITE(WorkerPoolCrash) {
+
+TEST_CASE(StatelessCleanup) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.add_stateless(true, false);
+    f.set_limits(2, 2);
+
+    EXPECT_EQ(f.alive_count(), 2u);
+    EXPECT_EQ(f.busy_count(), 1u);
+
+    f.simulate_crash(0, false);
+
+    EXPECT_EQ(f.alive_count(), 1u);
+    EXPECT_EQ(f.busy_count(), 0u);
+}
+
+TEST_CASE(StatefulLostDocuments) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+
+    // Deterministic: first two go to worker 0 (least loaded), third to worker 1
+    auto w0 = f.assign_worker(100);
+    auto w1 = f.assign_worker(200);
+    f.assign_worker(300);
+    ASSERT_NE(w0, w1);
+
+    // Record which docs worker 0 owns before crashing it
+    llvm::SmallVector<std::uint32_t> expected;
+    for(auto id: {100u, 200u, 300u}) {
+        if(f.owner_of(id) == 0)
+            expected.push_back(id);
+    }
+
+    f.simulate_crash(0, true);
+
+    ASSERT_EQ(f.crash_reports.size(), 1u);
+    auto& report = f.crash_reports[0];
+    EXPECT_TRUE(report.stateful);
+    EXPECT_EQ(report.worker_index, 0u);
+    EXPECT_EQ(report.lost_documents.size(), expected.size());
+
+    for(auto path_id: expected) {
+        EXPECT_FALSE(f.has_owner(path_id));
+        EXPECT_TRUE(llvm::is_contained(report.lost_documents, path_id));
+    }
+
+    // Other worker's documents are preserved
+    for(auto id: {100u, 200u, 300u}) {
+        if(!llvm::is_contained(expected, id))
+            EXPECT_TRUE(f.has_owner(id));
+    }
+}
+
+TEST_CASE(CrashInfoSignal) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+
+    f.simulate_crash(0, false, 0, 11);
+
+    ASSERT_EQ(f.crash_reports.size(), 1u);
+    EXPECT_EQ(f.crash_reports[0].exit_signal, 11);
+    EXPECT_EQ(f.crash_reports[0].exit_code, 0);
+    EXPECT_FALSE(f.crash_reports[0].stateful);
+}
+
+TEST_CASE(CrashInfoExitCode) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+
+    f.simulate_crash(0, false, 42, 0);
+
+    ASSERT_EQ(f.crash_reports.size(), 1u);
+    EXPECT_EQ(f.crash_reports[0].exit_code, 42);
+    EXPECT_EQ(f.crash_reports[0].exit_signal, 0);
+}
+
+TEST_CASE(WillRestart) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_max_restarts(3);
+    f.set_restart_count(0, false, 1);
+
+    auto should_restart = f.simulate_crash(0, false);
+
+    EXPECT_TRUE(should_restart);
+    ASSERT_EQ(f.crash_reports.size(), 1u);
+    EXPECT_TRUE(f.crash_reports[0].will_restart);
+    EXPECT_EQ(f.crash_reports[0].restart_count, 1u);
+}
+
+TEST_CASE(MaxRestartsExceeded) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_max_restarts(3);
+    f.set_restart_count(0, false, 3);
+
+    auto should_restart = f.simulate_crash(0, false);
+
+    EXPECT_FALSE(should_restart);
+    ASSERT_EQ(f.crash_reports.size(), 1u);
+    EXPECT_FALSE(f.crash_reports[0].will_restart);
+}
+
+TEST_CASE(ReleaseIdempotent) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+
+    EXPECT_EQ(f.busy_count(), 1u);
+    f.release_slot(0);
+    EXPECT_EQ(f.busy_count(), 0u);
+    f.release_slot(0);
+    EXPECT_EQ(f.busy_count(), 0u);
+}
+
+TEST_CASE(CrashThenRelease) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+
+    f.simulate_crash(0, false);
+    EXPECT_EQ(f.busy_count(), 0u);
+
+    // StatelessSlot destructor would call release_slot — must not underflow
+    f.release_slot(0);
+    EXPECT_EQ(f.busy_count(), 0u);
+}
+
+TEST_CASE(StatefulCrashClearsOwnership) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+    f.add_stateful(true, 0);
+    f.assign_worker(10);
+    f.assign_worker(20);
+    f.assign_worker(30);
+
+    auto idx0 = f.owner_of(10);
+    auto other_idx = idx0 == 0 ? 1u : 0u;
+    auto other_owned_before = f.stateful_owned(other_idx);
+
+    f.simulate_crash(idx0, true);
+
+    EXPECT_FALSE(f.has_owner(10));
+    EXPECT_EQ(f.stateful_owned(idx0), 0u);
+    EXPECT_EQ(f.stateful_owned(other_idx), other_owned_before);
+}
+
+TEST_CASE(AIMDBackoff) {
+    WorkerPoolFixture f;
+    f.set_limits(8, 8);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 6u);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 4u);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 3u);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 2u);
+}
+
+TEST_CASE(AIMDMinimum) {
+    WorkerPoolFixture f;
+    f.set_limits(1, 4);
+    f.apply_backoff();
+    EXPECT_EQ(f.low_limit(), 1u);
+}
+
+TEST_CASE(CrashAppliesBackoff) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_limits(8, 8);
+
+    f.simulate_crash(0, false);
+
+    EXPECT_EQ(f.low_limit(), 6u);
+}
+
+TEST_CASE(IdleStatelessCrash) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.add_stateless(true, false);
+    f.set_limits(2, 2);
+
+    EXPECT_EQ(f.alive_count(), 2u);
+    EXPECT_EQ(f.busy_count(), 0u);
+
+    f.simulate_crash(0, false);
+
+    EXPECT_EQ(f.alive_count(), 1u);
+    EXPECT_EQ(f.busy_count(), 0u);
+    EXPECT_FALSE(f.worker_alive(0));
+}
+
+TEST_CASE(RapidCrashSequence) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.add_stateless(true, true);
+    f.add_stateless(true, false);
+    f.set_limits(8, 8);
+
+    f.simulate_crash(0, false);
+    f.simulate_crash(1, false);
+    f.simulate_crash(2, false);
+
+    EXPECT_EQ(f.alive_count(), 0u);
+    EXPECT_EQ(f.busy_count(), 0u);
+    EXPECT_EQ(f.crash_reports.size(), 3u);
+    EXPECT_LT(f.low_limit(), 8u);
+}
+
+};  // TEST_SUITE(WorkerPoolCrash)
+
+TEST_SUITE(WorkerPoolIntegration) {
+
+TEST_CASE(StartAndStop) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 1));
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(StatelessRequest) {
+    TempDir tmp;
+    tmp.touch("test.cpp", "int x = 1;\n");
+    auto src = tmp.path("test.cpp");
+
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+        co_await kota::sleep(500);
+
+        worker::BuildParams params;
+        params.priority = worker::Priority::Low;
+        params.kind = worker::BuildKind::Index;
+        params.file = src;
+        params.directory = "/tmp";
+        params.arguments = make_args(src);
+
+        auto result = co_await f.pool.send_stateless(params);
+        EXPECT_TRUE(result.has_value());
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(CrashAndRestart) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+
+        auto pid = f.worker_pid(0);
+        EXPECT_GT(pid, 0);
+
+        f.kill_worker(0);
+
+        for(int i = 0; i < 50; ++i) {
+            co_await kota::sleep(100);
+            if(f.worker_alive(0))
+                break;
+        }
+        EXPECT_TRUE(f.worker_alive(0));
+        EXPECT_NE(f.worker_pid(0), pid);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(CrashNotification) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+
+        f.kill_worker(0);
+
+        for(int i = 0; i < 50; ++i) {
+            co_await kota::sleep(100);
+            if(!f.crash_reports.empty())
+                break;
+        }
+
+        CO_ASSERT_FALSE(f.crash_reports.empty());
+        EXPECT_FALSE(f.crash_reports[0].stateful);
+        EXPECT_EQ(f.crash_reports[0].exit_signal, 9);
+        EXPECT_TRUE(f.crash_reports[0].will_restart);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+};  // TEST_SUITE(WorkerPoolIntegration)
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -21,8 +21,10 @@ struct WorkerPoolFixture {
     }
 
     void add_stateless(bool alive = true, bool busy = false) {
+        auto idx = pool.stateless_workers.size();
         pool.stateless_workers.push_back(WorkerPool::WorkerProcess{});
         auto& w = pool.stateless_workers.back();
+        w.name = "SL-" + std::to_string(idx);
         w.alive = alive;
         w.busy = busy;
         if(alive)
@@ -32,8 +34,10 @@ struct WorkerPoolFixture {
     }
 
     void add_stateful(bool alive = true, std::size_t owned = 0) {
+        auto idx = pool.stateful_workers.size();
         pool.stateful_workers.push_back(WorkerPool::WorkerProcess{});
         auto& w = pool.stateful_workers.back();
+        w.name = "SF-" + std::to_string(idx);
         w.alive = alive;
         w.owned_documents = owned;
     }
@@ -151,16 +155,31 @@ struct WorkerPoolFixture {
         bool low_dispatched;
     };
 
+    unsigned get_backoff_cooldown() const {
+        return pool.backoff_cooldown;
+    }
+
+    std::size_t max_low_limit() const {
+        return pool.max_low_limit;
+    }
+
+    std::size_t high_queue_size() const {
+        return pool.high_queue.size();
+    }
+
+    std::size_t low_queue_size() const {
+        return pool.low_queue.size();
+    }
+
     PriorityResult test_priority_dispatch(std::size_t release_idx) {
         auto high = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
         auto low = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low);
         pool.high_queue.push_back(high.get());
+        high->queue = &pool.high_queue;
         pool.low_queue.push_back(low.get());
+        low->queue = &pool.low_queue;
         pool.release_stateless_slot(release_idx);
-        PriorityResult r{high->ready.is_set(), low->ready.is_set()};
-        pool.high_queue.clear();
-        pool.low_queue.clear();
-        return r;
+        return {high->ready.is_set(), low->ready.is_set()};
     }
 
     std::size_t test_low_dispatch(std::size_t count) {
@@ -169,13 +188,13 @@ struct WorkerPoolFixture {
             pending.push_back(
                 std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low));
             pool.low_queue.push_back(pending.back().get());
+            pending.back()->queue = &pool.low_queue;
         }
         pool.try_dispatch_pending();
         std::size_t dispatched = 0;
         for(auto& p: pending)
             if(p->ready.is_set())
                 ++dispatched;
-        pool.low_queue.clear();
         return dispatched;
     }
 
@@ -194,11 +213,51 @@ struct WorkerPoolFixture {
     ReleaseResult test_release_dispatches() {
         auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
         pool.high_queue.push_back(pending.get());
+        pending->queue = &pool.high_queue;
         bool before = pending->ready.is_set();
         pool.release_stateless_slot(0);
         bool after = pending->ready.is_set();
-        pool.high_queue.clear();
         return {before, after};
+    }
+
+    bool test_pending_cleanup_high() {
+        {
+            WorkerPool::PendingStateless pending(worker::Priority::High);
+            pool.high_queue.push_back(&pending);
+            pending.queue = &pool.high_queue;
+            if(pool.high_queue.size() != 1)
+                return false;
+        }
+        return pool.high_queue.empty();
+    }
+
+    bool test_pending_cleanup_low() {
+        {
+            WorkerPool::PendingStateless pending(worker::Priority::Low);
+            pool.low_queue.push_back(&pending);
+            pending.queue = &pool.low_queue;
+            if(pool.low_queue.size() != 1)
+                return false;
+        }
+        return pool.low_queue.empty();
+    }
+
+    struct DispatchResult {
+        bool dispatched;
+        bool queue_cleared;
+        bool queue_ptr_nulled;
+    };
+
+    DispatchResult test_dispatch_clears_queue() {
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        pool.high_queue.push_back(pending.get());
+        pending->queue = &pool.high_queue;
+        pool.release_stateless_slot(0);
+        return {
+            pending->ready.is_set(),
+            pool.high_queue.empty(),
+            pending->queue == nullptr,
+        };
     }
 };
 
@@ -442,6 +501,42 @@ TEST_CASE(PriorityOrdering) {
     EXPECT_TRUE(high_order < low_order);
 }
 
+TEST_CASE(SingleWorkerShared) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_limits(1, 1);
+    EXPECT_EQ(f.max_low_limit(), 1u);
+
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto low = co_await f.acquire_slot(worker::Priority::Low);
+        EXPECT_TRUE(f.is_busy(low));
+        f.release_slot(low);
+
+        auto high = co_await f.acquire_slot(worker::Priority::High);
+        EXPECT_TRUE(f.is_busy(high));
+        f.release_slot(high);
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(PendingCleanupOnDestroy) {
+    WorkerPoolFixture f;
+    EXPECT_TRUE(f.test_pending_cleanup_high());
+    EXPECT_TRUE(f.test_pending_cleanup_low());
+}
+
+TEST_CASE(DispatchClearsQueue) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+    auto r = f.test_dispatch_clears_queue();
+    EXPECT_TRUE(r.dispatched);
+    EXPECT_TRUE(r.queue_cleared);
+    EXPECT_TRUE(r.queue_ptr_nulled);
+}
+
 };  // TEST_SUITE(WorkerPoolScheduling)
 
 TEST_SUITE(WorkerPoolCrash) {
@@ -654,6 +749,34 @@ TEST_CASE(RapidCrashSequence) {
     EXPECT_EQ(f.busy_count(), 0u);
     EXPECT_EQ(f.crash_reports.size(), 3u);
     EXPECT_LT(f.low_limit(), 8u);
+}
+
+TEST_CASE(BackoffSetsCooldown) {
+    WorkerPoolFixture f;
+    f.set_limits(8, 8);
+    EXPECT_EQ(f.get_backoff_cooldown(), 0u);
+    f.apply_backoff();
+    EXPECT_GT(f.get_backoff_cooldown(), 0u);
+}
+
+TEST_CASE(CrashSetsCooldown) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_limits(8, 8);
+
+    f.simulate_crash(0, false);
+
+    EXPECT_EQ(f.low_limit(), 6u);
+    EXPECT_GT(f.get_backoff_cooldown(), 0u);
+}
+
+TEST_CASE(StatefulCrashNoCooldown) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 0);
+
+    f.simulate_crash(0, true);
+
+    EXPECT_EQ(f.get_backoff_cooldown(), 0u);
 }
 
 };  // TEST_SUITE(WorkerPoolCrash)

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -28,9 +28,9 @@ struct WorkerPoolFixture {
         w.alive = alive;
         w.busy = busy;
         if(alive)
-            ++pool.alive_stateless_count;
+            pool.alive_stateless_count += 1;
         if(busy)
-            ++pool.stateless_busy_count;
+            pool.stateless_busy_count += 1;
     }
 
     void add_stateful(bool alive = true, std::size_t owned = 0) {
@@ -194,7 +194,7 @@ struct WorkerPoolFixture {
         std::size_t dispatched = 0;
         for(auto& p: pending)
             if(p->ready.is_set())
-                ++dispatched;
+                dispatched += 1;
         return dispatched;
     }
 
@@ -247,6 +247,19 @@ struct WorkerPoolFixture {
         bool queue_cleared;
         bool queue_ptr_nulled;
     };
+
+    struct DrainResult {
+        bool drained;
+        std::size_t assigned_worker;
+    };
+
+    DrainResult test_dead_pool_drain() {
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        pool.high_queue.push_back(pending.get());
+        pending->queue = &pool.high_queue;
+        simulate_crash(0, false);
+        return {pending->ready.is_set(), pending->assigned_worker};
+    }
 
     DispatchResult test_dispatch_clears_queue() {
         auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
@@ -777,6 +790,36 @@ TEST_CASE(StatefulCrashNoCooldown) {
     f.simulate_crash(0, true);
 
     EXPECT_EQ(f.get_backoff_cooldown(), 0u);
+}
+
+TEST_CASE(DeadPoolReturnsError) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_limits(1, 1);
+    f.set_max_restarts(0);
+
+    f.simulate_crash(0, false);
+    EXPECT_EQ(f.alive_count(), 0u);
+
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto idx = co_await f.acquire_slot(worker::Priority::High);
+        EXPECT_EQ(idx, SIZE_MAX);
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(DeadPoolDrainsPending) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_limits(1, 1);
+    f.set_max_restarts(0);
+
+    auto r = f.test_dead_pool_drain();
+    EXPECT_TRUE(r.drained);
+    EXPECT_EQ(r.assigned_worker, SIZE_MAX);
+    EXPECT_EQ(f.high_queue_size(), 0u);
 }
 
 };  // TEST_SUITE(WorkerPoolCrash)


### PR DESCRIPTION
## Background

The old `WorkerPool` dispatched stateless requests via round-robin and had no priority
awareness. User-facing requests (completion, hover, format) competed equally with
background indexing for worker slots. When a worker crashed, the pool attempted a
restart but had no structured reporting, no concurrency back-off, and no way to
recover stateful session state. The `Indexer` managed its own concurrency limits and
memory monitoring separately, duplicating concerns that belong in the pool.

## Design

### Priority-aware scheduling

Stateless dispatch is split into two FIFO queues — **high** (user-facing: completion,
hover, format, PCH/PCM builds) and **low** (background indexing). A configurable
`low_limit` caps how many low-priority tasks can run concurrently, reserving at least
one worker for high-priority requests (`low_limit = N-1` for N workers). High-priority
requests bypass the limit and proceed whenever any worker is idle.

Callers acquire a slot via `acquire_stateless_slot()`, which either returns immediately
or suspends the coroutine into the appropriate queue. `PendingStateless` lives on the
coroutine frame; its destructor auto-removes itself from the queue so that coroutine
cancellation never leaves a dangling pointer. `StatelessSlot` is an RAII guard that
releases the slot on scope exit. `try_dispatch_pending()` wakes the highest-priority
waiter whenever a slot is freed.

### Crash handling

`process_crash()` centralises all crash bookkeeping:

- **Stateful**: collects `lost_documents` (path_ids owned by the crashed worker),
  clears ownership, and fires `on_crash`. `MasterServer` installs this callback to
  mark lost sessions dirty so the next feature request triggers recompilation.
- **Stateless**: decrements alive/busy counts, applies AIMD backoff to `low_limit`
  (×0.75, floor 1), and dispatches pending requests to surviving workers. If the last
  worker dies permanently, `fail_pending_requests()` wakes all waiters with `SIZE_MAX`
  so `send_stateless()` returns an error instead of hanging.

`send_stateless()` retries once on a mid-request crash. It snapshots `restart_count`
before sending; if the count changes (meaning the slot was crash-replaced by
`respawn_worker()`), it retries on a fresh slot rather than returning a stale IPC
error from the retired peer.

### Memory-aware throttling

`monitor_memory()` runs every 3 s and adjusts `low_limit` based on system memory:
decrease by 1 when available < 20 %, increase by 1 when > 40 % (capped at
`max_low_limit`). A `backoff_cooldown` (3 cycles ≈ 9 s) prevents the crash AIMD and
memory monitor from compounding reductions in the same window.

### Indexer simplification

The Indexer's own concurrency control (`max_concurrent`, `in_flight`, `slot_available`,
`monitor_resources()`) is removed — the pool now owns all scheduling. A local
`kota::semaphore(32)` caps in-flight coroutine frames to avoid spawning thousands of
suspended coroutines on large projects.

### Stateless worker isolation

Each stateless worker sets `UV_THREADPOOL_SIZE=1` at startup so libuv runs exactly one
compilation at a time. This makes the pool's slot-based scheduling the single source of
concurrency control.

## Test plan

- [x] 48 unit tests across 4 suites (668 total, 0 failures):
  - `WorkerPoolStateful` (8): least-loaded, skip-dead, assign/affinity, load-balance, remove/clear owner
  - `WorkerPoolScheduling` (14): pick-idle, acquire high/low, limit bypass, priority ordering, concurrency cap, RAII, pending cleanup on destroy, dispatch clears queue, single-worker shared
  - `WorkerPoolCrash` (22): stateless/stateful cleanup, lost documents, crash info, will_restart, max restarts, idempotent release, crash-then-release, AIMD math, backoff cooldown, dead-pool error/drain, rapid crash sequence
  - `WorkerPoolIntegration` (4): start/stop, stateless request round-trip, crash-and-restart, crash notification