### PR TITLE
refactor(server): event-driven invalidation engine

### DIFF
--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -8,8 +8,6 @@
 #include <utility>
 
 #include "command/argument_parser.h"
-#include "command/search_config.h"
-#include "compile/diagnostic.h"
 #include "index/tu_index.h"
 #include "server/context/context_resolver.h"
 #include "server/protocol/extension.h"
@@ -18,7 +16,6 @@
 #include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/timer.h"
-#include "syntax/include_resolver.h"
 #include "syntax/scan.h"
 
 #include "kota/async/async.h"
@@ -52,29 +49,6 @@ static std::string cache_key(std::initializer_list<llvm::StringRef> parts) {
     }
     auto hash = llvm::xxh3_128bits(llvm::arrayRefFromStringRef(input));
     return std::format("{:016x}{:016x}", hash.high64, hash.low64);
-}
-
-/// Diagnostic codes that strictly indicate a missing includer context (as
-/// opposed to ordinary in-progress typing errors). Deliberately narrow:
-/// a false positive costs a pointless prefix synthesis, a false negative
-/// just leaves the header in trial mode.
-static bool indicates_missing_context(llvm::ArrayRef<protocol::Diagnostic> diagnostics) {
-    constexpr static llvm::StringRef codes[] = {
-        "err_unknown_typename",
-        "err_undeclared_var_use",
-        "err_undeclared_var_use_suggest",
-        "err_pp_unterminated_conditional",
-    };
-    for(auto& diag: diagnostics) {
-        if(diag.severity != protocol::DiagnosticSeverity::Error || !diag.code.has_value()) {
-            continue;
-        }
-        auto* code = std::get_if<std::string>(&*diag.code);
-        if(code && llvm::is_contained(codes, *code)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 /// RAII completion of an in-flight PCH build registration: wakes waiters
@@ -126,8 +100,6 @@ static lsp::LineMap::Offset clamped_offset(const lsp::LineMap& map,
     }
     return map.line_bounds(starts[position.line]).end;
 }
-
-/// Detect whether the cursor is inside a preamble directive (include/import).
 
 Compiler::Compiler(kota::event_loop& loop,
                    Workspace& workspace,
@@ -200,7 +172,7 @@ void Compiler::init_compile_graph() {
         worker::BuildParams bp;
         bp.kind = worker::BuildKind::BuildPCM;
         bp.file = file_path;
-        fill_compile_args(file_path, bp.directory, bp.arguments);
+        contexts.resolve_command(file_path, bp.directory, bp.arguments);
 
         if(!workspace.store) {
             LOG_WARN("BuildPCM skipped for module {}: cache store is unavailable", mod_it->second);
@@ -295,95 +267,6 @@ void Compiler::init_compile_graph() {
     LOG_INFO("CompileGraph initialized with {} module(s)", workspace.path_to_module.size());
 }
 
-/// Per-file command selection decision log: which tiers were tried, which one
-/// was hit, and a hash of the final command for correlating later failures.
-static void log_command_decision(llvm::StringRef path,
-                                 llvm::ArrayRef<llvm::StringRef> tried,
-                                 CommandSource source,
-                                 llvm::ArrayRef<std::string> arguments) {
-    if(logging::options.level > logging::Level::info)
-        return;
-    std::string joined;
-    for(auto& arg: arguments) {
-        joined += arg;
-        joined += '\0';
-    }
-    LOG_INFO("compile_args: file={} tried=[{}] source={} args_hash={:016x}",
-             path,
-             llvm::join(tried, ","),
-             source,
-             llvm::xxh3_64bits(llvm::StringRef(joined)));
-}
-
-CommandSource Compiler::fill_compile_args(llvm::StringRef path,
-                                          std::string& directory,
-                                          std::vector<std::string>& arguments,
-                                          Session* session) {
-    auto path_id = workspace.path_pool.intern(path);
-    llvm::SmallVector<llvm::StringRef, 3> tried;
-
-    // Fill from the CDB layer with config rules applied (append/remove flags
-    // based on file patterns). Also used for tier 4: lookup() synthesizes a
-    // default command for files without an entry.
-    auto fill_from_cdb = [&] {
-        std::vector<std::string> rule_append, rule_remove;
-        workspace.config.match_rules(path, rule_append, rule_remove);
-        auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
-        auto* cmd = &results.front();
-        // Multi-config projects: honor the user's chosen CDB entry, matched
-        // by canonical command hash so the choice survives CDB reordering.
-        if(session && session->active_command.has_value()) {
-            for(auto& candidate: results) {
-                if(canonical_command_hash(candidate.to_string_argv(),
-                                          candidate.resolved.directory) ==
-                   *session->active_command) {
-                    cmd = &candidate;
-                    break;
-                }
-            }
-        }
-        workspace.toolchain.resolve_or_warn(*cmd);
-        directory = cmd->resolved.directory.str();
-        arguments = cmd->to_string_argv();
-    };
-
-    // 1. If the session has an active header context via switchContext,
-    //    use the host source's CDB entry with file path replaced and preamble injected.
-    if(session && session->active_context.has_value()) {
-        tried.push_back("switch_context");
-        if(contexts.fill_header_context_args(path, path_id, directory, arguments, session)) {
-            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
-            return CommandSource::IncludeGraph;
-        }
-    }
-
-    // 2. Real CDB entry for the file itself (lookup() synthesizes a command
-    //    for unknown files, so a non-empty result alone proves nothing).
-    tried.push_back("cdb");
-    if(workspace.cdb.has_entry(path)) {
-        fill_from_cdb();
-        log_command_decision(path, tried, CommandSource::CDBExact, arguments);
-        return CommandSource::CDBExact;
-    }
-
-    // 3. No CDB entry — try automatic header context resolution.
-    if(!(session && session->active_context.has_value())) {
-        tried.push_back("include_graph");
-        if(contexts.fill_header_context_args(path, path_id, directory, arguments, session)) {
-            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
-            return CommandSource::IncludeGraph;
-        }
-    }
-
-    // 4. Nothing matched — use the default command the CDB layer synthesizes
-    //    for unknown files, so the file still compiles and produces
-    //    diagnostics instead of failing silently.
-    tried.push_back("fallback");
-    fill_from_cdb();
-    log_command_decision(path, tried, CommandSource::Fallback, arguments);
-    return CommandSource::Fallback;
-}
-
 std::string uri_to_path(const std::string& uri) {
     auto parsed = lsp::URI::parse(uri);
     if(parsed.has_value()) {
@@ -393,119 +276,6 @@ std::string uri_to_path(const std::string& uri) {
         }
     }
     return uri;
-}
-
-/// Clang diagnostics indicating that an input file could not be found —
-/// the symptom of a guessed compile command missing include paths.
-static bool is_file_not_found(const protocol::Diagnostic& diagnostic) {
-    if(!diagnostic.code.has_value())
-        return false;
-    auto* code = std::get_if<protocol::string>(&*diagnostic.code);
-    return code && (*code == "err_pp_file_not_found" || *code == "err_pp_error_opening_file" ||
-                    *code == "err_module_not_found");
-}
-
-/// File-top warning explaining that diagnostics were produced with a guessed
-/// compile command, pointing at the compilation database documentation.
-static protocol::Diagnostic make_inferred_command_diagnostic(CommandSource source) {
-    DiagnosticID id{
-        .value = 0,
-        .level = DiagnosticLevel::Warning,
-        .source = DiagnosticSource::Clice,
-        .name = "inferred-compile-command",
-    };
-
-    protocol::Diagnostic diagnostic;
-    diagnostic.range = protocol::Range{
-        .start = protocol::Position{.line = 0, .character = 0},
-        .end = protocol::Position{.line = 0, .character = 0},
-    };
-    diagnostic.severity = protocol::DiagnosticSeverity::Warning;
-    diagnostic.code = id.name.str();
-    if(auto uri = id.diagnostic_document_uri()) {
-        diagnostic.code_description = protocol::CodeDescription{.href = std::move(*uri)};
-    }
-    diagnostic.source = "clice";
-    diagnostic.message = std::format(
-        "No compilation database entry for this file (compile command was {}), so some includes " "may not be found. Configure compile_commands.json for accurate diagnostics.",
-        source == CommandSource::Fallback ? "synthesized from defaults"
-                                          : "inferred from an including file");
-    return diagnostic;
-}
-
-std::vector<protocol::Diagnostic> format_diagnostics(const CompileOutput& output) {
-    std::vector<protocol::Diagnostic> diagnostics;
-    if(!output.diagnostics.empty()) {
-        auto status = kota::codec::json::from_json(output.diagnostics.data, diagnostics);
-        if(!status) {
-            LOG_WARN("Failed to deserialize diagnostics JSON");
-        }
-    }
-
-    // Suffix injection appends an #include past the user's EOF; errors in
-    // host code after the include point remap onto those phantom lines.
-    // They describe the includer, not the document — drop them.
-    if(output.line_limit.has_value()) {
-        std::erase_if(diagnostics, [&](const protocol::Diagnostic& d) {
-            return d.range.start.line >= *output.line_limit;
-        });
-    }
-
-    // Guidance (and only when it can explain something): an exact CDB match
-    // never gets the note, and neither does a guessed command that worked.
-    if(output.source != CommandSource::CDBExact &&
-       std::ranges::any_of(diagnostics, is_file_not_found)) {
-        diagnostics.insert(diagnostics.begin(), make_inferred_command_diagnostic(output.source));
-    }
-
-    return diagnostics;
-}
-
-/// Append the header context's suffix as one trailing #include line: the
-/// suffix content (everything after the include position along the chain)
-/// lives in its own file so features never see it, while the token stream
-/// still closes any braces the fragment is embedded in. The single extra
-/// line sits past the editor's EOF and is invisible to the client.
-void Compiler::append_suffix_include(const Session& session, std::string& text) {
-    if(!session.header_context.has_value() || session.header_context->suffix_path.empty()) {
-        return;
-    }
-    if(!text.ends_with('\n')) {
-        text += '\n';
-    }
-    text += "#include \"";
-    // Escape like preamble_synthesis's line markers: Windows separators
-    // must survive the preprocessor's string literal parsing.
-    for(char c: session.header_context->suffix_path) {
-        if(c == '\\' || c == '"') {
-            text += '\\';
-        }
-        text += c;
-    }
-    text += "\"\n";
-}
-
-std::vector<protocol::Range> format_inactive_regions(const Session& session,
-                                                     const CompileOutput& output) {
-    std::vector<protocol::Range> result;
-    if(!output.inactive_regions.has_value()) {
-        return result;
-    }
-    auto& regions = *output.inactive_regions;
-    auto map = session.line_map();
-    result.reserve(regions.size() / 2);
-    for(std::size_t i = 0; i + 1 < regions.size(); i += 2) {
-        auto start = map.to_position(regions[i]);
-        auto end = map.to_position(regions[i + 1]);
-        if(!start || !end) {
-            continue;
-        }
-        protocol::Range range;
-        range.start = *start;
-        range.end = *end;
-        result.push_back(range);
-    }
-    return result;
 }
 
 kota::task<bool> Compiler::ensure_pch(Session& session,
@@ -834,7 +604,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         params.version = session->version;
         params.text = session->text;
         auto source =
-            fill_compile_args(file_path, params.directory, params.arguments, session.get());
+            contexts.resolve_command(file_path, params.directory, params.arguments, session.get());
 
         // The line the appended suffix #include lands on — anything at or
         // past it is phantom text the user cannot see.
@@ -844,7 +614,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             suffix_line_limit =
                 static_cast<std::uint32_t>(newlines + (params.text.ends_with('\n') ? 0 : 1));
         }
-        append_suffix_include(*session, params.text);
+        contexts.append_suffix_include(*session, params.text);
 
         bool deps_ok = co_await ensure_deps(*session,
                                             params.directory,
@@ -1172,8 +942,8 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     wp.file = path;
     wp.version = session->version;
     wp.text = session->text;
-    fill_compile_args(path, wp.directory, wp.arguments, session.get());
-    append_suffix_include(*session, wp.text);
+    contexts.resolve_command(path, wp.directory, wp.arguments, session.get());
+    contexts.append_suffix_include(*session, wp.text);
 
     ScopedTimer timer;
     if(!co_await ensure_deps(*session, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
@@ -1238,63 +1008,6 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
     LOG_PERF("request", "kind=Format file={} total_ms={}", path, timer.ms());
     co_return std::move(result.value().result_json);
-}
-
-Compiler::RawResult Compiler::handle_completion(const protocol::Position& position,
-                                                std::shared_ptr<Session> session) {
-    auto path_id = session->path_id;
-    auto path = std::string(workspace.path_pool.resolve(path_id));
-
-    auto map = session->line_map();
-    auto offset = map.to_offset(position);
-    if(offset) {
-        auto pctx = detect_completion_context(session->text, *offset);
-        if(pctx.kind == CompletionContext::IncludeQuoted ||
-           pctx.kind == CompletionContext::IncludeAngled) {
-            std::string directory;
-            std::vector<std::string> arguments;
-            fill_compile_args(path, directory, arguments);
-
-            std::vector<const char*> args_ptrs;
-            args_ptrs.reserve(arguments.size());
-            for(auto& arg: arguments)
-                args_ptrs.push_back(arg.c_str());
-
-            auto search_config = extract_search_config(args_ptrs, directory);
-            DirListingCache dir_cache;
-            auto resolved = resolve_search_config(search_config, dir_cache);
-            bool angled = (pctx.kind == CompletionContext::IncludeAngled);
-            auto candidates = complete_include_path(resolved, pctx.prefix, angled, dir_cache);
-
-            std::vector<protocol::CompletionItem> items;
-            items.reserve(candidates.size());
-            for(auto& c: candidates) {
-                protocol::CompletionItem item;
-                item.label = c.is_directory ? c.name + "/" : c.name;
-                item.kind = protocol::CompletionItemKind::File;
-                items.push_back(std::move(item));
-            }
-            auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(items);
-            co_return serde_raw{json ? std::move(*json) : "[]"};
-        }
-        if(pctx.kind == CompletionContext::Import) {
-            auto module_names = complete_module_import(workspace.path_to_module, pctx.prefix);
-
-            std::vector<protocol::CompletionItem> items;
-            items.reserve(module_names.size());
-            for(auto& name: module_names) {
-                protocol::CompletionItem item;
-                item.label = name;
-                item.kind = protocol::CompletionItemKind::Module;
-                item.insert_text = name + ";";
-                items.push_back(std::move(item));
-            }
-            auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(items);
-            co_return serde_raw{json ? std::move(*json) : "[]"};
-        }
-    }
-
-    co_return co_await forward_build(worker::BuildKind::Completion, position, std::move(session));
 }
 
 }  // namespace clice

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -12,7 +12,6 @@
 #include "server/worker/worker_pool.h"
 #include "server/workspace/workspace.h"
 #include "support/signal.h"
-#include "syntax/completion.h"
 
 #include "kota/async/async.h"
 #include "kota/codec/json/json.h"
@@ -30,23 +29,6 @@ class ContextResolver;
 
 /// Convert a file:// URI to a local file path.
 std::string uri_to_path(const std::string& uri);
-
-/// Where the compile command for a file came from. Anything other than
-/// CDBExact means the command was guessed to some degree, which is why
-/// diagnostics produced with it may deserve a guidance note (see
-/// format_diagnostics).
-enum class CommandSource : std::uint8_t {
-    /// Direct compilation database entry for the file.
-    CDBExact,
-    /// Header compiled in the context of a host source found through the
-    /// include graph (automatic or via clice/switchContext).
-    IncludeGraph,
-    /// Reserved for command transfer heuristics (e.g. nearest CDB entry);
-    /// no producer yet.
-    Inferred,
-    /// Synthesized default command — no CDB entry and no usable host source.
-    Fallback,
-};
 
 /// Compilation service — drives worker processes to build ASTs, PCHs, and PCMs.
 ///
@@ -75,16 +57,6 @@ public:
     ~Compiler();
 
     void init_compile_graph();
-
-    /// Fill compile arguments for a file and report where they came from.
-    /// Tries, in order: CDB entry, header context through the include graph,
-    /// and finally a synthesized fallback command — so it always succeeds.
-    /// Emits a per-file decision log (tiers tried, tier hit, command hash).
-    /// @param session  If non-null, used for header context resolution on open files.
-    CommandSource fill_compile_args(llvm::StringRef path,
-                                    std::string& directory,
-                                    std::vector<std::string>& arguments,
-                                    Session* session = nullptr);
 
     /// Compile an open file's AST if dirty.  On success, updates session's
     /// file_index, pch_ref, ast_deps, and publishes diagnostics.
@@ -117,11 +89,6 @@ public:
     RawResult forward_format(std::shared_ptr<Session> session,
                              std::optional<protocol::Range> range = {});
 
-    /// Handle completion requests.  Detects preamble context (include/import)
-    /// and serves those locally; delegates code completion to a stateless worker.
-    RawResult handle_completion(const protocol::Position& position,
-                                std::shared_ptr<Session> session);
-
     /// Emitted after a compile round materializes its publishable products
     /// into the session's `output` field (both success and the failure/
     /// clear path). Subscribers read the output from the session; with no
@@ -153,26 +120,11 @@ private:
     bool is_stale(const Session& session);
     void record_deps(Session& session, llvm::ArrayRef<std::string> deps);
 
-    static void append_suffix_include(const Session& session, std::string& text);
-
     kota::event_loop& loop;
     Workspace& workspace;
     ContextResolver& contexts;
     WorkerPool& pool;
     kota::task_group<> compile_tasks{loop};
 };
-
-/// Format a materialized compile output into publishable diagnostics:
-/// deserialize the worker's raw diagnostics, drop phantom suffix-include
-/// lines, and — when the compile command was not an exact CDB match and
-/// the diagnostics contain file-not-found class errors — merge a file-top
-/// guidance diagnostic explaining the inferred command. Formatting is
-/// compile semantics; sending the result is the transport's job.
-std::vector<protocol::Diagnostic> format_diagnostics(const CompileOutput& output);
-
-/// Convert a compile output's inactive-region byte offsets into LSP ranges
-/// using the session's line map.
-std::vector<protocol::Range> format_inactive_regions(const Session& session,
-                                                     const CompileOutput& output);
 
 }  // namespace clice

--- a/src/server/context/context_resolver.cpp
+++ b/src/server/context/context_resolver.cpp
@@ -9,6 +9,7 @@
 
 #include "command/argument_parser.h"
 #include "command/search_config.h"
+#include "server/session/session_store.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
 #include "syntax/include_resolver.h"
@@ -609,6 +610,39 @@ void ContextResolver::restore_saved_context(Session& session) {
             workspace.saved_contexts.erase(it);
         }
     }
+}
+
+bool ContextResolver::drop_orphaned_choices(SessionStore& sessions) {
+    bool dropped_saved = false;
+    for(auto& [session_id, session]: sessions.sessions) {
+        if(!session->active_context.has_value()) {
+            continue;
+        }
+        auto host_id = session->active_context->host_path_id;
+        auto& occurrence = session->active_context->occurrence;
+        bool orphaned = workspace.dep_graph.find_include_chain(host_id, session_id).empty();
+        // A pinned occurrence can vanish while other inclusions of the
+        // header survive (the chain stays non-empty) — recount it.
+        if(!orphaned && occurrence.has_value()) {
+            auto count = workspace.count_occurrences(host_id, session_id);
+            orphaned = count > 0 && *occurrence >= count;
+        }
+        if(orphaned) {
+            LOG_INFO("Dropping orphaned context choice for {}: host {} no longer includes it",
+                     workspace.path_pool.resolve(session_id),
+                     workspace.path_pool.resolve(host_id));
+            session->active_context.reset();
+            session->header_context.reset();
+            session->pch_ref.reset();
+            session->ast_dirty = true;
+            session->trial_done = false;
+            // Invalidate in-flight compiles so they cannot clobber the
+            // reset state when they finish (same as switchContext).
+            session->generation += 1;
+            dropped_saved |= workspace.saved_contexts.erase(session_id) > 0;
+        }
+    }
+    return dropped_saved;
 }
 
 ext::QueryContextResult ContextResolver::query_contexts(llvm::StringRef path,

--- a/src/server/context/context_resolver.cpp
+++ b/src/server/context/context_resolver.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "command/argument_parser.h"
 #include "command/search_config.h"
 #include "support/filesystem.h"
 #include "support/logging.h"
@@ -14,6 +15,7 @@
 #include "syntax/preamble_synthesis.h"
 
 #include "kota/ipc/lsp/uri.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -23,6 +25,45 @@
 namespace clice {
 
 namespace lsp = kota::ipc::lsp;
+
+bool indicates_missing_context(llvm::ArrayRef<protocol::Diagnostic> diagnostics) {
+    constexpr static llvm::StringRef codes[] = {
+        "err_unknown_typename",
+        "err_undeclared_var_use",
+        "err_undeclared_var_use_suggest",
+        "err_pp_unterminated_conditional",
+    };
+    for(auto& diag: diagnostics) {
+        if(diag.severity != protocol::DiagnosticSeverity::Error || !diag.code.has_value()) {
+            continue;
+        }
+        auto* code = std::get_if<std::string>(&*diag.code);
+        if(code && llvm::is_contained(codes, *code)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Per-file command selection decision log: which tiers were tried, which one
+/// was hit, and a hash of the final command for correlating later failures.
+static void log_command_decision(llvm::StringRef path,
+                                 llvm::ArrayRef<llvm::StringRef> tried,
+                                 CommandSource source,
+                                 llvm::ArrayRef<std::string> arguments) {
+    if(logging::options.level > logging::Level::info)
+        return;
+    std::string joined;
+    for(auto& arg: arguments) {
+        joined += arg;
+        joined += '\0';
+    }
+    LOG_INFO("compile_args: file={} tried=[{}] source={} args_hash={:016x}",
+             path,
+             llvm::join(tried, ","),
+             source,
+             llvm::xxh3_64bits(llvm::StringRef(joined)));
+}
 
 /// Pick the host CDB entry matching the session's pinned command hash
 /// (multi-configuration hosts), defaulting to the first entry.
@@ -183,11 +224,99 @@ bool ContextResolver::fill_header_context_args(llvm::StringRef path,
 
     arguments = header_cmd.to_string_argv();
 
-    LOG_INFO("fill_compile_args: header context for {} (host={}, preamble={})",
+    LOG_INFO("resolve_command: header context for {} (host={}, preamble={})",
              path,
              host_path,
              ctx_ptr->preamble_path);
     return true;
+}
+
+CommandSource ContextResolver::resolve_command(llvm::StringRef path,
+                                               std::string& directory,
+                                               std::vector<std::string>& arguments,
+                                               Session* session) {
+    auto path_id = workspace.path_pool.intern(path);
+    llvm::SmallVector<llvm::StringRef, 3> tried;
+
+    // Fill from the CDB layer with config rules applied (append/remove flags
+    // based on file patterns). Also used for tier 4: lookup() synthesizes a
+    // default command for files without an entry.
+    auto fill_from_cdb = [&] {
+        std::vector<std::string> rule_append, rule_remove;
+        workspace.config.match_rules(path, rule_append, rule_remove);
+        auto results = workspace.cdb.lookup(path, {.remove = rule_remove, .append = rule_append});
+        auto* cmd = &results.front();
+        // Multi-config projects: honor the user's chosen CDB entry, matched
+        // by canonical command hash so the choice survives CDB reordering.
+        if(session && session->active_command.has_value()) {
+            for(auto& candidate: results) {
+                if(canonical_command_hash(candidate.to_string_argv(),
+                                          candidate.resolved.directory) ==
+                   *session->active_command) {
+                    cmd = &candidate;
+                    break;
+                }
+            }
+        }
+        workspace.toolchain.resolve_or_warn(*cmd);
+        directory = cmd->resolved.directory.str();
+        arguments = cmd->to_string_argv();
+    };
+
+    // 1. If the session has an active header context via switchContext,
+    //    use the host source's CDB entry with file path replaced and preamble injected.
+    if(session && session->active_context.has_value()) {
+        tried.push_back("switch_context");
+        if(fill_header_context_args(path, path_id, directory, arguments, session)) {
+            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
+            return CommandSource::IncludeGraph;
+        }
+    }
+
+    // 2. Real CDB entry for the file itself (lookup() synthesizes a command
+    //    for unknown files, so a non-empty result alone proves nothing).
+    tried.push_back("cdb");
+    if(workspace.cdb.has_entry(path)) {
+        fill_from_cdb();
+        log_command_decision(path, tried, CommandSource::CDBExact, arguments);
+        return CommandSource::CDBExact;
+    }
+
+    // 3. No CDB entry — try automatic header context resolution.
+    if(!(session && session->active_context.has_value())) {
+        tried.push_back("include_graph");
+        if(fill_header_context_args(path, path_id, directory, arguments, session)) {
+            log_command_decision(path, tried, CommandSource::IncludeGraph, arguments);
+            return CommandSource::IncludeGraph;
+        }
+    }
+
+    // 4. Nothing matched — use the default command the CDB layer synthesizes
+    //    for unknown files, so the file still compiles and produces
+    //    diagnostics instead of failing silently.
+    tried.push_back("fallback");
+    fill_from_cdb();
+    log_command_decision(path, tried, CommandSource::Fallback, arguments);
+    return CommandSource::Fallback;
+}
+
+void ContextResolver::append_suffix_include(const Session& session, std::string& text) {
+    if(!session.header_context.has_value() || session.header_context->suffix_path.empty()) {
+        return;
+    }
+    if(!text.ends_with('\n')) {
+        text += '\n';
+    }
+    text += "#include \"";
+    // Escape like preamble_synthesis's line markers: Windows separators
+    // must survive the preprocessor's string literal parsing.
+    for(char c: session.header_context->suffix_path) {
+        if(c == '\\' || c == '"') {
+            text += '\\';
+        }
+        text += c;
+    }
+    text += "\"\n";
 }
 
 std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32_t header_path_id,

--- a/src/server/context/context_resolver.h
+++ b/src/server/context/context_resolver.h
@@ -16,6 +16,8 @@
 
 namespace clice {
 
+struct SessionStore;
+
 namespace protocol = kota::ipc::protocol;
 
 /// Where the compile command for a file came from. Anything other than
@@ -89,6 +91,14 @@ public:
     /// session, validating it against the current CDB and include graph and
     /// dropping it when stale.
     void restore_saved_context(Session& session);
+
+    /// Drop active context choices whose include edge no longer exists. A
+    /// stale choice suppresses automatic host resolution, so it would strand
+    /// the header on the fallback command (or silently pin its command hash
+    /// to a different host). Expects the include graph to be current (the
+    /// caller rescans on save). Returns whether any persisted choice was
+    /// removed, i.e. whether the cache snapshot needs saving.
+    bool drop_orphaned_choices(SessionStore& sessions);
 
     /// clice/queryContext: list the compilation contexts (host sources and
     /// the file's own CDB configurations) available for a file, paginated.

--- a/src/server/context/context_resolver.h
+++ b/src/server/context/context_resolver.h
@@ -16,6 +16,31 @@
 
 namespace clice {
 
+namespace protocol = kota::ipc::protocol;
+
+/// Where the compile command for a file came from. Anything other than
+/// CDBExact means the command was guessed to some degree, which is why
+/// diagnostics produced with it may deserve a guidance note (see
+/// format_diagnostics).
+enum class CommandSource : std::uint8_t {
+    /// Direct compilation database entry for the file.
+    CDBExact,
+    /// Header compiled in the context of a host source found through the
+    /// include graph (automatic or via clice/switchContext).
+    IncludeGraph,
+    /// Reserved for command transfer heuristics (e.g. nearest CDB entry);
+    /// no producer yet.
+    Inferred,
+    /// Synthesized default command — no CDB entry and no usable host source.
+    Fallback,
+};
+
+/// Diagnostic codes that strictly indicate a missing includer context (as
+/// opposed to ordinary in-progress typing errors). Deliberately narrow:
+/// a false positive costs a pointless prefix synthesis, a false negative
+/// just leaves the header in trial mode.
+bool indicates_missing_context(llvm::ArrayRef<protocol::Diagnostic> diagnostics);
+
 /// Domain logic for compilation contexts of header files.
 ///
 /// A header without its own compilation database entry borrows a host
@@ -32,6 +57,23 @@ namespace clice {
 class ContextResolver {
 public:
     explicit ContextResolver(Workspace& workspace) : workspace(workspace) {}
+
+    /// Fill compile arguments for a file and report where they came from.
+    /// Tries, in order: CDB entry, header context through the include graph,
+    /// and finally a synthesized fallback command — so it always succeeds.
+    /// Emits a per-file decision log (tiers tried, tier hit, command hash).
+    /// @param session  If non-null, used for header context resolution on open files.
+    CommandSource resolve_command(llvm::StringRef path,
+                                  std::string& directory,
+                                  std::vector<std::string>& arguments,
+                                  Session* session = nullptr);
+
+    /// Append the header context's suffix as one trailing #include line: the
+    /// suffix content (everything after the include position along the chain)
+    /// lives in its own file so features never see it, while the token stream
+    /// still closes any braces the fragment is embedded in. The single extra
+    /// line sits past the editor's EOF and is invisible to the client.
+    void append_suffix_include(const Session& session, std::string& text);
 
     /// Fill compile arguments for a header from a host source's command found
     /// through the include graph, synthesizing a preamble prefix/suffix when

--- a/src/server/feature/feature_router.cpp
+++ b/src/server/feature/feature_router.cpp
@@ -1,19 +1,40 @@
 #include "server/feature/feature_router.h"
 
 #include <algorithm>
+#include <format>
+#include <iterator>
+#include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
+#include "command/search_config.h"
 #include "semantic/relation_kind.h"
+#include "semantic/symbol_kind.h"
 #include "server/compiler/compiler.h"
+#include "server/context/context_resolver.h"
+#include "server/index/background_indexer.h"
 #include "server/protocol/serialize.h"
 #include "server/protocol/worker.h"
+#include "syntax/completion.h"
+#include "syntax/include_resolver.h"
+
+#include "kota/codec/json/json.h"
 
 namespace clice {
+
+using serde_raw = kota::codec::RawValue;
 
 /// Error response for feature requests on files with no open session.
 static kota::ipc::Error document_not_open() {
     return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Document not open"};
+}
+
+/// Error response when a call/type hierarchy item cannot be resolved back to
+/// an indexed symbol.
+static kota::ipc::Error item_not_resolved(llvm::StringRef kind) {
+    return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
+                            std::format("Failed to resolve {} item", kind)};
 }
 
 const std::vector<feature::DocumentLink>*
@@ -123,6 +144,246 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
         }
     }
     co_return std::move(raw);
+}
+
+FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
+                                              const protocol::Position& position) {
+    co_return co_await compiler.forward_query(worker::QueryKind::Hover, session, position);
+}
+
+FeatureRouter::RawResult FeatureRouter::semantic_tokens(std::shared_ptr<Session> session) {
+    co_return co_await compiler.forward_query(worker::QueryKind::SemanticTokens, session);
+}
+
+FeatureRouter::RawResult FeatureRouter::inlay_hints(std::shared_ptr<Session> session,
+                                                    const protocol::Range& range) {
+    co_return co_await compiler.forward_query(worker::QueryKind::InlayHints, session, {}, range);
+}
+
+FeatureRouter::RawResult FeatureRouter::folding_range(std::shared_ptr<Session> session) {
+    co_return co_await compiler.forward_query(worker::QueryKind::FoldingRange, session);
+}
+
+FeatureRouter::RawResult FeatureRouter::document_symbol(std::shared_ptr<Session> session) {
+    co_return co_await compiler.forward_query(worker::QueryKind::DocumentSymbol, session);
+}
+
+FeatureRouter::RawResult FeatureRouter::code_action(std::shared_ptr<Session> session) {
+    co_return co_await compiler.forward_query(worker::QueryKind::CodeAction, session);
+}
+
+FeatureRouter::RawResult FeatureRouter::completion(std::shared_ptr<Session> session,
+                                                   const protocol::Position& position) {
+    auto pause = background_indexer.scoped_pause();
+
+    auto path_id = session->path_id;
+    auto path = std::string(workspace.path_pool.resolve(path_id));
+
+    auto map = session->line_map();
+    auto offset = map.to_offset(position);
+    if(offset) {
+        auto pctx = detect_completion_context(session->text, *offset);
+        if(pctx.kind == CompletionContext::IncludeQuoted ||
+           pctx.kind == CompletionContext::IncludeAngled) {
+            std::string directory;
+            std::vector<std::string> arguments;
+            contexts.resolve_command(path, directory, arguments);
+
+            std::vector<const char*> args_ptrs;
+            args_ptrs.reserve(arguments.size());
+            for(auto& arg: arguments)
+                args_ptrs.push_back(arg.c_str());
+
+            auto search_config = extract_search_config(args_ptrs, directory);
+            DirListingCache dir_cache;
+            auto resolved = resolve_search_config(search_config, dir_cache);
+            bool angled = (pctx.kind == CompletionContext::IncludeAngled);
+            auto candidates = complete_include_path(resolved, pctx.prefix, angled, dir_cache);
+
+            std::vector<protocol::CompletionItem> items;
+            items.reserve(candidates.size());
+            for(auto& c: candidates) {
+                protocol::CompletionItem item;
+                item.label = c.is_directory ? c.name + "/" : c.name;
+                item.kind = protocol::CompletionItemKind::File;
+                items.push_back(std::move(item));
+            }
+            auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(items);
+            co_return serde_raw{json ? std::move(*json) : "[]"};
+        }
+        if(pctx.kind == CompletionContext::Import) {
+            auto module_names = complete_module_import(workspace.path_to_module, pctx.prefix);
+
+            std::vector<protocol::CompletionItem> items;
+            items.reserve(module_names.size());
+            for(auto& name: module_names) {
+                protocol::CompletionItem item;
+                item.label = name;
+                item.kind = protocol::CompletionItemKind::Module;
+                item.insert_text = name + ";";
+                items.push_back(std::move(item));
+            }
+            auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(items);
+            co_return serde_raw{json ? std::move(*json) : "[]"};
+        }
+    }
+
+    co_return co_await compiler.forward_build(worker::BuildKind::Completion,
+                                              position,
+                                              std::move(session));
+}
+
+FeatureRouter::RawResult FeatureRouter::signature_help(std::shared_ptr<Session> session,
+                                                       const protocol::Position& position) {
+    auto pause = background_indexer.scoped_pause();
+    co_return co_await compiler.forward_build(worker::BuildKind::SignatureHelp, position, session);
+}
+
+FeatureRouter::RawResult FeatureRouter::formatting(std::shared_ptr<Session> session) {
+    auto pause = background_indexer.scoped_pause();
+    co_return co_await compiler.forward_format(session);
+}
+
+FeatureRouter::RawResult FeatureRouter::range_formatting(std::shared_ptr<Session> session,
+                                                         const protocol::Range& range) {
+    auto pause = background_indexer.scoped_pause();
+    co_return co_await compiler.forward_format(session, range);
+}
+
+FeatureRouter::RawResult FeatureRouter::references(std::shared_ptr<Session> session,
+                                                   llvm::StringRef path,
+                                                   const protocol::Position& position,
+                                                   bool include_declaration) {
+    auto locations =
+        index_query.query_relations(path, position, RelationKind::Reference, session.get());
+
+    if(include_declaration) {
+        for(auto kind: {RelationKind::Declaration, RelationKind::Definition}) {
+            auto extra = index_query.query_relations(path, position, kind, session.get());
+            locations.insert(locations.end(),
+                             std::make_move_iterator(extra.begin()),
+                             std::make_move_iterator(extra.end()));
+        }
+    }
+
+    co_return to_raw(locations);
+}
+
+/// Declarations plus the definition: symbols defined inline have no
+/// separate Declaration relation, and navigating to the definition is
+/// what every client expects in that case.
+FeatureRouter::RawResult FeatureRouter::declaration(std::shared_ptr<Session> session,
+                                                    llvm::StringRef path,
+                                                    const protocol::Position& position) {
+    auto locations =
+        index_query.query_relations(path, position, RelationKind::Declaration, session.get());
+    auto defs =
+        index_query.query_relations(path, position, RelationKind::Definition, session.get());
+    locations.insert(locations.end(),
+                     std::make_move_iterator(defs.begin()),
+                     std::make_move_iterator(defs.end()));
+    co_return to_raw(locations);
+}
+
+FeatureRouter::RawResult FeatureRouter::type_definition(std::shared_ptr<Session> session,
+                                                        llvm::StringRef path,
+                                                        const protocol::Position& position) {
+    co_return to_raw(index_query.query_symbol_targets(path,
+                                                      position,
+                                                      RelationKind::TypeDefinition,
+                                                      session.get()));
+}
+
+FeatureRouter::RawResult FeatureRouter::implementation(std::shared_ptr<Session> session,
+                                                       llvm::StringRef path,
+                                                       const protocol::Position& position) {
+    co_return to_raw(index_query.query_symbol_targets(path,
+                                                      position,
+                                                      RelationKind::Implementation,
+                                                      session.get()));
+}
+
+FeatureRouter::RawResult FeatureRouter::call_hierarchy_prepare(std::shared_ptr<Session> session,
+                                                               const std::string& uri,
+                                                               llvm::StringRef path,
+                                                               const protocol::Position& position) {
+    auto info = index_query.lookup_symbol(uri, path, position, session.get());
+    if(!info)
+        co_return serde_raw{"null"};
+    if(!(info->kind == SymbolKind::Function || info->kind == SymbolKind::Method))
+        co_return serde_raw{"null"};
+
+    std::vector<protocol::CallHierarchyItem> items;
+    items.push_back(IndexQuery::build_call_hierarchy_item(*info));
+    co_return to_raw(items);
+}
+
+FeatureRouter::RawResult
+    FeatureRouter::call_hierarchy_incoming(std::shared_ptr<Session> session,
+                                           llvm::StringRef path,
+                                           const protocol::CallHierarchyItem& item) {
+    auto info =
+        index_query.resolve_hierarchy_item(item.uri, path, item.range, item.data, session.get());
+    if(!info)
+        co_return kota::outcome_error(item_not_resolved("call hierarchy"));
+    auto results = index_query.find_incoming_calls(info->hash);
+    co_return to_raw(results);
+}
+
+FeatureRouter::RawResult
+    FeatureRouter::call_hierarchy_outgoing(std::shared_ptr<Session> session,
+                                           llvm::StringRef path,
+                                           const protocol::CallHierarchyItem& item) {
+    auto info =
+        index_query.resolve_hierarchy_item(item.uri, path, item.range, item.data, session.get());
+    if(!info)
+        co_return kota::outcome_error(item_not_resolved("call hierarchy"));
+    auto results = index_query.find_outgoing_calls(info->hash);
+    co_return to_raw(results);
+}
+
+FeatureRouter::RawResult FeatureRouter::type_hierarchy_prepare(std::shared_ptr<Session> session,
+                                                               const std::string& uri,
+                                                               llvm::StringRef path,
+                                                               const protocol::Position& position) {
+    auto info = index_query.lookup_symbol(uri, path, position, session.get());
+    if(!info)
+        co_return serde_raw{"null"};
+    if(!(info->kind == SymbolKind::Class || info->kind == SymbolKind::Struct ||
+         info->kind == SymbolKind::Enum || info->kind == SymbolKind::Union))
+        co_return serde_raw{"null"};
+
+    std::vector<protocol::TypeHierarchyItem> items;
+    items.push_back(IndexQuery::build_type_hierarchy_item(*info));
+    co_return to_raw(items);
+}
+
+FeatureRouter::RawResult
+    FeatureRouter::type_hierarchy_supertypes(std::shared_ptr<Session> session,
+                                             llvm::StringRef path,
+                                             const protocol::TypeHierarchyItem& item) {
+    auto info =
+        index_query.resolve_hierarchy_item(item.uri, path, item.range, item.data, session.get());
+    if(!info)
+        co_return kota::outcome_error(item_not_resolved("type hierarchy"));
+    auto results = index_query.find_supertypes(info->hash);
+    co_return to_raw(results);
+}
+
+FeatureRouter::RawResult
+    FeatureRouter::type_hierarchy_subtypes(std::shared_ptr<Session> session,
+                                           llvm::StringRef path,
+                                           const protocol::TypeHierarchyItem& item) {
+    auto info =
+        index_query.resolve_hierarchy_item(item.uri, path, item.range, item.data, session.get());
+    if(!info)
+        co_return kota::outcome_error(item_not_resolved("type hierarchy"));
+    auto results = index_query.find_subtypes(info->hash);
+    co_return to_raw(results);
+}
+
+FeatureRouter::RawResult FeatureRouter::workspace_symbol(llvm::StringRef query) {
+    co_return to_raw(index_query.search_symbols(query));
 }
 
 }  // namespace clice

--- a/src/server/feature/feature_router.h
+++ b/src/server/feature/feature_router.h
@@ -16,6 +16,8 @@
 namespace clice {
 
 class Compiler;
+class ContextResolver;
+class BackgroundIndexer;
 
 namespace protocol = kota::ipc::protocol;
 
@@ -43,8 +45,15 @@ namespace protocol = kota::ipc::protocol;
 /// or gate results themselves.
 class FeatureRouter {
 public:
-    FeatureRouter(Compiler& compiler, IndexQuery& index_query, Workspace& workspace) :
-        compiler(compiler), index_query(index_query), workspace(workspace) {}
+    FeatureRouter(Compiler& compiler,
+                  IndexQuery& index_query,
+                  Workspace& workspace,
+                  ContextResolver& contexts,
+                  BackgroundIndexer& background_indexer) :
+        compiler(compiler), index_query(index_query), workspace(workspace), contexts(contexts),
+        background_indexer(background_indexer) {}
+
+    using RawResult = kota::task<kota::codec::RawValue, kota::ipc::Error>;
 
     /// Full document-link result for a session: the worker's main-file links
     /// merged behind the PCH's cached preamble links.
@@ -55,9 +64,79 @@ public:
     /// targets, the index, and the worker's AST, with an index/directive
     /// retry after the forward's compile refreshes a dirty session.
     /// @param session may be null (document not open).
-    kota::task<kota::codec::RawValue, kota::ipc::Error> definition(std::shared_ptr<Session> session,
-                                                                   llvm::StringRef path,
-                                                                   const protocol::Position& pos);
+    RawResult definition(std::shared_ptr<Session> session,
+                         llvm::StringRef path,
+                         const protocol::Position& pos);
+
+    /// Single-source features routed through the router as a matter of
+    /// discipline, not necessity. Each currently forwards to exactly one
+    /// provider (the worker's AST, a stateless build, or the index), so most
+    /// are one-line delegations. They live here as reserved tenants: the
+    /// router is where a feature's answer is assembled once it draws on more
+    /// than one source, and these are the designated hooks for a future
+    /// read-only provider strategy (e.g. serving closed files from the index).
+    /// They are NOT dead code to be inlined back into the transports.
+    RawResult hover(std::shared_ptr<Session> session, const protocol::Position& position);
+    RawResult semantic_tokens(std::shared_ptr<Session> session);
+    RawResult inlay_hints(std::shared_ptr<Session> session, const protocol::Range& range);
+    RawResult folding_range(std::shared_ptr<Session> session);
+    RawResult document_symbol(std::shared_ptr<Session> session);
+    RawResult code_action(std::shared_ptr<Session> session);
+
+    /// Code completion. Serves preamble contexts (include/import) locally from
+    /// the include graph and module map; delegates ordinary code completion to
+    /// a stateless worker. Pauses background indexing for the request's span.
+    RawResult completion(std::shared_ptr<Session> session, const protocol::Position& position);
+
+    /// Signature help, forwarded to a stateless build. Pauses background
+    /// indexing for the request's span.
+    RawResult signature_help(std::shared_ptr<Session> session, const protocol::Position& position);
+
+    /// Whole-document and range formatting, forwarded to a stateless worker.
+    /// Pause background indexing for the request's span.
+    RawResult formatting(std::shared_ptr<Session> session);
+    RawResult range_formatting(std::shared_ptr<Session> session, const protocol::Range& range);
+
+    /// Index navigation queries. Closed documents are fully serveable from the
+    /// index and an empty result is a real answer (returned as []). @param
+    /// session may be null (document not open) — the index is queried anyway.
+    RawResult references(std::shared_ptr<Session> session,
+                         llvm::StringRef path,
+                         const protocol::Position& position,
+                         bool include_declaration);
+    RawResult declaration(std::shared_ptr<Session> session,
+                          llvm::StringRef path,
+                          const protocol::Position& position);
+    RawResult type_definition(std::shared_ptr<Session> session,
+                              llvm::StringRef path,
+                              const protocol::Position& position);
+    RawResult implementation(std::shared_ptr<Session> session,
+                             llvm::StringRef path,
+                             const protocol::Position& position);
+
+    RawResult call_hierarchy_prepare(std::shared_ptr<Session> session,
+                                     const std::string& uri,
+                                     llvm::StringRef path,
+                                     const protocol::Position& position);
+    RawResult call_hierarchy_incoming(std::shared_ptr<Session> session,
+                                      llvm::StringRef path,
+                                      const protocol::CallHierarchyItem& item);
+    RawResult call_hierarchy_outgoing(std::shared_ptr<Session> session,
+                                      llvm::StringRef path,
+                                      const protocol::CallHierarchyItem& item);
+
+    RawResult type_hierarchy_prepare(std::shared_ptr<Session> session,
+                                     const std::string& uri,
+                                     llvm::StringRef path,
+                                     const protocol::Position& position);
+    RawResult type_hierarchy_supertypes(std::shared_ptr<Session> session,
+                                        llvm::StringRef path,
+                                        const protocol::TypeHierarchyItem& item);
+    RawResult type_hierarchy_subtypes(std::shared_ptr<Session> session,
+                                      llvm::StringRef path,
+                                      const protocol::TypeHierarchyItem& item);
+
+    RawResult workspace_symbol(llvm::StringRef query);
 
 private:
     /// The preamble include links of a session's active PCH, or nullptr.
@@ -73,6 +152,8 @@ private:
     Compiler& compiler;
     IndexQuery& index_query;
     Workspace& workspace;
+    ContextResolver& contexts;
+    BackgroundIndexer& background_indexer;
 };
 
 }  // namespace clice

--- a/src/server/feature/format.cpp
+++ b/src/server/feature/format.cpp
@@ -1,0 +1,106 @@
+#include "server/feature/format.h"
+
+#include <algorithm>
+#include <format>
+#include <ranges>
+#include <string>
+#include <vector>
+
+#include "compile/diagnostic.h"
+#include "server/context/context_resolver.h"
+#include "support/logging.h"
+
+#include "kota/codec/json/json.h"
+
+namespace clice {
+
+/// Clang diagnostics indicating that an input file could not be found —
+/// the symptom of a guessed compile command missing include paths.
+static bool is_file_not_found(const protocol::Diagnostic& diagnostic) {
+    if(!diagnostic.code.has_value())
+        return false;
+    auto* code = std::get_if<protocol::string>(&*diagnostic.code);
+    return code && (*code == "err_pp_file_not_found" || *code == "err_pp_error_opening_file" ||
+                    *code == "err_module_not_found");
+}
+
+/// File-top warning explaining that diagnostics were produced with a guessed
+/// compile command, pointing at the compilation database documentation.
+static protocol::Diagnostic make_inferred_command_diagnostic(CommandSource source) {
+    DiagnosticID id{
+        .value = 0,
+        .level = DiagnosticLevel::Warning,
+        .source = DiagnosticSource::Clice,
+        .name = "inferred-compile-command",
+    };
+
+    protocol::Diagnostic diagnostic;
+    diagnostic.range = protocol::Range{
+        .start = protocol::Position{.line = 0, .character = 0},
+        .end = protocol::Position{.line = 0, .character = 0},
+    };
+    diagnostic.severity = protocol::DiagnosticSeverity::Warning;
+    diagnostic.code = id.name.str();
+    if(auto uri = id.diagnostic_document_uri()) {
+        diagnostic.code_description = protocol::CodeDescription{.href = std::move(*uri)};
+    }
+    diagnostic.source = "clice";
+    diagnostic.message = std::format(
+        "No compilation database entry for this file (compile command was {}), so some includes " "may not be found. Configure compile_commands.json for accurate diagnostics.",
+        source == CommandSource::Fallback ? "synthesized from defaults"
+                                          : "inferred from an including file");
+    return diagnostic;
+}
+
+std::vector<protocol::Diagnostic> format_diagnostics(const CompileOutput& output) {
+    std::vector<protocol::Diagnostic> diagnostics;
+    if(!output.diagnostics.empty()) {
+        auto status = kota::codec::json::from_json(output.diagnostics.data, diagnostics);
+        if(!status) {
+            LOG_WARN("Failed to deserialize diagnostics JSON");
+        }
+    }
+
+    // Suffix injection appends an #include past the user's EOF; errors in
+    // host code after the include point remap onto those phantom lines.
+    // They describe the includer, not the document — drop them.
+    if(output.line_limit.has_value()) {
+        std::erase_if(diagnostics, [&](const protocol::Diagnostic& d) {
+            return d.range.start.line >= *output.line_limit;
+        });
+    }
+
+    // Guidance (and only when it can explain something): an exact CDB match
+    // never gets the note, and neither does a guessed command that worked.
+    if(output.source != CommandSource::CDBExact &&
+       std::ranges::any_of(diagnostics, is_file_not_found)) {
+        diagnostics.insert(diagnostics.begin(), make_inferred_command_diagnostic(output.source));
+    }
+
+    return diagnostics;
+}
+
+std::vector<protocol::Range> format_inactive_regions(const Session& session,
+                                                     const CompileOutput& output) {
+    std::vector<protocol::Range> result;
+    if(!output.inactive_regions.has_value()) {
+        return result;
+    }
+    auto& regions = *output.inactive_regions;
+    auto map = session.line_map();
+    result.reserve(regions.size() / 2);
+    for(std::size_t i = 0; i + 1 < regions.size(); i += 2) {
+        auto start = map.to_position(regions[i]);
+        auto end = map.to_position(regions[i + 1]);
+        if(!start || !end) {
+            continue;
+        }
+        protocol::Range range;
+        range.start = *start;
+        range.end = *end;
+        result.push_back(range);
+    }
+    return result;
+}
+
+}  // namespace clice

--- a/src/server/feature/format.h
+++ b/src/server/feature/format.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+
+#include "server/session/session.h"
+
+#include "kota/ipc/lsp/protocol.h"
+
+namespace clice {
+
+namespace protocol = kota::ipc::protocol;
+
+/// Format a materialized compile output into publishable diagnostics:
+/// deserialize the worker's raw diagnostics, drop phantom suffix-include
+/// lines, and — when the compile command was not an exact CDB match and
+/// the diagnostics contain file-not-found class errors — merge a file-top
+/// guidance diagnostic explaining the inferred command. Formatting is
+/// compile semantics; sending the result is the transport's job.
+std::vector<protocol::Diagnostic> format_diagnostics(const CompileOutput& output);
+
+/// Convert a compile output's inactive-region byte offsets into LSP ranges
+/// using the session's line map.
+std::vector<protocol::Range> format_inactive_regions(const Session& session,
+                                                     const CompileOutput& output);
+
+}  // namespace clice

--- a/src/server/index/background_indexer.cpp
+++ b/src/server/index/background_indexer.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "index/tu_index.h"
-#include "server/compiler/compiler.h"
+#include "server/context/context_resolver.h"
 #include "server/protocol/worker.h"
 #include "server/session/session_store.h"
 #include "server/worker/worker_pool.h"
@@ -342,7 +342,7 @@ kota::task<> BackgroundIndexer::index_one(std::uint32_t server_path_id,
     params.file = file_path;
     // Bulk background indexing sticks to real commands; synthesized fallback
     // commands would fill the index with guesses.
-    if(compiler.fill_compile_args(file_path, params.directory, params.arguments, nullptr) ==
+    if(contexts.resolve_command(file_path, params.directory, params.arguments, nullptr) ==
        CommandSource::Fallback)
         co_return;
 

--- a/src/server/index/background_indexer.h
+++ b/src/server/index/background_indexer.h
@@ -14,7 +14,7 @@
 
 namespace clice {
 
-class Compiler;
+class ContextResolver;
 class WorkerPool;
 struct SessionStore;
 
@@ -38,9 +38,9 @@ public:
     BackgroundIndexer(kota::event_loop& loop,
                       Workspace& workspace,
                       WorkerPool& pool,
-                      Compiler& compiler,
+                      ContextResolver& contexts,
                       const SessionStore& sessions) :
-        loop(loop), bg_tasks(loop), workspace(workspace), pool(pool), compiler(compiler),
+        loop(loop), bg_tasks(loop), workspace(workspace), pool(pool), contexts(contexts),
         sessions(sessions) {}
 
     /// Temporarily pause background indexing to give priority to user
@@ -135,7 +135,7 @@ private:
     kota::task_group<> bg_tasks;
     Workspace& workspace;
     WorkerPool& pool;
-    Compiler& compiler;
+    ContextResolver& contexts;
 
     /// Open documents, read-only. A file with an open Session is skipped by
     /// background indexing (its buffer index is authoritative).

--- a/src/server/service/agent_client.cpp
+++ b/src/server/service/agent_client.cpp
@@ -68,7 +68,7 @@ AgentClient::AgentClient(MasterServer& server, kota::ipc::JsonPeer& peer) :
                const CompileCommandParams& params) -> RequestResult<CompileCommandParams> {
             std::string directory;
             std::vector<std::string> arguments;
-            srv.compiler.fill_compile_args(params.path, directory, arguments);
+            srv.contexts.resolve_command(params.path, directory, arguments);
 
             co_return CompileCommandResult{
                 .file = params.path,

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -238,7 +238,7 @@ void LSPClient::register_document_sync() {
             return;
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
-        srv.on_file_saved(path_id);
+        srv.dispatch(FileEvent::buffer_saved(path_id));
 
         LOG_DEBUG("didSave: {}", path);
     });

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -10,9 +10,9 @@
 #include "command/argument_parser.h"
 #include "semantic/symbol_kind.h"
 #include "server/context/context_resolver.h"
+#include "server/feature/format.h"
 #include "server/protocol/extension.h"
 #include "server/protocol/serialize.h"
-#include "server/protocol/worker.h"
 #include "server/service/master_server.h"
 #include "support/anomaly.h"
 #include "support/filesystem.h"
@@ -34,18 +34,10 @@ namespace lsp = kota::ipc::lsp;
 namespace refl = kota::meta;
 using kota::ipc::RequestResult;
 using RequestContext = kota::ipc::JsonPeer::RequestContext;
-using serde_raw = kota::codec::RawValue;
 
 /// Error response for feature requests on files with no open session.
 static kota::ipc::Error document_not_open() {
     return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Document not open"};
-}
-
-/// Error response when a call/type hierarchy item cannot be resolved back to
-/// an indexed symbol.
-static kota::ipc::Error item_not_resolved(llvm::StringRef kind) {
-    return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams,
-                            std::format("Failed to resolve {} item", kind)};
 }
 
 LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(server), peer(peer) {
@@ -259,20 +251,18 @@ void LSPClient::register_language_features() {
             resolve_uri(params.text_document_position_params.text_document.uri);
         if(!session)
             co_return kota::outcome_error(document_not_open());
-        co_return co_await srv.compiler.forward_query(
-            worker::QueryKind::Hover,
-            session,
-            params.text_document_position_params.position);
+        co_return co_await srv.features.hover(session,
+                                              params.text_document_position_params.position);
     });
 
-    peer.on_request([this](RequestContext& ctx,
-                           const protocol::SemanticTokensParams& params) -> RawResult {
-        auto& srv = this->server;
-        auto [path, path_id, session] = resolve_uri(params.text_document.uri);
-        if(!session)
-            co_return kota::outcome_error(document_not_open());
-        co_return co_await srv.compiler.forward_query(worker::QueryKind::SemanticTokens, session);
-    });
+    peer.on_request(
+        [this](RequestContext& ctx, const protocol::SemanticTokensParams& params) -> RawResult {
+            auto& srv = this->server;
+            auto [path, path_id, session] = resolve_uri(params.text_document.uri);
+            if(!session)
+                co_return kota::outcome_error(document_not_open());
+            co_return co_await srv.features.semantic_tokens(session);
+        });
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::InlayHintParams& params) -> RawResult {
@@ -280,10 +270,7 @@ void LSPClient::register_language_features() {
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
-            co_return co_await srv.compiler.forward_query(worker::QueryKind::InlayHints,
-                                                          session,
-                                                          {},
-                                                          params.range);
+            co_return co_await srv.features.inlay_hints(session, params.range);
         });
 
     peer.on_request(
@@ -292,17 +279,17 @@ void LSPClient::register_language_features() {
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
-            co_return co_await srv.compiler.forward_query(worker::QueryKind::FoldingRange, session);
+            co_return co_await srv.features.folding_range(session);
         });
 
-    peer.on_request([this](RequestContext& ctx,
-                           const protocol::DocumentSymbolParams& params) -> RawResult {
-        auto& srv = this->server;
-        auto [path, path_id, session] = resolve_uri(params.text_document.uri);
-        if(!session)
-            co_return kota::outcome_error(document_not_open());
-        co_return co_await srv.compiler.forward_query(worker::QueryKind::DocumentSymbol, session);
-    });
+    peer.on_request(
+        [this](RequestContext& ctx, const protocol::DocumentSymbolParams& params) -> RawResult {
+            auto& srv = this->server;
+            auto [path, path_id, session] = resolve_uri(params.text_document.uri);
+            if(!session)
+                co_return kota::outcome_error(document_not_open());
+            co_return co_await srv.features.document_symbol(session);
+        });
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DocumentLinkParams& params) -> RawResult {
@@ -321,39 +308,8 @@ void LSPClient::register_language_features() {
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
-            co_return co_await srv.compiler.forward_query(worker::QueryKind::CodeAction, session);
+            co_return co_await srv.features.code_action(session);
         });
-
-    auto lookup_at = [this](const std::string& uri, const protocol::Position& pos) {
-        auto [path, path_id, session] = resolve_uri(uri);
-        return this->server.index_query.lookup_symbol(uri, path, pos, session.get());
-    };
-
-    auto query_at = [this](const std::string& uri,
-                           const protocol::Position& pos,
-                           RelationKind kind) -> std::vector<protocol::Location> {
-        auto [path, path_id, session] = resolve_uri(uri);
-        return this->server.index_query.query_relations(path, pos, kind, session.get());
-    };
-
-    auto query_targets_at = [this](const std::string& uri,
-                                   const protocol::Position& pos,
-                                   RelationKind kind) -> std::vector<protocol::Location> {
-        auto [path, path_id, session] = resolve_uri(uri);
-        return this->server.index_query.query_symbol_targets(path, pos, kind, session.get());
-    };
-
-    auto resolve_item =
-        [this](const std::string& uri,
-               const protocol::Range& range,
-               const std::optional<protocol::LSPAny>& data) -> std::optional<SymbolInfo> {
-        auto [path, path_id, session] = resolve_uri(uri);
-        return this->server.index_query.resolve_hierarchy_item(uri,
-                                                               path,
-                                                               range,
-                                                               data,
-                                                               session.get());
-    };
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::DefinitionParams& params) -> RawResult {
@@ -367,51 +323,38 @@ void LSPClient::register_language_features() {
     // fully serveable from the index, and an empty result is a real answer,
     // returned as [] — never an error.
     peer.on_request(
-        [query_at](RequestContext& ctx, const protocol::ReferenceParams& params) -> RawResult {
+        [this](RequestContext& ctx, const protocol::ReferenceParams& params) -> RawResult {
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
-
-            auto locations = query_at(uri, pos, RelationKind::Reference);
-
-            if(params.context.include_declaration) {
-                for(auto kind: {RelationKind::Declaration, RelationKind::Definition}) {
-                    auto extra = query_at(uri, pos, kind);
-                    locations.insert(locations.end(),
-                                     std::make_move_iterator(extra.begin()),
-                                     std::make_move_iterator(extra.end()));
-                }
-            }
-
-            co_return to_raw(locations);
+            auto [path, path_id, session] = resolve_uri(uri);
+            co_return co_await this->server.features.references(session,
+                                                                path,
+                                                                pos,
+                                                                params.context.include_declaration);
         });
 
-    peer.on_request([query_targets_at](RequestContext& ctx,
-                                       const protocol::TypeDefinitionParams& params) -> RawResult {
-        auto& uri = params.text_document_position_params.text_document.uri;
-        auto& pos = params.text_document_position_params.position;
-        co_return to_raw(query_targets_at(uri, pos, RelationKind::TypeDefinition));
-    });
-
-    peer.on_request([query_targets_at](RequestContext& ctx,
-                                       const protocol::ImplementationParams& params) -> RawResult {
-        auto& uri = params.text_document_position_params.text_document.uri;
-        auto& pos = params.text_document_position_params.position;
-        co_return to_raw(query_targets_at(uri, pos, RelationKind::Implementation));
-    });
-
-    // Declarations plus the definition: symbols defined inline have no
-    // separate Declaration relation, and navigating to the definition is
-    // what every client expects in that case.
     peer.on_request(
-        [query_at](RequestContext& ctx, const protocol::DeclarationParams& params) -> RawResult {
+        [this](RequestContext& ctx, const protocol::TypeDefinitionParams& params) -> RawResult {
             auto& uri = params.text_document_position_params.text_document.uri;
             auto& pos = params.text_document_position_params.position;
-            auto locations = query_at(uri, pos, RelationKind::Declaration);
-            auto defs = query_at(uri, pos, RelationKind::Definition);
-            locations.insert(locations.end(),
-                             std::make_move_iterator(defs.begin()),
-                             std::make_move_iterator(defs.end()));
-            co_return to_raw(locations);
+            auto [path, path_id, session] = resolve_uri(uri);
+            co_return co_await this->server.features.type_definition(session, path, pos);
+        });
+
+    peer.on_request(
+        [this](RequestContext& ctx, const protocol::ImplementationParams& params) -> RawResult {
+            auto& uri = params.text_document_position_params.text_document.uri;
+            auto& pos = params.text_document_position_params.position;
+            auto [path, path_id, session] = resolve_uri(uri);
+            co_return co_await this->server.features.implementation(session, path, pos);
+        });
+
+    peer.on_request(
+        [this](RequestContext& ctx, const protocol::DeclarationParams& params) -> RawResult {
+            auto& uri = params.text_document_position_params.text_document.uri;
+            auto& pos = params.text_document_position_params.position;
+            auto [path, path_id, session] = resolve_uri(uri);
+            co_return co_await this->server.features.declaration(session, path, pos);
         });
 
     peer.on_request([this](RequestContext& ctx,
@@ -421,11 +364,8 @@ void LSPClient::register_language_features() {
             resolve_uri(params.text_document_position_params.text_document.uri);
         if(!session)
             co_return kota::outcome_error(document_not_open());
-        auto pause = srv.background_indexer.scoped_pause();
-        auto result =
-            co_await srv.compiler.handle_completion(params.text_document_position_params.position,
-                                                    session);
-        co_return std::move(result);
+        co_return co_await srv.features.completion(session,
+                                                   params.text_document_position_params.position);
     });
 
     peer.on_request(
@@ -435,12 +375,9 @@ void LSPClient::register_language_features() {
                 resolve_uri(params.text_document_position_params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
-            auto pause = srv.background_indexer.scoped_pause();
-            auto result =
-                co_await srv.compiler.forward_build(worker::BuildKind::SignatureHelp,
-                                                    params.text_document_position_params.position,
-                                                    session);
-            co_return std::move(result);
+            co_return co_await srv.features.signature_help(
+                session,
+                params.text_document_position_params.position);
         });
 
     peer.on_request(
@@ -449,8 +386,7 @@ void LSPClient::register_language_features() {
             auto [path, path_id, session] = resolve_uri(params.text_document.uri);
             if(!session)
                 co_return kota::outcome_error(document_not_open());
-            auto pause = srv.background_indexer.scoped_pause();
-            co_return co_await srv.compiler.forward_format(session);
+            co_return co_await srv.features.formatting(session);
         });
 
     peer.on_request([this](RequestContext& ctx,
@@ -459,89 +395,60 @@ void LSPClient::register_language_features() {
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         if(!session)
             co_return kota::outcome_error(document_not_open());
-        auto pause = srv.background_indexer.scoped_pause();
-        co_return co_await srv.compiler.forward_format(session, params.range);
+        co_return co_await srv.features.range_formatting(session, params.range);
     });
 
-    peer.on_request(
-        [this, lookup_at](RequestContext& ctx,
-                          const protocol::CallHierarchyPrepareParams& params) -> RawResult {
-            auto& uri = params.text_document_position_params.text_document.uri;
-            auto& pos = params.text_document_position_params.position;
-
-            auto info = lookup_at(uri, pos);
-            if(!info)
-                co_return serde_raw{"null"};
-            if(!(info->kind == SymbolKind::Function || info->kind == SymbolKind::Method))
-                co_return serde_raw{"null"};
-
-            std::vector<protocol::CallHierarchyItem> items;
-            items.push_back(IndexQuery::build_call_hierarchy_item(*info));
-            co_return to_raw(items);
-        });
-
-    peer.on_request([this, resolve_item](
-                        RequestContext& ctx,
-                        const protocol::CallHierarchyIncomingCallsParams& params) -> RawResult {
-        auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
-        if(!info)
-            co_return kota::outcome_error(item_not_resolved("call hierarchy"));
-        auto results = this->server.index_query.find_incoming_calls(info->hash);
-        co_return to_raw(results);
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::CallHierarchyPrepareParams& params) -> RawResult {
+        auto& uri = params.text_document_position_params.text_document.uri;
+        auto& pos = params.text_document_position_params.position;
+        auto [path, path_id, session] = resolve_uri(uri);
+        co_return co_await this->server.features.call_hierarchy_prepare(session, uri, path, pos);
     });
 
-    peer.on_request([this, resolve_item](
-                        RequestContext& ctx,
-                        const protocol::CallHierarchyOutgoingCallsParams& params) -> RawResult {
-        auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
-        if(!info)
-            co_return kota::outcome_error(item_not_resolved("call hierarchy"));
-        auto results = this->server.index_query.find_outgoing_calls(info->hash);
-        co_return to_raw(results);
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::CallHierarchyIncomingCallsParams& params) -> RawResult {
+        auto [path, path_id, session] = resolve_uri(params.item.uri);
+        co_return co_await this->server.features.call_hierarchy_incoming(session,
+                                                                         path,
+                                                                         params.item);
     });
 
-    peer.on_request(
-        [this, lookup_at](RequestContext& ctx,
-                          const protocol::TypeHierarchyPrepareParams& params) -> RawResult {
-            auto& uri = params.text_document_position_params.text_document.uri;
-            auto& pos = params.text_document_position_params.position;
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::CallHierarchyOutgoingCallsParams& params) -> RawResult {
+        auto [path, path_id, session] = resolve_uri(params.item.uri);
+        co_return co_await this->server.features.call_hierarchy_outgoing(session,
+                                                                         path,
+                                                                         params.item);
+    });
 
-            auto info = lookup_at(uri, pos);
-            if(!info)
-                co_return serde_raw{"null"};
-            if(!(info->kind == SymbolKind::Class || info->kind == SymbolKind::Struct ||
-                 info->kind == SymbolKind::Enum || info->kind == SymbolKind::Union))
-                co_return serde_raw{"null"};
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::TypeHierarchyPrepareParams& params) -> RawResult {
+        auto& uri = params.text_document_position_params.text_document.uri;
+        auto& pos = params.text_document_position_params.position;
+        auto [path, path_id, session] = resolve_uri(uri);
+        co_return co_await this->server.features.type_hierarchy_prepare(session, uri, path, pos);
+    });
 
-            std::vector<protocol::TypeHierarchyItem> items;
-            items.push_back(IndexQuery::build_type_hierarchy_item(*info));
-            co_return to_raw(items);
-        });
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::TypeHierarchySupertypesParams& params) -> RawResult {
+        auto [path, path_id, session] = resolve_uri(params.item.uri);
+        co_return co_await this->server.features.type_hierarchy_supertypes(session,
+                                                                           path,
+                                                                           params.item);
+    });
 
-    peer.on_request(
-        [this, resolve_item](RequestContext& ctx,
-                             const protocol::TypeHierarchySupertypesParams& params) -> RawResult {
-            auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
-            if(!info)
-                co_return kota::outcome_error(item_not_resolved("type hierarchy"));
-            auto results = this->server.index_query.find_supertypes(info->hash);
-            co_return to_raw(results);
-        });
-
-    peer.on_request(
-        [this, resolve_item](RequestContext& ctx,
-                             const protocol::TypeHierarchySubtypesParams& params) -> RawResult {
-            auto info = resolve_item(params.item.uri, params.item.range, params.item.data);
-            if(!info)
-                co_return kota::outcome_error(item_not_resolved("type hierarchy"));
-            auto results = this->server.index_query.find_subtypes(info->hash);
-            co_return to_raw(results);
-        });
+    peer.on_request([this](RequestContext& ctx,
+                           const protocol::TypeHierarchySubtypesParams& params) -> RawResult {
+        auto [path, path_id, session] = resolve_uri(params.item.uri);
+        co_return co_await this->server.features.type_hierarchy_subtypes(session,
+                                                                         path,
+                                                                         params.item);
+    });
 
     peer.on_request(
         [this](RequestContext& ctx, const protocol::WorkspaceSymbolParams& params) -> RawResult {
-            auto results = this->server.index_query.search_symbols(params.query);
-            co_return to_raw(results);
+            co_return co_await this->server.features.workspace_symbol(params.query);
         });
 }
 

--- a/src/server/service/lsp_client.cpp
+++ b/src/server/service/lsp_client.cpp
@@ -203,6 +203,8 @@ void LSPClient::register_document_sync() {
         // Restore a context choice persisted from an earlier session.
         srv.contexts.restore_saved_context(*session);
 
+        srv.dispatch(FileEvent::buffer_opened(path_id));
+
         LOG_DEBUG("didOpen: {} (v{})", path, params.text_document.version);
     });
 
@@ -216,6 +218,8 @@ void LSPClient::register_document_sync() {
             return;
 
         srv.sessions.apply_change(*session, params.content_changes, params.text_document.version);
+
+        srv.dispatch(FileEvent::buffer_edited(path_id));
 
         LOG_DEBUG("didChange: path={} version={} gen={}",
                   path,
@@ -474,12 +478,14 @@ void LSPClient::register_extensions() {
         [this](RequestContext& ctx, const ext::SwitchContextParams& params) -> RawResult {
             auto [path, path_id, session] = resolve_uri(params.uri);
             auto [context_path, context_path_id, context_session] = resolve_uri(params.context_uri);
-            co_return to_raw(this->server.contexts.switch_context(path,
-                                                                  path_id,
-                                                                  session.get(),
-                                                                  context_path,
-                                                                  context_path_id,
-                                                                  params));
+            auto result = this->server.contexts.switch_context(path,
+                                                               path_id,
+                                                               session.get(),
+                                                               context_path,
+                                                               context_path_id,
+                                                               params);
+            this->server.dispatch(FileEvent::context_changed(path_id));
+            co_return to_raw(result);
         });
 }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -98,10 +98,7 @@ void MasterServer::wire() {
     pool.on_crash = [this](const WorkerCrashInfo& info) {
         if(!info.stateful)
             return;
-        for(auto path_id: info.lost_documents) {
-            if(auto session = sessions.find(path_id))
-                session->ast_dirty = true;
-        }
+        dispatch(FileEvent::worker_crashed(info.lost_documents));
     };
 
     pool.on_evicted = [this](const std::string& path) {
@@ -135,7 +132,6 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
     namespace protocol = kota::ipc::protocol;
 
     auto path = workspace.path_pool.resolve(path_id);
-    workspace.on_file_closed(path_id);
     // Route the eviction notification before dropping ownership:
     // notify_stateful uses the owner table to find the worker.
     pool.notify_stateful(path_id, worker::EvictParams{std::string(path)});
@@ -150,8 +146,7 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
 
     sessions.close(path_id);
 
-    background_indexer.enqueue(path_id);
-    background_indexer.schedule();
+    dispatch(FileEvent::buffer_closed(path_id));
 
     LOG_DEBUG("didClose: {}", path);
 }
@@ -171,6 +166,12 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
             session->trial_done = false;
         }
         workspace.forget_self_contained(path_id);
+    }
+
+    for(auto path_id: dirty.mark_lost) {
+        if(auto session = sessions.find(path_id)) {
+            session->ast_dirty = true;
+        }
     }
 
     // Header sessions whose synthesized preamble embeds changed chain

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -33,8 +33,8 @@ namespace protocol = kota::ipc::protocol;
 MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     loop(loop), pool(loop), contexts(workspace), compiler(loop, workspace, contexts, pool),
     index_query(workspace, sessions), background_indexer(loop, workspace, pool, contexts, sessions),
-    features(compiler, index_query, workspace, contexts, background_indexer), bg_tasks(loop),
-    self_path(std::move(self_path)) {}
+    features(compiler, index_query, workspace, contexts, background_indexer),
+    invalidator(workspace, sessions), bg_tasks(loop), self_path(std::move(self_path)) {}
 
 MasterServer::~MasterServer() = default;
 
@@ -236,6 +236,50 @@ void MasterServer::on_file_saved(std::uint32_t path_id) {
     }
 
     background_indexer.schedule();
+}
+
+void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
+    auto dirty = invalidator.apply(events);
+
+    for(auto path_id: dirty.reset_trial) {
+        if(auto session = sessions.find(path_id)) {
+            session->trial_done = false;
+        }
+    }
+
+    for(auto path_id: dirty.mark_ast_dirty) {
+        if(auto session = sessions.find(path_id)) {
+            session->ast_dirty = true;
+            session->trial_done = false;
+        }
+        workspace.forget_self_contained(path_id);
+    }
+
+    // Header sessions whose synthesized preamble embeds changed chain
+    // content: zeroing build_at forces deps_changed() to re-validate every
+    // chain file by content hash. Do NOT reset the context itself: an
+    // in-flight compile can clobber ast_dirty when it finishes, and the
+    // surviving snapshot is what lets is_stale() recover.
+    for(auto path_id: dirty.force_revalidate) {
+        auto session = sessions.find(path_id);
+        if(session && session->header_context) {
+            session->header_context->deps.build_at = 0;
+            session->ast_dirty = true;
+            session->trial_done = false;
+        }
+    }
+
+    for(auto path_id: dirty.enqueue_reindex) {
+        background_indexer.enqueue(path_id);
+    }
+
+    if(dirty.save_cache) {
+        workspace.save_cache();
+    }
+
+    if(dirty.reschedule_indexing) {
+        background_indexer.schedule();
+    }
 }
 
 void MasterServer::schedule_shutdown() {

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -156,88 +156,6 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
     LOG_DEBUG("didClose: {}", path);
 }
 
-void MasterServer::on_file_saved(std::uint32_t path_id) {
-    // The saved file's own self-containment may have changed; re-evaluate
-    // on its next compile.
-    workspace.header_modes.erase(path_id);
-    workspace.header_mode_hashes.erase(path_id);
-    if(auto session = find_session(path_id)) {
-        session->trial_done = false;
-    }
-
-    auto dirtied = workspace.rescan_after_save(path_id);
-    for(auto dirty_id: dirtied) {
-        auto session = find_session(dirty_id);
-        if(session) {
-            session->ast_dirty = true;
-            session->trial_done = false;
-            workspace.forget_self_contained(dirty_id);
-        } else {
-            background_indexer.enqueue(dirty_id);
-        }
-    }
-
-    // Header sessions whose include chain contains the saved file must
-    // re-synthesize their preamble: it embeds the chain files' content, so
-    // neither the dependents cascade above nor clang's own dependency
-    // tracking catches this. Zeroing build_at forces deps_changed() to
-    // re-validate every chain file by content hash. Do NOT reset the
-    // context itself: an in-flight compile can clobber ast_dirty when it
-    // finishes, and the surviving snapshot is what lets is_stale() recover.
-    for(auto& [session_id, session]: sessions.sessions) {
-        if(session->header_context && llvm::is_contained(session->header_context->chain, path_id)) {
-            session->header_context->deps.build_at = 0;
-            session->ast_dirty = true;
-            session->trial_done = false;
-            // The chain change may have made the header self-contained
-            // (e.g. a dependency now provides the missing declarations);
-            // drop the persisted verdict so the trial can downgrade it.
-            workspace.header_modes.erase(session_id);
-            workspace.header_mode_hashes.erase(session_id);
-        }
-    }
-
-    // A save can remove the include edge a user's context choice depends
-    // on. A stale active_context suppresses automatic host resolution, so
-    // it would strand the header on the fallback command (or silently pin
-    // its command hash to a different host) — drop it instead. The include
-    // graph was already rescanned above.
-    bool dropped_saved = false;
-    for(auto& [session_id, session]: sessions.sessions) {
-        if(!session->active_context.has_value()) {
-            continue;
-        }
-        auto host_id = session->active_context->host_path_id;
-        auto& occurrence = session->active_context->occurrence;
-        bool orphaned = workspace.dep_graph.find_include_chain(host_id, session_id).empty();
-        // A pinned occurrence can vanish while other inclusions of the
-        // header survive (the chain stays non-empty) — recount it.
-        if(!orphaned && occurrence.has_value()) {
-            auto count = workspace.count_occurrences(host_id, session_id);
-            orphaned = count > 0 && *occurrence >= count;
-        }
-        if(orphaned) {
-            LOG_INFO("Dropping orphaned context choice for {}: host {} no longer includes it",
-                     workspace.path_pool.resolve(session_id),
-                     workspace.path_pool.resolve(host_id));
-            session->active_context.reset();
-            session->header_context.reset();
-            session->pch_ref.reset();
-            session->ast_dirty = true;
-            session->trial_done = false;
-            // Invalidate in-flight compiles so they cannot clobber the
-            // reset state when they finish (same as switchContext).
-            session->generation += 1;
-            dropped_saved |= workspace.saved_contexts.erase(session_id) > 0;
-        }
-    }
-    if(dropped_saved) {
-        workspace.save_cache();
-    }
-
-    background_indexer.schedule();
-}
-
 void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
     auto dirty = invalidator.apply(events);
 
@@ -273,7 +191,11 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
         background_indexer.enqueue(path_id);
     }
 
-    if(dirty.save_cache) {
+    bool save = dirty.save_cache;
+    if(dirty.recheck_contexts) {
+        save |= contexts.drop_orphaned_choices(sessions);
+    }
+    if(save) {
         workspace.save_cache();
     }
 

--- a/src/server/service/master_server.cpp
+++ b/src/server/service/master_server.cpp
@@ -32,8 +32,9 @@ namespace protocol = kota::ipc::protocol;
 
 MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     loop(loop), pool(loop), contexts(workspace), compiler(loop, workspace, contexts, pool),
-    index_query(workspace, sessions), background_indexer(loop, workspace, pool, compiler, sessions),
-    features(compiler, index_query, workspace), bg_tasks(loop), self_path(std::move(self_path)) {}
+    index_query(workspace, sessions), background_indexer(loop, workspace, pool, contexts, sessions),
+    features(compiler, index_query, workspace, contexts, background_indexer), bg_tasks(loop),
+    self_path(std::move(self_path)) {}
 
 MasterServer::~MasterServer() = default;
 

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -13,6 +13,7 @@
 #include "server/session/session_store.h"
 #include "server/worker/worker_pool.h"
 #include "server/workspace/config.h"
+#include "server/workspace/invalidator.h"
 #include "server/workspace/workspace.h"
 
 #include "kota/async/async.h"
@@ -93,6 +94,11 @@ public:
 
     void on_file_saved(std::uint32_t path_id);
 
+    /// The single entry point for file events: fold the batch through the
+    /// Invalidator, then execute the resulting effects against the mutable
+    /// services (sessions, context resolver, background indexer).
+    void dispatch(llvm::ArrayRef<FileEvent> events);
+
     void schedule_shutdown();
 
     kota::event& get_shutdown_event() {
@@ -116,6 +122,7 @@ public:
     IndexQuery index_query;
     BackgroundIndexer background_indexer;
     FeatureRouter features;
+    Invalidator invalidator;
 
     /// Lifecycle state, advanced by the LSP initialize/shutdown handlers.
     ServerLifecycle lifecycle = ServerLifecycle::Uninitialized;

--- a/src/server/service/master_server.h
+++ b/src/server/service/master_server.h
@@ -92,8 +92,6 @@ public:
     std::shared_ptr<Session> open_session(std::uint32_t path_id);
     void close_session(std::uint32_t path_id, kota::ipc::JsonPeer& peer);
 
-    void on_file_saved(std::uint32_t path_id);
-
     /// The single entry point for file events: fold the batch through the
     /// Invalidator, then execute the resulting effects against the mutable
     /// services (sessions, context resolver, background indexer).

--- a/src/server/workspace/invalidator.cpp
+++ b/src/server/workspace/invalidator.cpp
@@ -87,6 +87,12 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 break;
             }
             case FileEvent::Kind::BufferClosed: {
+                // Disk is the truth again: update the module graph and hand
+                // the file back to the background indexer, whose shard now
+                // supersedes the dropped session's index.
+                workspace.on_file_closed(event.path_id);
+                dirty.enqueue_reindex.push_back(event.path_id);
+                dirty.reschedule_indexing = true;
                 break;
             }
             case FileEvent::Kind::DiskChanged: {
@@ -99,15 +105,26 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 break;
             }
             case FileEvent::Kind::ContextChanged: {
+                // Context validation, persistence and session reset happen in
+                // ContextResolver::switch_context, which already lives in the
+                // right module; this case is a hook for future cross-file
+                // policy.
                 break;
             }
             case FileEvent::Kind::WorkerCrashed: {
+                // The worker's ASTs are gone; every document it owned must
+                // recompile. Compile inputs did not change, so trial state
+                // and self-containment verdicts stay untouched.
+                for(auto path_id: event.paths) {
+                    dirty.mark_lost.push_back(path_id);
+                }
                 break;
             }
         }
     }
 
     dedup(dirty.mark_ast_dirty);
+    dedup(dirty.mark_lost);
     dedup(dirty.reset_trial);
     dedup(dirty.force_revalidate);
     dedup(dirty.enqueue_reindex);

--- a/src/server/workspace/invalidator.cpp
+++ b/src/server/workspace/invalidator.cpp
@@ -1,0 +1,76 @@
+#include "server/workspace/invalidator.h"
+
+#include <utility>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+namespace clice {
+
+/// Default ReadFile: the real filesystem.
+static std::optional<std::string> read_from_disk(llvm::StringRef path) {
+    auto buffer = llvm::MemoryBuffer::getFile(path);
+    if(!buffer) {
+        return std::nullopt;
+    }
+    return std::string((*buffer)->getBuffer());
+}
+
+Invalidator::Invalidator(Workspace& workspace, const SessionStore& store, ReadFile read_file) :
+    workspace(workspace), store(store),
+    read_file(read_file ? std::move(read_file) : ReadFile(read_from_disk)) {}
+
+/// Batch effects may name the same file twice (two saves in one batch);
+/// execution must see each id once.
+static void dedup(llvm::SmallVector<std::uint32_t>& ids) {
+    llvm::sort(ids);
+    ids.erase(llvm::unique(ids), ids.end());
+}
+
+DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
+    DirtySet dirty;
+
+    for(auto& event: events) {
+        switch(event.kind) {
+            case FileEvent::Kind::BufferOpened: {
+                // Buffer installation itself is SessionStore::apply_open's
+                // job; nothing cross-file to invalidate yet.
+                break;
+            }
+            case FileEvent::Kind::BufferEdited: {
+                // Buffer sync (text/version/ast_dirty/generation) is
+                // SessionStore::apply_change's job; nothing cross-file yet.
+                break;
+            }
+            case FileEvent::Kind::BufferSaved: {
+                break;
+            }
+            case FileEvent::Kind::BufferClosed: {
+                break;
+            }
+            case FileEvent::Kind::DiskChanged: {
+                // TODO: no producer yet — the disk poller / cache validation
+                // side will emit these.
+                break;
+            }
+            case FileEvent::Kind::DiskRemoved: {
+                // TODO: no producer yet (see DiskChanged).
+                break;
+            }
+            case FileEvent::Kind::ContextChanged: {
+                break;
+            }
+            case FileEvent::Kind::WorkerCrashed: {
+                break;
+            }
+        }
+    }
+
+    dedup(dirty.mark_ast_dirty);
+    dedup(dirty.reset_trial);
+    dedup(dirty.force_revalidate);
+    dedup(dirty.enqueue_reindex);
+    return dirty;
+}
+
+}  // namespace clice

