### PR TITLE
refactor(index): multi-level symbol table

### DIFF
--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -398,8 +398,8 @@ void MergedIndex::serialize(this const Self& self, llvm::raw_ostream& out) {
                                          binary::CreateSymbol(builder,
                                                               CreateString(builder, symbol.name),
                                                               symbol.kind.value(),
-                                                              static_cast<uint8_t>(symbol.scope),
-                                                              CreateVector(builder, buffer)));
+                                                              CreateVector(builder, buffer),
+                                                              static_cast<uint8_t>(symbol.scope)));
     });
 
     auto merged_index = binary::CreateMergedIndex(builder,

--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -141,6 +141,9 @@ struct MergedIndex::Impl {
     /// All merged symbol relations.
     llvm::DenseMap<SymbolHash, llvm::DenseMap<Relation, roaring::Roaring>> relations;
 
+    /// Symbols local to this file (FileLocal) or TU (TULocal).
+    SymbolTable symbols;
+
     /// Sorted occurrences cache for fast lookup.
     std::vector<Occurrence> occurrences_cache;
 
@@ -268,6 +271,19 @@ void MergedIndex::load_in_memory(this Self& self) {
         index.line_starts = kota::ipc::lsp::build_line_starts(index.content);
     }
 
+    if(root->symbols()) {
+        for(auto entry: *root->symbols()) {
+            auto& symbol = index.symbols[entry->symbol_id()];
+            if(auto* s = entry->symbol()) {
+                if(s->name())
+                    symbol.name = s->name()->str();
+                symbol.kind = SymbolKind(static_cast<std::uint8_t>(s->kind()));
+                symbol.scope = static_cast<SymbolScope>(s->scope());
+                symbol.reference_files = read_bitmap(s->refs());
+            }
+        }
+    }
+
     self.buffer.reset();
 }
 
@@ -372,6 +388,20 @@ void MergedIndex::serialize(this const Self& self, llvm::raw_ostream& out) {
     auto content_offset = CreateString(builder, index->content);
     auto line_starts_offset = builder.CreateVector(index->line_starts);
 
+    auto symbols = transform(index->symbols, [&](auto&& value) {
+        auto& [symbol_id, symbol] = value;
+        buffer.clear();
+        buffer.resize_for_overwrite(symbol.reference_files.getSizeInBytes(false));
+        symbol.reference_files.write(buffer.data(), false);
+        return binary::CreateSymbolEntry(builder,
+                                         symbol_id,
+                                         binary::CreateSymbol(builder,
+                                                              CreateString(builder, symbol.name),
+                                                              symbol.kind.value(),
+                                                              static_cast<uint8_t>(symbol.scope),
+                                                              CreateVector(builder, buffer)));
+    });
+
     auto merged_index = binary::CreateMergedIndex(builder,
                                                   index->max_canonical_id,
                                                   CreateVector(builder, canonical_cache),
@@ -381,7 +411,8 @@ void MergedIndex::serialize(this const Self& self, llvm::raw_ostream& out) {
                                                   CreateVector(builder, relations),
                                                   removed,
                                                   content_offset,
-                                                  line_starts_offset);
+                                                  line_starts_offset,
+                                                  CreateVector(builder, symbols));
     builder.Finish(merged_index);
 
     out.write(safe_cast<char>(builder.GetBufferPointer()), builder.GetSize());
@@ -589,6 +620,47 @@ void MergedIndex::remove(this Self& self, std::uint32_t path_id) {
 
     // Invalidate cached occurrences.
     index.occurrences_cache.clear();
+}
+
+bool MergedIndex::find_symbol(this const Self& self,
+                              SymbolHash hash,
+                              std::string& name,
+                              SymbolKind& kind) {
+    if(self.impl) {
+        auto it = self.impl->symbols.find(hash);
+        if(it != self.impl->symbols.end()) {
+            name = it->second.name;
+            kind = it->second.kind;
+            return true;
+        }
+    } else if(self.buffer) {
+        auto root = fbs::GetRoot<binary::MergedIndex>(self.buffer->getBufferStart());
+        if(root->symbols()) {
+            for(auto entry: *root->symbols()) {
+                if(entry->symbol_id() == hash) {
+                    if(auto* s = entry->symbol()) {
+                        if(s->name())
+                            name = s->name()->str();
+                        kind = SymbolKind(static_cast<std::uint8_t>(s->kind()));
+                    }
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void MergedIndex::merge_symbols(this Self& self, const SymbolTable& symbols) {
+    self.load_in_memory();
+    for(auto& [hash, symbol]: symbols) {
+        auto [it, inserted] = self.impl->symbols.try_emplace(hash);
+        if(inserted) {
+            it->second.name = symbol.name;
+            it->second.kind = symbol.kind;
+            it->second.scope = symbol.scope;
+        }
+    }
 }
 
 void MergedIndex::merge(this Self& self,

--- a/src/index/merged_index.h
+++ b/src/index/merged_index.h
@@ -71,6 +71,12 @@ public:
     /// Get line starts for position mapping.
     std::span<const std::uint32_t> line_starts(this const Self& self);
 
+    /// Look up a symbol in this shard's local symbol table.
+    bool find_symbol(this const Self& self, SymbolHash hash, std::string& name, SymbolKind& kind);
+
+    /// Add symbols to this shard's local symbol table (idempotent by hash).
+    void merge_symbols(this Self& self, const SymbolTable& symbols);
+
     /// Merge the index with given compilation context.
     void merge(this Self& self,
                std::uint32_t path_id,

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -59,8 +59,8 @@ void ProjectIndex::serialize(this ProjectIndex& self, llvm::raw_ostream& os) {
                                          binary::CreateSymbol(builder,
                                                               CreateString(builder, symbol.name),
                                                               symbol.kind.value(),
-                                                              static_cast<uint8_t>(symbol.scope),
-                                                              CreateVector(builder, buffer)));
+                                                              CreateVector(builder, buffer),
+                                                              static_cast<uint8_t>(symbol.scope)));
     });
 
     auto project_index =

--- a/src/index/project_index.cpp
+++ b/src/index/project_index.cpp
@@ -14,6 +14,8 @@ llvm::SmallVector<std::uint32_t> ProjectIndex::merge(this ProjectIndex& self, TU
     }
 
     for(auto& [symbol_id, symbol]: index.symbols) {
+        if(symbol.scope != SymbolScope::External)
+            continue;
         auto& target_symbol = self.symbols[symbol_id];
         if(target_symbol.name.empty()) {
             target_symbol.name = symbol.name;
@@ -57,6 +59,7 @@ void ProjectIndex::serialize(this ProjectIndex& self, llvm::raw_ostream& os) {
                                          binary::CreateSymbol(builder,
                                                               CreateString(builder, symbol.name),
                                                               symbol.kind.value(),
+                                                              static_cast<uint8_t>(symbol.scope),
                                                               CreateVector(builder, buffer)));
     });
 
@@ -98,6 +101,7 @@ ProjectIndex ProjectIndex::from(const void* data) {
             symbol.name = name->str();
         }
         symbol.kind = SymbolKind(static_cast<std::uint8_t>(fb_symbol->kind()));
+        symbol.scope = static_cast<index::SymbolScope>(fb_symbol->scope());
         symbol.reference_files = read_bitmap(fb_symbol->refs());
     }
 

--- a/src/index/schema.fbs
+++ b/src/index/schema.fbs
@@ -83,10 +83,10 @@ name:
     string;
 kind:
     ubyte;
-scope:
-    ubyte;
 refs:
     [ubyte];
+scope:
+    ubyte;
 }
 
 table SymbolEntry {

--- a/src/index/schema.fbs
+++ b/src/index/schema.fbs
@@ -83,6 +83,8 @@ name:
     string;
 kind:
     ubyte;
+scope:
+    ubyte;
 refs:
     [ubyte];
 }
@@ -121,6 +123,9 @@ content:
 
 line_starts:
     [uint];
+
+symbols:
+    [SymbolEntry];
 }
 
 table TUFileRelationsEntry {

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -18,7 +18,7 @@ SymbolScope classify_scope(const clang::NamedDecl* decl) {
     auto linkage = decl->getFormalLinkage();
     if(linkage == clang::Linkage::None)
         return SymbolScope::FileLocal;
-    if(linkage == clang::Linkage::Internal)
+    if(linkage == clang::Linkage::Internal || linkage == clang::Linkage::Module)
         return SymbolScope::TULocal;
     return SymbolScope::External;
 }
@@ -254,8 +254,8 @@ void TUIndex::serialize(llvm::raw_ostream& os) const {
                                          binary::CreateSymbol(builder,
                                                               CreateString(builder, symbol.name),
                                                               symbol.kind.value(),
-                                                              static_cast<uint8_t>(symbol.scope),
-                                                              CreateVector(builder, buffer)));
+                                                              CreateVector(builder, buffer),
+                                                              static_cast<uint8_t>(symbol.scope)));
     });
 
     /// Serialize a single FileIndex into a TUFileIndexEntry.

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -8,10 +8,20 @@
 #include "semantic/semantic_visitor.h"
 
 #include "llvm/Support/SHA256.h"
