### PR TITLE
fix(server): update kotatsu and fix related workarounds

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -41,7 +41,7 @@ set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG 0b38494
+    GIT_TAG 02b255f
 )
 
 set(KOTA_ENABLE_ZEST ON)

--- a/src/server/compiler/compile_graph.cpp
+++ b/src/server/compiler/compile_graph.cpp
@@ -121,7 +121,10 @@ void CompileGraph::release(std::uint32_t path_id) {
 }
 
 kota::task<> CompileGraph::zero_interest_check(std::uint32_t path_id) {
-    co_await kota::sleep(0);
+    // Resumes on the next event-loop iteration, strictly after every deferred
+    // resume of the current one — i.e. after the release/re-acquire cascade
+    // that scheduled this check has fully settled.
+    co_await kota::yield();
 
     auto& unit = units.find(path_id)->second;
     unit.zero_check_pending = false;

--- a/src/server/compiler/compile_graph.h
+++ b/src/server/compiler/compile_graph.h
@@ -194,10 +194,8 @@ private:
     resolve_fn resolve;
     llvm::DenseMap<std::uint32_t, CompileUnit> units;
 
-    /// Owns every unit task; structured shutdown via shutdown().
-    /// Note: kota::task_group only reclaims completed child frames on
-    /// destruction, so frames accumulate over the graph's lifetime — one per
-    /// compilation round, same trade-off as Compiler::compile_tasks.
+    /// Owns every unit task; structured shutdown via shutdown(). Completed
+    /// child frames are reclaimed eagerly by the group.
     kota::task_group<> tasks;
 };
 

--- a/tests/unit/server/compile_graph_tests.cpp
+++ b/tests/unit/server/compile_graph_tests.cpp
@@ -278,10 +278,6 @@ TEST_CASE(concurrent_requests_share_round) {
             co_await md.gate(1).started.wait();
             EXPECT_EQ(graph->refcount(1), 2u);
             md.gate(1).proceed.set();
-            // Suspend once before finishing: a when_all child that completes
-            // synchronously during the arm phase trips a when_any bookkeeping
-            // assert downstream (kotatsu bug, pending an upstream fix).
-            co_await kota::sleep(0);
             co_return;
         };
 
@@ -1086,9 +1082,6 @@ TEST_CASE(shared_dep_failure_propagates) {
             co_await md.gate(5).started.wait();
             EXPECT_EQ(graph->refcount(5), 2u);
             md.gate(5).proceed.set();
-            // Suspend once before finishing (kotatsu when_all arm bug, see
-            // concurrent_requests_share_round).
-            co_await kota::sleep(0);
             co_return;
         };
 
@@ -1682,7 +1675,7 @@ TEST_CASE(randomized_stress) {
             }
 
             // Let deferred unwinds land, then check structural sanity.
-            co_await kota::sleep(0);
+            co_await kota::yield();
             EXPECT_TRUE(graph->consistent());
         }
 


### PR DESCRIPTION
## Summary
- Bump kotatsu from `0b38494` to `02b255f` (upstream `refactor(async): redesign runtime state machine, unify cancellation semantics #173`)
- Replace `kota::sleep(0)` with `kota::yield()` for clearer event-loop deferral semantics
- Remove two `co_await kota::sleep(0)` workarounds for the now-fixed `when_all` arm-phase bug
- Update `task_group` comment to reflect eager child-frame reclamation

## Test plan
- [x] Unit tests pass locally (715/715)
- [x] Smoke tests pass locally (3/3)
- [x] Integration tests pass in CI