--- a/src/server/workspace/invalidator.cpp
+++ b/src/server/workspace/invalidator.cpp
@@ -43,6 +43,47 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 break;
             }
             case FileEvent::Kind::BufferSaved: {
+                auto path_id = event.path_id;
+
+                // The saved file's own self-containment may have changed;
+                // re-evaluate on its next compile.
+                workspace.header_modes.erase(path_id);
+                workspace.header_mode_hashes.erase(path_id);
+                dirty.reset_trial.push_back(path_id);
+
+                // Rescan disk state (include edges, module declaration,
+                // compile-graph cascade, PCM caches); the cascade names the
+                // module units whose build products went stale.
+                auto dirtied = workspace.rescan_after_save(path_id);
+                for(auto dirty_id: dirtied) {
+                    if(store.find(dirty_id)) {
+                        dirty.mark_ast_dirty.push_back(dirty_id);
+                    } else {
+                        dirty.enqueue_reindex.push_back(dirty_id);
+                    }
+                }
+
+                // Header sessions whose include chain contains the saved file
+                // must re-synthesize their preamble: it embeds the chain
+                // files' content, so neither the dependents cascade above nor
+                // clang's own dependency tracking catches this.
+                for(auto& [session_id, session]: store.sessions) {
+                    if(session->header_context &&
+                       llvm::is_contained(session->header_context->chain, path_id)) {
+                        dirty.force_revalidate.push_back(session_id);
+                        // The chain change may have made the header
+                        // self-contained (e.g. a dependency now provides the
+                        // missing declarations); drop the persisted verdict
+                        // so the trial can downgrade it.
+                        workspace.header_modes.erase(session_id);
+                        workspace.header_mode_hashes.erase(session_id);
+                    }
+                }
+
+                // A save can remove the include edge a user's context choice
+                // depends on; the include graph was already rescanned above.
+                dirty.recheck_contexts = true;
+                dirty.reschedule_indexing = true;
                 break;
             }
             case FileEvent::Kind::BufferClosed: {

--- a/src/server/workspace/invalidator.h
+++ b/src/server/workspace/invalidator.h
@@ -74,9 +74,13 @@ struct FileEvent {
 /// these; MasterServer::dispatch() executes them against the mutable
 /// services (sessions, context resolver, background indexer).
 struct DirtySet {
-    /// Recompile needed: ast_dirty + trial_done=false + forget the cached
-    /// self-containment verdict.
+    /// Compile inputs changed: ast_dirty + trial_done=false + forget the
+    /// cached self-containment verdict.
     llvm::SmallVector<std::uint32_t> mark_ast_dirty;
+    /// Built AST lost (worker crash) but compile inputs did not change:
+    /// recompile only, without re-running the header trial or touching the
+    /// self-containment verdict.
+    llvm::SmallVector<std::uint32_t> mark_lost;
     /// Re-run the header trial only (trial_done=false); the AST itself is
     /// not stale.
     llvm::SmallVector<std::uint32_t> reset_trial;
@@ -96,8 +100,9 @@ struct DirtySet {
     bool reschedule_indexing = false;
 
     bool empty() const {
-        return mark_ast_dirty.empty() && reset_trial.empty() && force_revalidate.empty() &&
-               enqueue_reindex.empty() && !recheck_contexts && !save_cache && !reschedule_indexing;
+        return mark_ast_dirty.empty() && mark_lost.empty() && reset_trial.empty() &&
+               force_revalidate.empty() && enqueue_reindex.empty() && !recheck_contexts &&
+               !save_cache && !reschedule_indexing;
     }
 };
 

--- a/src/server/workspace/invalidator.h
+++ b/src/server/workspace/invalidator.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "server/session/session_store.h"
+#include "server/workspace/workspace.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace clice {
+
+/// A change to a file the server cares about, described by what happened —
+/// not by what must be invalidated. Events are plain values handed to
+/// MasterServer::dispatch(); there is no log and no replay (this is not
+/// event sourcing), the event batch is just the call's argument.
+struct FileEvent {
+    enum class Kind : std::uint8_t {
+        /// didOpen installed a fresh buffer for the file.
+        BufferOpened,
+        /// didChange folded edits into the open buffer.
+        BufferEdited,
+        /// didSave: the on-disk content now matches the buffer.
+        BufferSaved,
+        /// didClose dropped the buffer; disk is the truth again.
+        BufferClosed,
+        /// The file changed on disk behind the server's back. No producer
+        /// yet — reserved for the disk poller / cache validation side.
+        DiskChanged,
+        /// The file disappeared from disk. No producer yet (see DiskChanged).
+        DiskRemoved,
+        /// clice/switchContext changed the file's active header context.
+        ContextChanged,
+        /// A stateful worker crashed; `paths` lists the documents it owned.
+        WorkerCrashed,
+    };
+
+    Kind kind;
+    std::uint32_t path_id = no_path_id;
+    /// WorkerCrashed only: the crashed worker's lost documents.
+    llvm::SmallVector<std::uint32_t> paths;
+
+    static FileEvent buffer_opened(std::uint32_t path_id) {
+        return {Kind::BufferOpened, path_id};
+    }
+
+    static FileEvent buffer_edited(std::uint32_t path_id) {
+        return {Kind::BufferEdited, path_id};
+    }
+
+    static FileEvent buffer_saved(std::uint32_t path_id) {
+        return {Kind::BufferSaved, path_id};
+    }
+
+    static FileEvent buffer_closed(std::uint32_t path_id) {
+        return {Kind::BufferClosed, path_id};
+    }
+
+    static FileEvent context_changed(std::uint32_t path_id) {
+        return {Kind::ContextChanged, path_id};
+    }
+
+    static FileEvent worker_crashed(llvm::ArrayRef<std::uint32_t> lost_documents) {
+        FileEvent event{Kind::WorkerCrashed};
+        event.paths.assign(lost_documents.begin(), lost_documents.end());
+        return event;
+    }
+};
+
+/// The effects an event batch demands, deduplicated. The engine computes
+/// these; MasterServer::dispatch() executes them against the mutable
+/// services (sessions, context resolver, background indexer).
+struct DirtySet {
+    /// Recompile needed: ast_dirty + trial_done=false + forget the cached
+    /// self-containment verdict.
+    llvm::SmallVector<std::uint32_t> mark_ast_dirty;
+    /// Re-run the header trial only (trial_done=false); the AST itself is
+    /// not stale.
+    llvm::SmallVector<std::uint32_t> reset_trial;
+    /// Header sessions whose synthesized preamble embeds changed content:
+    /// zero deps.build_at so every chain file is re-validated by hash, plus
+    /// the mark_ast_dirty treatment.
+    llvm::SmallVector<std::uint32_t> force_revalidate;
+    /// Closed files whose index entries went stale: enqueue for background
+    /// reindexing.
+    llvm::SmallVector<std::uint32_t> enqueue_reindex;
+    /// Include edges changed: context choices may now be orphaned; run the
+    /// context resolver's orphan cleanup.
+    bool recheck_contexts = false;
+    /// Persist the workspace cache snapshot.
+    bool save_cache = false;
+    /// Kick the background indexer's scheduler.
+    bool reschedule_indexing = false;
+
+    bool empty() const {
+        return mark_ast_dirty.empty() && reset_trial.empty() && force_revalidate.empty() &&
+               enqueue_reindex.empty() && !recheck_contexts && !save_cache && !reschedule_indexing;
+    }
+};
+
+/// The invalidation engine: the single place that maps file events onto
+/// derived-state invalidation.
+///
+/// Ownership charter:
+///   - reads the session store, never mutates it;
+///   - directly updates the derived graphs Workspace owns (include graph,
+///     module map, header modes, ...);
+///   - anything touching Sessions, the index queue, or cache persistence is
+///     returned as a DirtySet effect and executed by the dispatcher, so the
+///     engine stays testable with just a Workspace and a SessionStore.
+///
+/// The engine is told about every event, but the buffer-change mechanics of
+/// BufferOpened/BufferEdited (text, version, ast_dirty, generation) are the
+/// SessionStore's charter and stay in apply_open/apply_change; those cases
+/// exist as hooks for future cross-file policy, not as the sync path.
+class Invalidator {
+public:
+    /// Read a file's current on-disk content, or nullopt if unreadable.
+    /// Defaults to the real filesystem; unit tests inject file content
+    /// through it. Reserved for the Disk* events' content validation.
+    using ReadFile = std::function<std::optional<std::string>(llvm::StringRef path)>;
+
+    Invalidator(Workspace& workspace, const SessionStore& store, ReadFile read_file = {});
+
+    /// Fold a batch of events into one deduplicated effect set.
+    DirtySet apply(llvm::ArrayRef<FileEvent> events);
+
+private:
+    Workspace& workspace;
+    const SessionStore& store;
+    ReadFile read_file;
+};
+
+}  // namespace clice

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -1,5 +1,5 @@
-#include "test/test.h"
 #include "test/temp_dir.h"
+#include "test/test.h"
 #include "server/compiler/compile_graph.h"
 #include "server/context/context_resolver.h"
 #include "server/workspace/invalidator.h"
@@ -15,6 +15,23 @@ TEST_CASE(EmptyBatchNoEffects) {
     Invalidator invalidator(workspace, store);
 
     auto dirty = invalidator.apply({});
+
+    ASSERT_TRUE(dirty.empty());
+}
+
+TEST_CASE(NoOpEventsNoEffects) {
+    Workspace workspace;
+    SessionStore store;
+    auto file = workspace.path_pool.intern("/proj/a.cpp");
+    store.open(file);
+
+    Invalidator invalidator(workspace, store);
+    // Buffer sync stays in SessionStore and context switching in
+    // ContextResolver; these events must produce no effects of their own.
+    FileEvent events[] = {FileEvent::buffer_opened(file),
+                          FileEvent::buffer_edited(file),
+                          FileEvent::context_changed(file)};
+    auto dirty = invalidator.apply(events);
 
     ASSERT_TRUE(dirty.empty());
 }
@@ -41,7 +58,7 @@ TEST_CASE(SaveResetsTrialOnly) {
     ASSERT_TRUE(dirty.reschedule_indexing);
 }
 
-TEST_CASE(ModuleCascadeSplitsOpenClosed) {
+TEST_CASE(CascadeSplitsOpenClosed) {
     kota::event_loop loop;
     Workspace workspace;
     SessionStore store;
@@ -83,7 +100,7 @@ TEST_CASE(ModuleCascadeSplitsOpenClosed) {
     loop.run();
 }
 
-TEST_CASE(ChainInvalidationHitAndMiss) {
+TEST_CASE(ChainHitAndMiss) {
     Workspace workspace;
     SessionStore store;
     auto saved = workspace.path_pool.intern("/proj/inner.h");
@@ -109,6 +126,39 @@ TEST_CASE(ChainInvalidationHitAndMiss) {
     ASSERT_EQ(dirty.force_revalidate, llvm::SmallVector<std::uint32_t>{hit});
     ASSERT_FALSE(workspace.header_modes.contains(hit));
     ASSERT_FALSE(workspace.header_mode_hashes.contains(hit));
+}
+
+TEST_CASE(CloseEnqueuesReindex) {
+    Workspace workspace;
+    SessionStore store;
+    auto closed = workspace.path_pool.intern("/proj/a.cpp");
+
+    Invalidator invalidator(workspace, store);
+    auto dirty = invalidator.apply(FileEvent::buffer_closed(closed));
+
+    ASSERT_EQ(dirty.enqueue_reindex, llvm::SmallVector<std::uint32_t>{closed});
+    ASSERT_TRUE(dirty.reschedule_indexing);
+    ASSERT_TRUE(dirty.mark_ast_dirty.empty());
+}
+
+TEST_CASE(CrashMarksLostDirty) {
+    Workspace workspace;
+    SessionStore store;
+    auto first = workspace.path_pool.intern("/proj/a.cpp");
+    auto second = workspace.path_pool.intern("/proj/b.cpp");
+    store.open(first);
+    store.open(second);
+
+    Invalidator invalidator(workspace, store);
+    std::uint32_t lost[] = {first, second};
+    auto dirty = invalidator.apply(FileEvent::worker_crashed(lost));
+
+    llvm::SmallVector<std::uint32_t> expected{first, second};
+    llvm::sort(expected);
+    ASSERT_EQ(dirty.mark_lost, expected);
+    // A crash loses build products, not compile inputs: no trial reset.
+    ASSERT_TRUE(dirty.mark_ast_dirty.empty());
+    ASSERT_TRUE(dirty.reset_trial.empty());
 }
 
 TEST_CASE(BatchSavesDeduplicate) {
@@ -155,6 +205,7 @@ TEST_CASE(RemovedEdgeDropsChoice) {
 
     auto session = store.open(header);
     session->active_context = Session::ActiveContext{host, std::nullopt, ""};
+    session->header_context.emplace();
     session->trial_done = true;
     workspace.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
     auto generation = session->generation;

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -1,0 +1,22 @@
+#include "test/test.h"
+#include "server/workspace/invalidator.h"
+
+namespace clice::testing {
+namespace {
+
+TEST_SUITE(Invalidator) {
+
+TEST_CASE(EmptyBatchNoEffects) {
+    Workspace workspace;
+    SessionStore store;
+    Invalidator invalidator(workspace, store);
+
+    auto dirty = invalidator.apply({});
+
+    ASSERT_TRUE(dirty.empty());
+}
+
+};  // TEST_SUITE(Invalidator)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -1,4 +1,7 @@
 #include "test/test.h"
+#include "test/temp_dir.h"
+#include "server/compiler/compile_graph.h"
+#include "server/context/context_resolver.h"
 #include "server/workspace/invalidator.h"
 
 namespace clice::testing {
@@ -16,7 +19,179 @@ TEST_CASE(EmptyBatchNoEffects) {
     ASSERT_TRUE(dirty.empty());
 }
 
+TEST_CASE(SaveResetsTrialOnly) {
+    Workspace workspace;
+    SessionStore store;
+    auto saved = workspace.path_pool.intern("/proj/a.h");
+    store.open(saved);
+    workspace.header_modes[saved] = HeaderMode::NeedsContext;
+    workspace.header_mode_hashes[saved] = 42;
+
+    Invalidator invalidator(workspace, store);
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
+
+    // The saved file itself is not stale — its buffer was already current —
+    // only its self-containment verdict needs re-evaluation.
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{saved});
+    ASSERT_TRUE(dirty.mark_ast_dirty.empty());
+    ASSERT_TRUE(dirty.force_revalidate.empty());
+    ASSERT_FALSE(workspace.header_modes.contains(saved));
+    ASSERT_FALSE(workspace.header_mode_hashes.contains(saved));
+    ASSERT_TRUE(dirty.recheck_contexts);
+    ASSERT_TRUE(dirty.reschedule_indexing);
+}
+
+TEST_CASE(ModuleCascadeSplitsOpenClosed) {
+    kota::event_loop loop;
+    Workspace workspace;
+    SessionStore store;
+    auto mod = workspace.path_pool.intern("/proj/m.cppm");
+    auto open_user = workspace.path_pool.intern("/proj/open_user.cppm");
+    auto closed_user = workspace.path_pool.intern("/proj/closed_user.cppm");
+
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::uint32_t>> deps;
+    deps[open_user] = {mod};
+    deps[closed_user] = {mod};
+    workspace.compile_graph = std::make_unique<CompileGraph>(
+        loop,
+        [](std::uint32_t) -> kota::task<bool> { co_return true; },
+        [deps = std::move(deps)](std::uint32_t id) -> llvm::SmallVector<std::uint32_t> {
+            auto it = deps.find(id);
+            return it != deps.end() ? it->second : llvm::SmallVector<std::uint32_t>{};
+        });
+
+    store.open(open_user);
+    Invalidator invalidator(workspace, store);
+
+    auto body = [&]() -> kota::task<> {
+        co_await workspace.compile_graph->compile(open_user);
+        co_await workspace.compile_graph->compile(closed_user);
+
+        auto dirty = invalidator.apply(FileEvent::buffer_saved(mod));
+
+        // Cascade-dirtied module units split by session state: open buffers
+        // recompile, closed files go back to the background indexer.
+        EXPECT_EQ(dirty.mark_ast_dirty, llvm::SmallVector<std::uint32_t>{open_user});
+        llvm::SmallVector<std::uint32_t> reindexed{mod, closed_user};
+        llvm::sort(reindexed);
+        EXPECT_EQ(dirty.enqueue_reindex, reindexed);
+
+        co_await workspace.compile_graph->shutdown();
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+}
+
+TEST_CASE(ChainInvalidationHitAndMiss) {
+    Workspace workspace;
+    SessionStore store;
+    auto saved = workspace.path_pool.intern("/proj/inner.h");
+    auto other = workspace.path_pool.intern("/proj/other.h");
+    auto hit = workspace.path_pool.intern("/proj/hit.h");
+    auto miss = workspace.path_pool.intern("/proj/miss.h");
+
+    auto hit_session = store.open(hit);
+    hit_session->header_context.emplace();
+    hit_session->header_context->chain = {saved};
+    workspace.header_modes[hit] = HeaderMode::NeedsContext;
+    workspace.header_mode_hashes[hit] = 7;
+
+    auto miss_session = store.open(miss);
+    miss_session->header_context.emplace();
+    miss_session->header_context->chain = {other};
+
+    Invalidator invalidator(workspace, store);
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(saved));
+
+    // Only the session whose synthesized preamble embeds the saved file
+    // re-validates; the persisted verdict drops so the trial can downgrade.
+    ASSERT_EQ(dirty.force_revalidate, llvm::SmallVector<std::uint32_t>{hit});
+    ASSERT_FALSE(workspace.header_modes.contains(hit));
+    ASSERT_FALSE(workspace.header_mode_hashes.contains(hit));
+}
+
+TEST_CASE(BatchSavesDeduplicate) {
+    Workspace workspace;
+    SessionStore store;
+    auto saved = workspace.path_pool.intern("/proj/a.h");
+    store.open(saved);
+
+    Invalidator invalidator(workspace, store);
+    FileEvent events[] = {FileEvent::buffer_saved(saved), FileEvent::buffer_saved(saved)};
+    auto dirty = invalidator.apply(events);
+
+    ASSERT_EQ(dirty.reset_trial, llvm::SmallVector<std::uint32_t>{saved});
+}
+
 };  // TEST_SUITE(Invalidator)
+
+TEST_SUITE(DropOrphanedChoices) {
+
+TEST_CASE(SurvivingEdgeKeepsChoice) {
+    Workspace workspace;
+    SessionStore store;
+    auto host = workspace.path_pool.intern("/proj/host.cpp");
+    auto header = workspace.path_pool.intern("/proj/h.h");
+    workspace.dep_graph.set_includes(host, 0, {header});
+    workspace.dep_graph.build_reverse_map();
+
+    auto session = store.open(header);
+    session->active_context = Session::ActiveContext{host, std::nullopt, ""};
+    workspace.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
+
+    ContextResolver resolver(workspace);
+    ASSERT_FALSE(resolver.drop_orphaned_choices(store));
+    ASSERT_TRUE(session->active_context.has_value());
+    ASSERT_TRUE(workspace.saved_contexts.contains(header));
+}
+
+TEST_CASE(RemovedEdgeDropsChoice) {
+    Workspace workspace;
+    SessionStore store;
+    auto host = workspace.path_pool.intern("/proj/host.cpp");
+    auto header = workspace.path_pool.intern("/proj/h.h");
+    workspace.dep_graph.build_reverse_map();
+
+    auto session = store.open(header);
+    session->active_context = Session::ActiveContext{host, std::nullopt, ""};
+    session->trial_done = true;
+    workspace.saved_contexts[header] = SavedContext{host, std::nullopt, ""};
+    auto generation = session->generation;
+
+    ContextResolver resolver(workspace);
+    ASSERT_TRUE(resolver.drop_orphaned_choices(store));
+    ASSERT_FALSE(session->active_context.has_value());
+    ASSERT_FALSE(session->header_context.has_value());
+    ASSERT_TRUE(session->ast_dirty);
+    ASSERT_FALSE(session->trial_done);
+    ASSERT_EQ(session->generation, generation + 1);
+    ASSERT_FALSE(workspace.saved_contexts.contains(header));
+}
+
+TEST_CASE(VanishedOccurrenceDropsChoice) {
+    TempDir tmp;
+    Workspace workspace;
+    SessionStore store;
+    // The host still includes the header, but only once — the pinned
+    // occurrence #1 no longer exists.
+    tmp.touch("host.cpp", R"(#include "h.h")");
+    tmp.touch("h.h");
+    auto host = workspace.path_pool.intern(tmp.path("host.cpp"));
+    auto header = workspace.path_pool.intern(tmp.path("h.h"));
+    workspace.dep_graph.set_includes(host, 0, {header});
+    workspace.dep_graph.build_reverse_map();
+
+    auto session = store.open(header);
+    session->active_context = Session::ActiveContext{host, 1, ""};
+    workspace.saved_contexts[header] = SavedContext{host, 1, ""};
+
+    ContextResolver resolver(workspace);
+    ASSERT_TRUE(resolver.drop_orphaned_choices(store));
+    ASSERT_FALSE(session->active_context.has_value());
+}
+
+};  // TEST_SUITE(DropOrphanedChoices)
 
 }  // namespace
 }  // namespace clice::testing


### PR DESCRIPTION
## What

A pure refactor with zero behavior change, in two movements:

**Module boundary cleanup.** Every LSP language feature now routes through `FeatureRouter` instead of transports calling `Compiler`/`IndexQuery` directly. Single-source features are one-line delegations, kept as designated hooks for a future read-only provider strategy (serving closed files from the index). Compile-command assembly moves from `Compiler::fill_compile_args` to `ContextResolver::resolve_command` — command selection is context-domain logic — and `BackgroundIndexer` now depends on `ContextResolver` instead of `Compiler`. Diagnostic/inactive-region formatting helpers move to `server/feature/format.h`, leaving `Compiler` as pure build orchestration.

**The invalidation engine.** File-change handling was scattered across `MasterServer` (didSave's five-part cascade, the crash handler, didClose cleanup). It is now centralized: `FileEvent` (a closed vocabulary — buffer open/edit/save/close, disk change/remove, context switch, worker crash) goes into `MasterServer::dispatch()`, the `Invalidator` engine folds a batch into a deduplicated `DirtySet` of effects, and the dispatcher executes them against the mutable services. The engine reads the session store, mutates only Workspace-owned derived state, and returns everything else as effects — so it is unit-testable with plain data structures. This is not event sourcing: no log, no replay; the event batch is just the call's argument.

The `DiskChanged`/`DiskRemoved` events are defined but have no producer yet; they are the hook for the upcoming disk poller and cache-validation work.

## Behavior preservation

- Every migrated handler keeps its exact error semantics (`document_not_open` for AST-backed queries vs. empty results for index-backed navigation).
- Background-indexing pause scope is unchanged (completion, signature help, formatting ×2).
- The didSave cascade maps one-to-one onto the `BufferSaved` case; the orphaned-context cleanup becomes `ContextResolver::drop_orphaned_choices` verbatim.
- Worker crashes use a dedicated `mark_lost` effect that only marks ASTs dirty — a crash loses build products, not compile inputs, so it must not re-run header trials or drop self-containment verdicts (exactly the old handler's behavior).
- The only ordering change (module-graph update on didClose now runs after session erase instead of before pool eviction) touches disjoint state and is observationally equivalent; argued in the commit message.

## Tests

- New unit tests for the engine's effect mapping: save resets only the trial for the saved file, module-cascade open/closed split (against a real `CompileGraph`), preamble-chain hit/miss, orphan-drop trigger conditions (edge removed, pinned occurrence vanished), no-op events, batch dedup, crash marking, close re-enqueue.
- The dispatch executor's branches are covered end-to-end by the existing staleness/self-containment/context-switching integration tests.
- Locally green: 795 unit, 238 integration, 3/3 smoke — with zero snapshot changes.