+#include "clang/AST/DeclCXX.h"
 
 namespace clice::index {
 
 namespace {
+
+SymbolScope classify_scope(const clang::NamedDecl* decl) {
+    auto linkage = decl->getFormalLinkage();
+    if(linkage == clang::Linkage::None)
+        return SymbolScope::FileLocal;
+    if(linkage == clang::Linkage::Internal)
+        return SymbolScope::TULocal;
+    return SymbolScope::External;
+}
 
 class Builder : public SemanticVisitor<Builder> {
 public:
@@ -48,6 +58,7 @@ public:
             auto& symbol = it->second;
             symbol.name = ast::display_name_of(decl);
             symbol.kind = SymbolKind::from(decl);
+            symbol.scope = classify_scope(decl);
         }
         index.occurrences.emplace_back(range, symbol_id.hash);
     }
@@ -243,6 +254,7 @@ void TUIndex::serialize(llvm::raw_ostream& os) const {
                                          binary::CreateSymbol(builder,
                                                               CreateString(builder, symbol.name),
                                                               symbol.kind.value(),
+                                                              static_cast<uint8_t>(symbol.scope),
                                                               CreateVector(builder, buffer)));
     });
 
@@ -301,6 +313,7 @@ TUIndex TUIndex::from(const void* data) {
         auto& symbol = index.symbols[entry->symbol_id()];
         symbol.name = entry->symbol()->name()->str();
         symbol.kind = SymbolKind(static_cast<std::uint8_t>(entry->symbol()->kind()));
+        symbol.scope = static_cast<SymbolScope>(entry->symbol()->scope());
         symbol.reference_files = read_bitmap(entry->symbol()->refs());
     }
 

