### PR TITLE
feat(inlay-hints): resolve typeof specifiers to underlying types in hints

### DIFF
--- a/src/feature/inlay_hints.cpp
+++ b/src/feature/inlay_hints.cpp
@@ -876,6 +876,16 @@ public:
         if(const auto* DT = llvm::dyn_cast<clang::DecltypeType>(TL.getType()))
             if(clang::QualType UT = DT->getUnderlyingType(); !UT->isDependentType())
                 builder.add_type_hint(TL.getSourceRange(), UT, ": ");
+
+        // Resolve `typeof(expr)` and `typeof(type)` specifiers, mirroring the
+        // decltype handling above.
+        if(const auto* TT = llvm::dyn_cast<clang::TypeOfExprType>(TL.getType()))
+            if(clang::QualType UT = TT->getUnderlyingExpr()->getType(); !UT->isDependentType())
+                builder.add_type_hint(TL.getSourceRange(), UT, ": ");
+
+        if(const auto* TT = llvm::dyn_cast<clang::TypeOfType>(TL.getType()))
+            if(clang::QualType UT = TT->getUnmodifiedType(); !UT->isDependentType())
+                builder.add_type_hint(TL.getSourceRange(), UT, ": ");
         return true;
     }
 

--- a/src/semantic/ast_utility.cpp
+++ b/src/semantic/ast_utility.cpp
@@ -1073,9 +1073,16 @@ clang::QualType maybe_desugar(clang::ASTContext& context, clang::QualType type) 
         return type.getCanonicalType();
     }
 
+    // Prefer desugared type when `auto` deduces to a `decltype(expr)`,
+    // `typeof(expr)`, or `typeof(type)` specifier. This prevents hints like
+    // `: typeof(int)` and instead shows the resolved type `: int`.
     if(const auto* AT = type->getContainedAutoType()) {
-        if(!AT->getDeducedType().isNull() && AT->getDeducedType()->isDecltypeType()) {
-            return type.getCanonicalType();
+        if(!AT->getDeducedType().isNull()) {
+            auto deduced = AT->getDeducedType();
+            if(deduced->isDecltypeType() || llvm::isa<clang::TypeOfExprType>(deduced) ||
+               llvm::isa<clang::TypeOfType>(deduced)) {
+                return type.getCanonicalType();
+            }
         }
     }
 


### PR DESCRIPTION
Extend type inlay hints to desugar `typeof(expr)` and `typeof(type)` through to their resolved types, both when auto-deduced (e.g. `auto x = (typeof(int)){3}` now shows `: int` instead of `: typeof(int)`) and when typeof appears directly in declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inlay type hints now support additional `typeof(...)` forms, alongside existing `decltype(...)` handling.
* **Bug Fixes**
  * Improved type display for `auto` values so inferred types are more consistently shown in their canonical form when derived from `typeof(...)` or `decltype(...)`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->