--- a/src/index/tu_index.h
+++ b/src/index/tu_index.h
@@ -20,6 +20,20 @@ namespace clice::index {
 using Range = LocalSourceRange;
 using SymbolHash = std::uint64_t;
 
+/// Visibility scope of a symbol, determining which level of the multi-level
+/// symbol table stores it.
+enum class SymbolScope : std::uint8_t {
+    /// Can be referenced from any TU (external linkage).  Stored in ProjectIndex.
+    External = 0,
+    /// Can be referenced across files within one TU but not across TUs
+    /// (internal linkage: static, anonymous namespace).  Stored in the main
+    /// file's MergedIndex shard.
+    TULocal = 1,
+    /// Cannot be referenced from any other file (local variables, parameters,
+    /// labels).  Stored in the defining file's MergedIndex shard.
+    FileLocal = 2,
+};
+
 struct Relation {
     RelationKind kind;
 
@@ -66,6 +80,8 @@ struct Symbol {
     std::string name;
 
     SymbolKind kind;
+
+    SymbolScope scope = SymbolScope::External;
 
     /// All files that referenced this symbol.
     Bitmap reference_files;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -35,6 +35,20 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
     auto file_ids_map = workspace.project_index.merge(tu_index);
     auto main_tu_path_id = static_cast<std::uint32_t>(tu_index.graph.paths.size() - 1);
 
+    // Collect non-External symbols referenced in a FileIndex.  Each file's
+    // MergedIndex shard stores exactly the local symbols its occurrences
+    // reference, so lookup is a single shard check — no scanning.
+    auto collect_local_symbols = [&](const index::FileIndex& file_idx) {
+        index::SymbolTable result;
+        for(auto& occ: file_idx.occurrences) {
+            auto it = tu_index.symbols.find(occ.target);
+            if(it != tu_index.symbols.end() && it->second.scope != index::SymbolScope::External) {
+                result.try_emplace(occ.target, it->second);
+            }
+        }
+        return result;
+    };
+
     auto merge_file_index = [&](std::uint32_t tu_path_id, index::FileIndex& file_idx) {
         auto global_path_id = file_ids_map[tu_path_id];
         auto& shard = workspace.merged_indices[global_path_id];
@@ -59,6 +73,7 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
                         std::move(include_locs),
                         file_idx,
                         file_content);
+            shard.merge_symbols(collect_local_symbols(file_idx));
         } else {
             std::optional<std::uint32_t> include_id;
             for(std::uint32_t i = 0; i < tu_index.graph.locations.size(); ++i) {
@@ -80,6 +95,7 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
                 header_content = header_content_storage;
             }
             shard.merge(global_path_id, *include_id, file_idx, header_content);
+            shard.merge_symbols(collect_local_symbols(file_idx));
         }
     };
 
@@ -88,9 +104,13 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
     }
     merge_file_index(main_tu_path_id, tu_index.main_file_index);
 
-    LOG_INFO("Merged TUIndex: {} paths, {} symbols, {} merged_shards",
+    auto external_count = std::ranges::count_if(tu_index.symbols, [](auto& kv) {
+        return kv.second.scope == index::SymbolScope::External;
+    });
+    LOG_INFO("Merged TUIndex: {} paths, {} symbols ({} external), {} merged_shards",
              tu_index.graph.paths.size(),
              tu_index.symbols.size(),
+             external_count,
              workspace.merged_indices.size());
 }
 
@@ -244,8 +264,11 @@ bool Indexer::need_update(llvm::StringRef file_path) {
 }
 
 bool Indexer::find_symbol_info(index::SymbolHash hash, std::string& name, SymbolKind& kind) const {
+    // Check open sessions first (has all symbols for unsaved buffers).
     bool found = false;
     foreach_session([&](std::uint32_t, const Session& session) -> bool {
+        if(!session.symbols)
+            return true;
         auto it = session.symbols->find(hash);
         if(it != session.symbols->end()) {
             name = it->second.name;
@@ -257,11 +280,21 @@ bool Indexer::find_symbol_info(index::SymbolHash hash, std::string& name, Symbol
     });
     if(found)
         return true;
+
+    // Check ProjectIndex (external symbols).
     auto it = workspace.project_index.symbols.find(hash);
     if(it != workspace.project_index.symbols.end()) {
         name = it->second.name;
         kind = it->second.kind;
         return true;
+    }
+
+    // Check per-file MergedIndex shards (TU-local + file-local symbols).
+    // Each shard stores exactly the local symbols its occurrences reference,
+    // so the symbol will be in the shard that produced the occurrence.
+    for(auto& [path_id, shard]: workspace.merged_indices) {
+        if(shard.find_symbol(hash, name, kind))
+            return true;
     }
     return false;
 }

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -357,6 +357,83 @@ TEST_CASE(CacheInvalidatedAfterMerge) {
     ASSERT_TRUE(found_second);
 }
 
+TEST_CASE(LocalSymbolTable) {
+    build_index(R"(
+            void foo() { int local = 42; }
+            int global = 0;
+        )");
+
+    index::MergedIndex merged;
+    auto main_path_id = static_cast<std::uint32_t>(tu_index.graph.paths.size() - 1);
+    merged.merge(main_path_id, tu_index.built_at, {}, tu_index.main_file_index, "");
+
+    // Collect non-External symbols from the TU that appear in the FileIndex.
+    index::SymbolTable local_syms;
+    for(auto& occ: tu_index.main_file_index.occurrences) {
+        auto it = tu_index.symbols.find(occ.target);
+        if(it != tu_index.symbols.end() && it->second.scope != index::SymbolScope::External) {
+            local_syms.try_emplace(occ.target, it->second);
+        }
+    }
+    merged.merge_symbols(local_syms);
+
+    // FileLocal symbols should be findable in the shard.
+    std::string name;
+    SymbolKind kind;
+    bool found_local = false;
+    for(auto& [hash, symbol]: local_syms) {
+        if(symbol.name == "local") {
+            ASSERT_TRUE(merged.find_symbol(hash, name, kind));
+            ASSERT_EQ(name, "local");
+            found_local = true;
+        }
+    }
+    ASSERT_TRUE(found_local);
+
+    // External symbol should NOT be in the shard's local table.
+    for(auto& [hash, symbol]: tu_index.symbols) {
+        if(symbol.name == "global") {
+            ASSERT_FALSE(merged.find_symbol(hash, name, kind));
+        }
+    }
+}
+
+TEST_CASE(LocalSymbolSerialization) {
+    build_index(R"(
+            static int static_var = 0;
+            void foo() { int local = 1; }
+        )");
+
+    index::MergedIndex merged;
+    auto main_path_id = static_cast<std::uint32_t>(tu_index.graph.paths.size() - 1);
+    merged.merge(main_path_id, tu_index.built_at, {}, tu_index.main_file_index, "");
+
+    index::SymbolTable local_syms;
+    for(auto& occ: tu_index.main_file_index.occurrences) {
+        auto it = tu_index.symbols.find(occ.target);
+        if(it != tu_index.symbols.end() && it->second.scope != index::SymbolScope::External) {
+            local_syms.try_emplace(occ.target, it->second);
+        }
+    }
+    merged.merge_symbols(local_syms);
+
+    // Serialize and deserialize.
+    llvm::SmallString<4096> buf;
+    {
+        llvm::raw_svector_ostream os(buf);
+        merged.serialize(os);
+    }
+    auto restored = index::MergedIndex(llvm::StringRef(buf.data(), buf.size()));
+
+    // Symbols should survive round-trip (via buffer path).
+    std::string name;
+    SymbolKind kind;
+    for(auto& [hash, symbol]: local_syms) {
+        ASSERT_TRUE(restored.find_symbol(hash, name, kind));
+        ASSERT_EQ(name, symbol.name);
+    }
+}
+
 };  // TEST_SUITE(MergedIndex)
 }  // namespace
 }  // namespace clice::testing

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -375,6 +375,7 @@ TEST_CASE(LocalSymbolTable) {
             local_syms.try_emplace(occ.target, it->second);
         }
     }
+    ASSERT_FALSE(local_syms.empty());
     merged.merge_symbols(local_syms);
 
     // FileLocal symbols should be findable in the shard.
@@ -415,6 +416,7 @@ TEST_CASE(LocalSymbolSerialization) {
             local_syms.try_emplace(occ.target, it->second);
         }
     }
+    ASSERT_FALSE(local_syms.empty());
     merged.merge_symbols(local_syms);
 
     // Serialize and deserialize.

--- a/tests/unit/index/project_index_tests.cpp
+++ b/tests/unit/index/project_index_tests.cpp
@@ -33,9 +33,11 @@ TEST_CASE(MergeSingleTU) {
     // Symbols from the TU should be merged into the project.
     ASSERT_FALSE(project.symbols.empty());
 
-    // Every symbol from the TU should be in the project.
+    // Only External symbols should be in the project.
     for(auto& [hash, symbol]: tu.symbols) {
-        ASSERT_TRUE(project.symbols.contains(hash));
+        if(symbol.scope == index::SymbolScope::External) {
+            ASSERT_TRUE(project.symbols.contains(hash));
+        }
     }
 }
 
@@ -197,6 +199,58 @@ TEST_CASE(NameSurvivesRoundTrip) {
         ASSERT_TRUE(restored.symbols.contains(hash));
         ASSERT_EQ(restored.symbols[hash].name, symbol.name);
         ASSERT_EQ(restored.symbols[hash].kind.value(), symbol.kind.value());
+    }
+}
+
+TEST_CASE(LocalSymbolsExcluded) {
+    index::TUIndex tu;
+    ASSERT_TRUE(build_and_index(R"(
+            int global = 0;
+            static int file_static = 1;
+            void foo() { int local = 2; }
+        )",
+                                tu));
+
+    index::ProjectIndex project;
+    project.merge(tu);
+
+    // global (External) should be in ProjectIndex.
+    bool found_global = false;
+    bool found_static = false;
+    bool found_local = false;
+    for(auto& [hash, symbol]: project.symbols) {
+        if(symbol.name == "global")
+            found_global = true;
+        if(symbol.name == "file_static")
+            found_static = true;
+        if(symbol.name == "local")
+            found_local = true;
+    }
+    ASSERT_TRUE(found_global);
+    ASSERT_FALSE(found_static);
+    ASSERT_FALSE(found_local);
+}
+
+TEST_CASE(ScopeRoundTrip) {
+    index::TUIndex tu;
+    ASSERT_TRUE(build_and_index(R"(
+            int external_var = 0;
+            static int tu_local_var = 1;
+            void foo() { int file_local_var = 2; }
+        )",
+                                tu));
+
+    index::ProjectIndex project;
+    project.merge(tu);
+
+    llvm::SmallString<4096> buf;
+    llvm::raw_svector_ostream os(buf);
+    project.serialize(os);
+    auto restored = index::ProjectIndex::from(buf.data());
+
+    for(auto& [hash, symbol]: project.symbols) {
+        ASSERT_TRUE(restored.symbols.contains(hash));
+        ASSERT_EQ(static_cast<int>(restored.symbols[hash].scope), static_cast<int>(symbol.scope));
     }
 }
 

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -642,14 +642,21 @@ TEST_CASE(ScopeExternal) {
             namespace ns { int ns_var = 1; }
         )");
 
+    std::set<std::string> expected{"global_var",
+                                   "global_func",
+                                   "GlobalClass",
+                                   "member",
+                                   "ns_var",
+                                   "ns"};
+    std::set<std::string> found;
     for(auto& [hash, symbol]: tu_index.symbols) {
-        if(symbol.name == "global_var" || symbol.name == "global_func" ||
-           symbol.name == "GlobalClass" || symbol.name == "member" || symbol.name == "ns_var" ||
-           symbol.name == "ns") {
+        if(expected.contains(symbol.name)) {
             ASSERT_EQ(static_cast<int>(symbol.scope),
                       static_cast<int>(index::SymbolScope::External));
+            found.insert(symbol.name);
         }
     }
+    ASSERT_EQ(found, expected);
 }
 
 TEST_CASE(ScopeFileLocal) {
@@ -660,12 +667,16 @@ TEST_CASE(ScopeFileLocal) {
             void bar(int param) {}
         )");
 
+    std::set<std::string> expected{"local_var", "param"};
+    std::set<std::string> found;
     for(auto& [hash, symbol]: tu_index.symbols) {
-        if(symbol.name == "local_var" || symbol.name == "param") {
+        if(expected.contains(symbol.name)) {
             ASSERT_EQ(static_cast<int>(symbol.scope),
                       static_cast<int>(index::SymbolScope::FileLocal));
+            found.insert(symbol.name);
         }
     }
+    ASSERT_EQ(found, expected);
 }
 
 TEST_CASE(ScopeTULocal) {
@@ -675,13 +686,16 @@ TEST_CASE(ScopeTULocal) {
             namespace { int anon_var = 1; }
         )");
 
+    std::set<std::string> expected{"static_var", "static_func", "anon_var"};
+    std::set<std::string> found;
     for(auto& [hash, symbol]: tu_index.symbols) {
-        if(symbol.name == "static_var" || symbol.name == "static_func" ||
-           symbol.name == "anon_var") {
+        if(expected.contains(symbol.name)) {
             ASSERT_EQ(static_cast<int>(symbol.scope),
                       static_cast<int>(index::SymbolScope::TULocal));
+            found.insert(symbol.name);
         }
     }
+    ASSERT_EQ(found, expected);
 }
 
 };  // TEST_SUITE(tu_index)

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -634,6 +634,56 @@ TEST_CASE(LookupRelation) {
     EXPECT_FALSE(found_any);
 }
 
+TEST_CASE(ScopeExternal) {
+    build_index(R"(
+            int global_var = 0;
+            void global_func() {}
+            struct GlobalClass { int member; };
+            namespace ns { int ns_var = 1; }
+        )");
+
+    for(auto& [hash, symbol]: tu_index.symbols) {
+        if(symbol.name == "global_var" || symbol.name == "global_func" ||
+           symbol.name == "GlobalClass" || symbol.name == "member" || symbol.name == "ns_var" ||
+           symbol.name == "ns") {
+            ASSERT_EQ(static_cast<int>(symbol.scope),
+                      static_cast<int>(index::SymbolScope::External));
+        }
+    }
+}
+
+TEST_CASE(ScopeFileLocal) {
+    build_index(R"(
+            void foo() {
+                int local_var = 42;
+            }
+            void bar(int param) {}
+        )");
+
+    for(auto& [hash, symbol]: tu_index.symbols) {
+        if(symbol.name == "local_var" || symbol.name == "param") {
+            ASSERT_EQ(static_cast<int>(symbol.scope),
+                      static_cast<int>(index::SymbolScope::FileLocal));
+        }
+    }
+}
+
+TEST_CASE(ScopeTULocal) {
+    build_index(R"(
+            static int static_var = 0;
+            static void static_func() {}
+            namespace { int anon_var = 1; }
+        )");
+
+    for(auto& [hash, symbol]: tu_index.symbols) {
+        if(symbol.name == "static_var" || symbol.name == "static_func" ||
+           symbol.name == "anon_var") {
+            ASSERT_EQ(static_cast<int>(symbol.scope),
+                      static_cast<int>(index::SymbolScope::TULocal));
+        }
+    }
+}
+
 };  // TEST_SUITE(tu_index)
 
 }  // namespace


### PR DESCRIPTION
## Summary

- Classify symbols into three scopes via `clang::getFormalLinkage()`: **External** (cross-TU), **TULocal** (internal linkage), **FileLocal** (no linkage)
- Only External symbols go into `ProjectIndex`, reducing merge overhead by keeping local symbols out of the global HashMap
- Each file's `MergedIndex` shard stores the non-External symbols its occurrences reference, enabling direct lookup without scanning
- FlatBuffer schema updated: `Symbol` gains a `scope` field, `MergedIndex` gains a per-shard `symbols` table

## Test plan

- [x] `tu_index.ScopeExternal/FileLocal/TULocal` — verify `classify_scope()` classification
- [x] `ProjectIndex.LocalSymbolsExcluded` — verify non-External symbols filtered from ProjectIndex
- [x] `ProjectIndex.ScopeRoundTrip` — scope survives serialization
- [x] `MergedIndex.LocalSymbolTable` — local symbols stored and retrievable from shard
- [x] `MergedIndex.LocalSymbolSerialization` — local symbols survive shard round-trip
- [x] All 715 unit tests, 178 integration tests, 3 smoke tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added symbol scope support, distinguishing external, TU-local, and file-local symbols.
  * Improved symbol lookup so local symbols can be found in shard-level indices.
  * Preserved symbol metadata through save/load cycles for more complete index data.

* **Bug Fixes**
  * Fixed merging so only externally visible symbols are included in the project-wide symbol set.
  * Ensured symbol scope is retained after serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->