### PR TITLE
fix(server): document-sync protocol edges and notify pipeline

### DIFF
--- a/src/server/state/session_store.h
+++ b/src/server/state/session_store.h
@@ -21,9 +21,10 @@ namespace protocol = kota::ipc::protocol;
 /// this store hands out.
 ///
 /// Future work: this store does not yet detect buffer desync (client and
-/// server drifting out of sync), warn on non-monotonic document versions, or
-/// bound the number of concurrently open sessions. Those safeguards are left
-/// for later.
+/// server drifting out of sync) or bound the number of concurrently open
+/// sessions. Those safeguards are left for later. Non-monotonic document
+/// versions are warned about at the transport edge, where the protocol
+/// context lives.
 struct SessionStore {
     llvm::DenseMap<std::uint32_t, std::shared_ptr<Session>> sessions;
 

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -47,17 +47,19 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
     progress_conn =
         server.indexer.on_progress_changed.connect([this]() { report_index_progress(); });
 
-    // The notify hook is process-wide and forwards anomaly/guidance messages
-    // as window/logMessage notifications. It captures the peer, so it must
-    // live exactly as long as this LSPClient (cleared in the destructor).
-    // TODO: materialize these messages into server state and deliver them
-    // through a typed signal instead of a process-wide hook.
-    logging::set_notify_hook([&peer](logging::NotifyLevel level, std::string_view message) {
+    // Guidance/anomaly messages travel as window/logMessage, which the LSP
+    // spec allows before the initialize handshake — deliver the backlog a
+    // headless server accumulated, then subscribe for live messages.
+    auto forward_notify = [&peer](const NotifyMessage& message) {
         peer.send_notification(protocol::LogMessageParams{
-            static_cast<protocol::MessageType>(level),
-            std::string(message),
+            static_cast<protocol::MessageType>(message.level),
+            message.text,
         });
-    });
+    };
+    for(const auto& message: server.notify_log) {
+        forward_notify(message);
+    }
+    notify_conn = server.on_notify.connect(forward_notify);
 
     register_lifecycle();
     register_document_sync();
@@ -103,11 +105,6 @@ void LSPClient::register_lifecycle() {
             .open_close = true,
             .change = protocol::TextDocumentSyncKind::Incremental,
             .save = protocol::variant<protocol::boolean, protocol::SaveOptions>{true},
-        };
-        caps.workspace = protocol::WorkspaceOptions{};
-        caps.workspace->workspace_folders = protocol::WorkspaceFoldersServerCapabilities{
-            .supported = true,
-            .change_notifications = true,
         };
 
         caps.hover_provider = true;
@@ -173,8 +170,28 @@ void LSPClient::register_lifecycle() {
     });
 
     peer.on_notification([this]([[maybe_unused]] const protocol::InitializedParams& params) {
-        this->server.initialize();
+        auto& srv = this->server;
+        // A server pre-initialized from the command line (serve
+        // --workspace) rejects the LSP initialize request but the client
+        // still completes its handshake; re-running initialize() here
+        // would spawn a second worker pool.
+        if(srv.lifecycle == ServerLifecycle::Initialized) {
+            srv.initialize();
+        }
+
+        this->client_ready = true;
         this->publish_config_diagnostics();
+
+        // Replay compile outputs that materialized while no ready client
+        // was attached (documents opened and compiled before the
+        // handshake, or while the server ran headless).
+        srv.sessions.for_each(
+            [this]([[maybe_unused]] std::uint32_t path_id, const Session& session) {
+                if(session.output.has_value()) {
+                    this->push_output(session);
+                }
+                return true;
+            });
     });
 
     peer.on_request(
@@ -191,11 +208,27 @@ void LSPClient::register_lifecycle() {
     });
 }
 
+/// True once the server has begun shutting down; document-sync
+/// notifications arriving past this point are dropped.
+static bool past_shutdown(ServerLifecycle lifecycle) {
+    return lifecycle == ServerLifecycle::ShuttingDown || lifecycle == ServerLifecycle::Exited;
+}
+
 void LSPClient::register_document_sync() {
     peer.on_notification([this](const protocol::DidOpenTextDocumentParams& params) {
         auto& srv = this->server;
-        if(srv.lifecycle != ServerLifecycle::Ready)
+        if(past_shutdown(srv.lifecycle))
             return;
+
+        // A didOpen racing ahead of the initialize handshake is a client
+        // protocol violation, but sessions are plain state with no worker
+        // dependency — accept the buffer so the session is in place once
+        // the server is ready. A compile attempted before then degrades to
+        // an operational worker-unavailable error and leaves the session
+        // dirty, so the first post-ready request recompiles it.
+        if(srv.lifecycle != ServerLifecycle::Ready) {
+            LOG_WARN("didOpen before the server is ready, accepting: {}", params.text_document.uri);
+        }
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         session = srv.open_session(path_id);
@@ -212,12 +245,23 @@ void LSPClient::register_document_sync() {
 
     peer.on_notification([this](const protocol::DidChangeTextDocumentParams& params) {
         auto& srv = this->server;
-        if(srv.lifecycle != ServerLifecycle::Ready)
+        if(past_shutdown(srv.lifecycle))
             return;
 
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
-        if(!session)
+        if(!session) {
+            // Dropping is the only safe move: without the didOpen baseline
+            // there is no buffer to fold the edits into.
+            LOG_ERROR("didChange for a document with no open session, dropping: {}", path);
             return;
+        }
+
+        if(params.text_document.version <= session->version) {
+            LOG_WARN("didChange version did not increase for {}: {} -> {}",
+                     path,
+                     session->version,
+                     params.text_document.version);
+        }
 
         srv.sessions.apply_change(*session, params.content_changes, params.text_document.version);
 
@@ -231,15 +275,22 @@ void LSPClient::register_document_sync() {
 
     peer.on_notification([this](const protocol::DidCloseTextDocumentParams& params) {
         auto& srv = this->server;
-        if(srv.lifecycle != ServerLifecycle::Ready)
+        if(past_shutdown(srv.lifecycle))
             return;
 
+        // Accepted before the server is ready for the same reason didOpen
+        // is: a session opened during the handshake window must not stay
+        // open forever when the editor already closed it.
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         srv.close_session(path_id, this->peer);
     });
 
     peer.on_notification([this](const protocol::DidSaveTextDocumentParams& params) {
         auto& srv = this->server;
+        // Unlike didOpen/didChange, a save arriving before the server is
+        // ready needs no special handling: BufferSaved only invalidates
+        // derived state, none of which exists yet — the workspace load at
+        // ready reads the saved disk content anyway.
         if(srv.lifecycle != ServerLifecycle::Ready)
             return;
 
@@ -572,6 +623,12 @@ void LSPClient::publish_config_diagnostics() {
 }
 
 void LSPClient::push_output(const Session& session) {
+    // Held back until the handshake completes (the LSP spec forbids
+    // publishDiagnostics before the initialize response); the output stays
+    // materialized on the session and the initialized handler replays it.
+    if(!client_ready) {
+        return;
+    }
     if(!session.output.has_value()) {
         return;
     }
@@ -607,6 +664,12 @@ void LSPClient::report_index_progress() {
         case Stage::Begin: {
             st.round_active = true;
             st.total = static_cast<std::uint32_t>(p.total);
+            // Progress-token creation is a server→client request, forbidden
+            // until the initialize response; a round that begins before the
+            // handshake stays unannounced (the next round announces).
+            if(!client_ready) {
+                break;
+            }
             // Register a fresh work-done token; once the client acknowledges
             // it, announce the round. This is the create()+begin() handshake
             // the indexer used to run inline, now driven from the transport so
@@ -626,11 +689,19 @@ void LSPClient::report_index_progress() {
             // Captureless lambda with the state as a parameter: parameters
             // are copied into the coroutine frame, while captures would live
             // in the closure temporary that dies with this statement.
-            // TODO: an in-flight create() still races connection teardown —
-            // the reporter references the peer while awaiting. This matches
-            // the pre-refactor risk (the reporter captured the peer inside
-            // the indexer coroutine); a real fix needs a cancellation handle
-            // tied to the peer's lifetime.
+            //
+            // Connection teardown mid-handshake needs no cancellation
+            // handle. The only suspension point touching the peer is
+            // create()'s send_request, and the peer fails every pending
+            // outgoing request before its run() returns — that resumption
+            // reads only the request's shared completion state, never the
+            // peer. Both composition sites destroy the LSPClient before the
+            // peer, so once the peer can be gone `abandoned` is already
+            // set and the continuation below drops the token without
+            // another peer access. The timeout path does reach back into
+            // peer internals, but it can only fire while the peer is alive:
+            // teardown completes the wait through the failure path first,
+            // which also stops the timeout timer.
             server.loop.schedule([](std::shared_ptr<IndexProgressState> state) -> kota::task<> {
                 // Timeout prevents the handshake from hanging when the client
                 // never responds.
@@ -672,7 +743,6 @@ void LSPClient::report_index_progress() {
 }
 
 LSPClient::~LSPClient() {
-    logging::set_notify_hook(nullptr);
     // A progress handshake may still be awaiting the client; it holds this
     // state alive and checks the flag before touching the peer.
     index_progress->abandoned = true;

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -41,6 +41,12 @@ static kota::ipc::Error document_not_open() {
     return kota::ipc::Error{kota::ipc::protocol::ErrorCode::InvalidParams, "Document not open"};
 }
 
+/// True once the server has begun shutting down; document-sync
+/// notifications arriving past this point are dropped.
+static bool past_shutdown(ServerLifecycle lifecycle) {
+    return lifecycle == ServerLifecycle::ShuttingDown || lifecycle == ServerLifecycle::Exited;
+}
+
 LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(server), peer(peer) {
     output_conn = server.compiler.on_output.connect(
         [this](const std::shared_ptr<Session>& session) { push_output(*session); });
@@ -48,23 +54,27 @@ LSPClient::LSPClient(MasterServer& server, kota::ipc::JsonPeer& peer) : server(s
         server.indexer.on_progress_changed.connect([this]() { report_index_progress(); });
 
     // Guidance/anomaly messages travel as window/logMessage, which the LSP
-    // spec allows before the initialize handshake — deliver the backlog a
-    // headless server accumulated, then subscribe for live messages.
-    auto forward_notify = [&peer](const NotifyMessage& message) {
-        peer.send_notification(protocol::LogMessageParams{
-            static_cast<protocol::MessageType>(message.level),
-            message.text,
-        });
-    };
-    for(const auto& message: server.notify_log) {
-        forward_notify(message);
-    }
-    notify_conn = server.on_notify.connect(forward_notify);
+    // spec allows before the initialize handshake — drain what a headless
+    // server accumulated, then drain again on every wake-up.
+    forward_notify_messages();
+    notify_conn = server.on_notify.connect([this]() { forward_notify_messages(); });
 
     register_lifecycle();
     register_document_sync();
     register_language_features();
     register_extensions();
+}
+
+void LSPClient::forward_notify_messages() {
+    auto first_seq = server.notify_seq - server.notify_log.size();
+    for(auto seq = std::max(notify_cursor, first_seq); seq < server.notify_seq; ++seq) {
+        auto& message = server.notify_log[static_cast<std::size_t>(seq - first_seq)];
+        peer.send_notification(protocol::LogMessageParams{
+            static_cast<protocol::MessageType>(message.level),
+            message.text,
+        });
+    }
+    notify_cursor = server.notify_seq;
 }
 
 LSPClient::ResolvedDoc LSPClient::resolve_uri(const std::string& uri) {
@@ -208,17 +218,13 @@ void LSPClient::register_lifecycle() {
     });
 }
 
-/// True once the server has begun shutting down; document-sync
-/// notifications arriving past this point are dropped.
-static bool past_shutdown(ServerLifecycle lifecycle) {
-    return lifecycle == ServerLifecycle::ShuttingDown || lifecycle == ServerLifecycle::Exited;
-}
-
 void LSPClient::register_document_sync() {
     peer.on_notification([this](const protocol::DidOpenTextDocumentParams& params) {
         auto& srv = this->server;
         if(past_shutdown(srv.lifecycle))
             return;
+
+        auto [path, path_id, session] = resolve_uri(params.text_document.uri);
 
         // A didOpen racing ahead of the initialize handshake is a client
         // protocol violation, but sessions are plain state with no worker
@@ -227,10 +233,9 @@ void LSPClient::register_document_sync() {
         // an operational worker-unavailable error and leaves the session
         // dirty, so the first post-ready request recompiles it.
         if(srv.lifecycle != ServerLifecycle::Ready) {
-            LOG_WARN("didOpen before the server is ready, accepting: {}", params.text_document.uri);
+            LOG_WARN("didOpen before the server is ready, accepting: {}", path);
         }
 
-        auto [path, path_id, session] = resolve_uri(params.text_document.uri);
         session = srv.open_session(path_id);
         srv.sessions.apply_open(*session, params.text_document.text, params.text_document.version);
 
@@ -280,9 +285,11 @@ void LSPClient::register_document_sync() {
 
         // Accepted before the server is ready for the same reason didOpen
         // is: a session opened during the handshake window must not stay
-        // open forever when the editor already closed it.
+        // open forever when the editor already closed it. The diagnostics
+        // clear is suppressed until the handshake completes — nothing was
+        // pushed, and publishDiagnostics may not flow yet.
         auto [path, path_id, session] = resolve_uri(params.text_document.uri);
-        srv.close_session(path_id, this->peer);
+        srv.close_session(path_id, client_ready ? &this->peer : nullptr);
     });
 
     peer.on_notification([this](const protocol::DidSaveTextDocumentParams& params) {

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -194,10 +194,16 @@ void LSPClient::register_lifecycle() {
 
         // Replay compile outputs that materialized while no ready client
         // was attached (documents opened and compiled before the
-        // handshake, or while the server ran headless).
+        // handshake, or while the server ran headless). Only outputs that
+        // still describe the current buffer are replayed: an edit during
+        // the handshake marks the session dirty, and pushing the pre-edit
+        // output would pair stale inactive regions (whose notification
+        // carries no version) with the new text — the next compile pushes
+        // fresh results instead.
         srv.sessions.for_each(
             [this]([[maybe_unused]] std::uint32_t path_id, const Session& session) {
-                if(session.output.has_value()) {
+                if(session.output.has_value() && !session.ast_dirty &&
+                   session.output->version == session.version) {
                     this->push_output(session);
                 }
                 return true;

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -15,7 +15,6 @@
 namespace clice {
 
 class MasterServer;
-struct NotifyMessage;
 struct Session;
 
 class LSPClient {
@@ -59,6 +58,12 @@ private:
     /// background indexer's on_progress_changed signal.
     void report_index_progress();
 
+    /// Send every not-yet-forwarded notify-log message as
+    /// window/logMessage, advancing notify_cursor. Invoked once from the
+    /// constructor (a headless server may have accumulated messages) and
+    /// then by the server's on_notify signal.
+    void forward_notify_messages();
+
     MasterServer& server;
     kota::ipc::JsonPeer& peer;
 
@@ -75,9 +80,13 @@ private:
     /// Subscription to background-index progress; disconnects on destruction.
     Signal<>::Connection progress_conn;
 
-    /// Subscription to guidance/anomaly messages; disconnects on
+    /// Subscription to guidance/anomaly message wake-ups; disconnects on
     /// destruction.
-    Signal<const NotifyMessage&>::Connection notify_conn;
+    Signal<>::Connection notify_conn;
+
+    /// Sequence number of the next notify-log message to forward (see
+    /// MasterServer::notify_seq).
+    std::uint64_t notify_cursor = 0;
 
     /// Progress-token lifecycle, split into orthogonal facts so the
     /// asynchronous create() handshake can reconcile against rounds that

--- a/src/server/transport/lsp_client.h
+++ b/src/server/transport/lsp_client.h
@@ -15,6 +15,7 @@
 namespace clice {
 
 class MasterServer;
+struct NotifyMessage;
 struct Session;
 
 class LSPClient {
@@ -47,7 +48,9 @@ private:
 
     /// Push a session's materialized compile output (diagnostics and
     /// inactive regions) to the client. Invoked by the compiler's
-    /// on_output signal.
+    /// on_output signal, and by the initialized handler to replay outputs
+    /// that materialized before the client was ready. No-op until
+    /// client_ready.
     void push_output(const Session& session);
 
     /// React to a background-indexing progress change: drive the LSP
@@ -59,11 +62,22 @@ private:
     MasterServer& server;
     kota::ipc::JsonPeer& peer;
 
+    /// The client completed the initialized handshake. Until then the LSP
+    /// spec forbids server→client traffic other than window/* messages, so
+    /// diagnostics pushes and progress-token creation are held back;
+    /// compile outputs missed in that window are replayed by the
+    /// initialized handler from the sessions' materialized output state.
+    bool client_ready = false;
+
     /// Subscription to compile outputs; disconnects on destruction.
     Signal<std::shared_ptr<Session>>::Connection output_conn;
 
     /// Subscription to background-index progress; disconnects on destruction.
     Signal<>::Connection progress_conn;
+
+    /// Subscription to guidance/anomaly messages; disconnects on
+    /// destruction.
+    Signal<const NotifyMessage&>::Connection notify_conn;
 
     /// Progress-token lifecycle, split into orthogonal facts so the
     /// asynchronous create() handshake can reconcile against rounds that

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -31,9 +31,10 @@ namespace clice {
 namespace lsp = kota::ipc::lsp;
 namespace protocol = kota::ipc::protocol;
 
-/// Bound on the notify backlog. Only messages that fire before a client
-/// attaches accumulate here (a handful of startup guidance reports in
-/// practice); the cap is a safety net, not a working-set size.
+/// Retention bound of the notify log. Subscribers drain promptly, so only
+/// messages that fire before any client attaches accumulate (a handful of
+/// startup guidance reports in practice); the cap is a safety net, not a
+/// working-set size.
 constexpr static std::size_t notify_log_limit = 128;
 
 MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
@@ -43,16 +44,16 @@ MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     invalidator(workspace, sessions, contexts), bg_tasks(loop), self_path(std::move(self_path)) {
     // The notify hook is process-wide because the logging layer cannot
     // depend on the server; the composition root owns it for the server's
-    // lifetime and turns reports into state (notify_log) plus a typed
+    // lifetime and turns reports into state (notify_log) plus a wake-up
     // signal. Master-side reports only ever fire on the event-loop thread
     // (see support/anomaly.h), so no synchronization is needed here.
     logging::set_notify_hook([this](logging::NotifyLevel level, std::string_view message) {
-        if(notify_log.size() < notify_log_limit) {
-            notify_log.push_back(NotifyMessage{level, std::string(message)});
-            on_notify.emit(notify_log.back());
-        } else {
-            on_notify.emit(NotifyMessage{level, std::string(message)});
+        notify_log.push_back(NotifyMessage{level, std::string(message)});
+        if(notify_log.size() > notify_log_limit) {
+            notify_log.pop_front();
         }
+        notify_seq += 1;
+        on_notify.emit();
     });
 }
 
@@ -194,7 +195,7 @@ std::shared_ptr<Session> MasterServer::open_session(std::uint32_t path_id) {
     return sessions.open(path_id);
 }
 
-void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& peer) {
+void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer* peer) {
     namespace protocol = kota::ipc::protocol;
 
     auto path = workspace.path_pool.resolve(path_id);
@@ -203,12 +204,17 @@ void MasterServer::close_session(std::uint32_t path_id, kota::ipc::JsonPeer& pee
     pool.notify_stateful(path_id, worker::EvictParams{std::string(path)});
     pool.remove_owner(path_id);
 
-    protocol::PublishDiagnosticsParams diag_params;
-    auto uri = lsp::URI::from_file_path(std::string(path));
-    if(uri)
-        diag_params.uri = uri->str();
-    diag_params.diagnostics = {};
-    peer.send_notification(diag_params);
+    // Null before the client's handshake completed: nothing was ever
+    // pushed, so there are no diagnostics to clear (and the LSP spec
+    // forbids publishDiagnostics before the initialize response).
+    if(peer) {
+        protocol::PublishDiagnosticsParams diag_params;
+        auto uri = lsp::URI::from_file_path(std::string(path));
+        if(uri)
+            diag_params.uri = uri->str();
+        diag_params.diagnostics = {};
+        peer->send_notification(diag_params);
+    }
 
     sessions.close(path_id);
 

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -289,7 +289,12 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
         workspace.save_cache(contexts);
     }
 
-    if(dirty.reschedule_indexing) {
+    // Not before the server is ready: document-sync events are accepted
+    // early (a pre-ready didClose lands here), but the scheduler reads
+    // configuration that initialize() has not applied yet. The reindex
+    // queue filled above is kept — the post-ready workspace load kicks the
+    // scheduler.
+    if(dirty.reschedule_indexing && lifecycle == ServerLifecycle::Ready) {
         indexer.schedule();
     }
 }

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -31,13 +31,34 @@ namespace clice {
 namespace lsp = kota::ipc::lsp;
 namespace protocol = kota::ipc::protocol;
 
+/// Bound on the notify backlog. Only messages that fire before a client
+/// attaches accumulate here (a handful of startup guidance reports in
+/// practice); the cap is a safety net, not a working-set size.
+constexpr static std::size_t notify_log_limit = 128;
+
 MasterServer::MasterServer(kota::event_loop& loop, std::string self_path) :
     loop(loop), pool(loop), contexts(workspace), compiler(loop, workspace, contexts, pool),
     index_query(workspace, sessions), indexer(loop, workspace, pool, contexts, sessions),
     features(compiler, index_query, workspace, contexts, indexer),
-    invalidator(workspace, sessions, contexts), bg_tasks(loop), self_path(std::move(self_path)) {}
+    invalidator(workspace, sessions, contexts), bg_tasks(loop), self_path(std::move(self_path)) {
+    // The notify hook is process-wide because the logging layer cannot
+    // depend on the server; the composition root owns it for the server's
+    // lifetime and turns reports into state (notify_log) plus a typed
+    // signal. Master-side reports only ever fire on the event-loop thread
+    // (see support/anomaly.h), so no synchronization is needed here.
+    logging::set_notify_hook([this](logging::NotifyLevel level, std::string_view message) {
+        if(notify_log.size() < notify_log_limit) {
+            notify_log.push_back(NotifyMessage{level, std::string(message)});
+            on_notify.emit(notify_log.back());
+        } else {
+            on_notify.emit(NotifyMessage{level, std::string(message)});
+        }
+    });
+}
 
-MasterServer::~MasterServer() = default;
+MasterServer::~MasterServer() {
+    logging::set_notify_hook(nullptr);
+}
 
 void MasterServer::initialize() {
     config_issues.clear();
@@ -93,6 +114,15 @@ void MasterServer::initialize() {
     wire();
 
     load_workspace();
+
+    // Documents opened before the server became ready were validated
+    // against an empty resolver; re-check their persisted context choices
+    // now that the workspace cache is loaded.
+    for(auto& [path_id, session]: sessions.sessions) {
+        if(session) {
+            contexts.validate_saved_context(*session);
+        }
+    }
 
     if(!workspace_root.empty()) {
         // Construct after the workspace load so the tracker's baseline CDB
@@ -490,10 +520,6 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
             return 1;
         }
 
-        // Pre-initialize for standalone (no-editor) use; LSP initialize will be rejected.
-        if(!ws.empty())
-            server.initialize(ws);
-
         std::unique_ptr<kota::ipc::Transport> final_transport = std::move(*transport);
         if(!record.empty()) {
             final_transport =
@@ -521,7 +547,15 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
                          kota::ipc::JsonPeer& peer,
                          std::list<Connection>& connections,
                          kota::tcp::acceptor acceptor,
-                         bool has_acceptor) -> kota::task<> {
+                         bool has_acceptor,
+                         std::string workspace) -> kota::task<> {
+            // Pre-initialize for standalone (no-editor) use; LSP initialize
+            // will be rejected. Runs inside the loop — before the peer
+            // reads its first message — because initialize() spawns
+            // background tasks that need the running loop context.
+            if(!workspace.empty()) {
+                server.initialize(workspace);
+            }
             if(has_acceptor) {
                 co_await kota::when_any(
                     peer.run(),
@@ -531,7 +565,7 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
                 co_await kota::when_any(peer.run(), server.get_shutdown_event().wait());
             }
             co_await server.shutdown_and_cleanup();
-        }(server, lsp_peer, connections, std::move(agent_acceptor), has_agent_acceptor));
+        }(server, lsp_peer, connections, std::move(agent_acceptor), has_agent_acceptor, ws));
         loop.run();
         return 0;
     }
@@ -543,20 +577,23 @@ int run_serve_mode(const ServerOptions& opts, const char* self_path) {
             return 1;
         }
 
-        if(!ws.empty())
-            server.initialize(ws);
-
         bool register_lsp = ws.empty();
         LOG_INFO("Listening on {}:{} ...", host, port);
         loop.schedule([](MasterServer& server,
                          kota::tcp::acceptor acceptor,
                          bool register_lsp,
-                         std::list<Connection>& connections) -> kota::task<> {
+                         std::list<Connection>& connections,
+                         std::string workspace) -> kota::task<> {
+            // See the pipe-mode comment: pre-initialization must run
+            // inside the loop.
+            if(!workspace.empty()) {
+                server.initialize(workspace);
+            }
             co_await kota::when_any(
                 accept_connections(server, std::move(acceptor), register_lsp, connections),
                 server.get_shutdown_event().wait());
             co_await server.shutdown_and_cleanup();
-        }(server, std::move(*acceptor), register_lsp, connections));
+        }(server, std::move(*acceptor), register_lsp, connections, ws));
         loop.run();
         return 0;
     }

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
@@ -102,7 +103,11 @@ public:
 
     std::shared_ptr<Session> find_session(std::uint32_t path_id);
     std::shared_ptr<Session> open_session(std::uint32_t path_id);
-    void close_session(std::uint32_t path_id, kota::ipc::JsonPeer& peer);
+
+    /// Close the session and clear its published diagnostics on `peer`.
+    /// Pass null when no handshake-complete client is attached: nothing was
+    /// ever pushed, so there is nothing to clear.
+    void close_session(std::uint32_t path_id, kota::ipc::JsonPeer* peer);
 
     /// The single entry point for file events: fold the batch through the
     /// Invalidator, then execute the resulting effects against the mutable
@@ -140,17 +145,22 @@ public:
     /// clice/internal/poll test hook drives ticks directly.
     std::unique_ptr<FileTracker> tracker;
 
-    /// Announces a guidance/anomaly message (window/logMessage material).
-    /// The constructor owns the process-wide logging notify hook for the
-    /// server's lifetime and forwards every report here; transports
-    /// subscribe instead of touching the hook themselves. The argument is
-    /// only valid during the emission — subscribers forward it immediately.
-    Signal<const NotifyMessage&> on_notify;
+    /// Wakes subscribers after a new message landed in notify_log. Pure
+    /// wake-up per the Signal contract: subscribers keep a sequence cursor
+    /// and read the messages from the log, so a late subscriber (or a
+    /// missed signal) simply catches up on its next drain. The constructor
+    /// owns the process-wide logging notify hook for the server's lifetime
+    /// and forwards every report here; transports subscribe instead of
+    /// touching the hook themselves.
+    Signal<> on_notify;
 
-    /// Messages retained for clients that attach late (bounded; once full,
-    /// live delivery via on_notify continues but the overflow is not
-    /// retained — the log file is the durable record).
-    std::vector<NotifyMessage> notify_log;
+    /// Recent guidance/anomaly messages (window/logMessage material),
+    /// bounded by dropping the oldest. notify_seq numbers the next message,
+    /// so notify_seq - notify_log.size() is the oldest retained sequence; a
+    /// subscriber lagging further behind than the retention window loses
+    /// the evicted messages (the log file keeps the durable record).
+    std::deque<NotifyMessage> notify_log;
+    std::uint64_t notify_seq = 0;
 
     /// Lifecycle state, advanced by the LSP initialize/shutdown handlers.
     ServerLifecycle lifecycle = ServerLifecycle::Uninitialized;

--- a/src/server/transport/master_server.h
+++ b/src/server/transport/master_server.h
@@ -16,6 +16,8 @@
 #include "server/state/session_store.h"
 #include "server/state/workspace.h"
 #include "server/worker/worker_pool.h"
+#include "support/anomaly.h"
+#include "support/signal.h"
 
 #include "kota/async/async.h"
 #include "kota/deco/deco.h"
@@ -74,6 +76,14 @@ enum class ServerLifecycle : std::uint8_t {
     Exited,
 };
 
+/// A guidance or anomaly message materialized for transport delivery.
+/// The log file is the durable record; this copy exists so a client that
+/// attaches after the message fired can still be shown it.
+struct NotifyMessage {
+    logging::NotifyLevel level;
+    std::string text;
+};
+
 /// Core server state — owns the two-layer state model (Workspace + Sessions),
 /// the worker pool, compilation engine, index query, and background indexer.
 ///
@@ -129,6 +139,18 @@ public:
     /// workspace-less sessions); its polling loops run in bg_tasks, and the
     /// clice/internal/poll test hook drives ticks directly.
     std::unique_ptr<FileTracker> tracker;
+
+    /// Announces a guidance/anomaly message (window/logMessage material).
+    /// The constructor owns the process-wide logging notify hook for the
+    /// server's lifetime and forwards every report here; transports
+    /// subscribe instead of touching the hook themselves. The argument is
+    /// only valid during the emission — subscribers forward it immediately.
+    Signal<const NotifyMessage&> on_notify;
+
+    /// Messages retained for clients that attach late (bounded; once full,
+    /// live delivery via on_notify continues but the overflow is not
+    /// retained — the log file is the durable record).
+    std::vector<NotifyMessage> notify_log;
 
     /// Lifecycle state, advanced by the LSP initialize/shutdown handlers.
     ServerLifecycle lifecycle = ServerLifecycle::Uninitialized;

--- a/src/support/anomaly.h
+++ b/src/support/anomaly.h
@@ -76,12 +76,13 @@ enum class NotifyLevel : std::uint8_t {
     Warning = 2,
 };
 
-/// Process-wide hook that pushes anomaly/guidance messages to the LSP client.
-/// The master sets it once a client peer is available; workers never set it.
+/// Process-wide hook observing anomaly/guidance messages. The master's
+/// composition root (MasterServer) owns it for the server's lifetime and
+/// materializes messages for transport delivery; workers never set it.
 /// Hook registration is internally synchronized, so reporting from any
 /// thread is safe — but the hook itself is invoked from the reporting
 /// thread, so what it DOES must be safe there (the master's hook touches
-/// the peer and is only ever invoked from the event-loop thread).
+/// event-loop state and is only ever invoked from the event-loop thread).
 void set_notify_hook(std::function<void(NotifyLevel, std::string_view)> hook);
 
 /// Replace the debug trap so unit tests can observe anomalies (in any build

--- a/tests/integration/features/test_server.py
+++ b/tests/integration/features/test_server.py
@@ -36,6 +36,11 @@ async def test_capabilities(client, workspace):
     assert capability_enabled(caps.inlay_hint_provider)
     # codeAction is not implemented yet, so it must not be advertised.
     assert not capability_enabled(caps.code_action_provider)
+    # workspace/didChangeWorkspaceFolders is not handled, so workspace
+    # folder support must not be advertised.
+    assert caps.workspace is None or not capability_enabled(
+        caps.workspace.workspace_folders
+    )
     assert caps.document_formatting_provider is True
     assert caps.document_range_formatting_provider is True
     assert caps.semantic_tokens_provider is not None

--- a/tests/integration/lifecycle/test_protocol_edges.py
+++ b/tests/integration/lifecycle/test_protocol_edges.py
@@ -125,6 +125,44 @@ async def test_replay_after_late_handshake(request, executable, tmp_path):
     check_no_anomaly(request, c)
 
 
+async def test_no_stale_replay(request, executable, tmp_path):
+    ws = tmp_path
+    write_source(ws, "main.cpp", "int add(int a, int b) { return a + b; }\n")
+    write_cdb(ws, ["main.cpp"])
+    (ws / "clice.toml").write_text(TEST_TOML)
+
+    c = CliceClient()
+    await c.start_io(str(executable), "serve", f"--workspace={ws}")
+    try:
+        uri, content = c.open(ws / "main.cpp")
+        hover = await c.hover_at(uri, 0, 4)
+        assert hover is not None
+        # An edit during the handshake window invalidates the materialized
+        # output; the replay must skip it instead of pairing pre-edit
+        # results with the new text.
+        did_change(c, uri, 1, content + "int bad(\n")
+        with pytest.raises(Exception):
+            await c.initialize_async(
+                InitializeParams(
+                    capabilities=ClientCapabilities(), root_uri=ws.as_uri()
+                )
+            )
+        c.initialized(InitializedParams())
+        # A request round-trip orders us after the initialized processing:
+        # a (wrong) replay push would already have been recorded.
+        await c.query_context(uri)
+        assert uri not in c.diagnostics
+        # The next compile pushes fresh results for the edited buffer.
+        event = c.wait_for_diagnostics(uri)
+        await c.hover_at(uri, 0, 4)
+        await asyncio.wait_for(event.wait(), timeout=30.0)
+        assert get_errors(c.diagnostics[uri])
+    finally:
+        c.workspace = ws
+        await shutdown_client(c)
+    check_no_anomaly(request, c)
+
+
 async def test_startup_guidance_delivered(request, executable, tmp_path):
     ws = tmp_path
     write_source(ws, "main.cpp", "int x = 1;\n")

--- a/tests/integration/lifecycle/test_protocol_edges.py
+++ b/tests/integration/lifecycle/test_protocol_edges.py
@@ -39,6 +39,25 @@ async def test_open_before_initialize(request, executable, workspace):
 
 
 @pytest.mark.workspace("hello_world")
+async def test_close_before_initialize(request, executable, workspace):
+    c = CliceClient()
+    await c.start_io(str(executable), "serve")
+    try:
+        uri, _ = c.open(workspace / "main.cpp")
+        c.close(uri)
+        await c.initialize(workspace)
+        # The pre-handshake close must not push a diagnostics clear (an
+        # ungated one would be on the wire before the initialize response),
+        # and the closed session must not be replayed.
+        assert uri not in c.diagnostics
+        with pytest.raises(Exception, match="Document not open"):
+            await c.hover_at(uri, 0, 0)
+    finally:
+        await shutdown_client(c)
+    check_no_anomaly(request, c)
+
+
+@pytest.mark.workspace("hello_world")
 async def test_change_without_open(client, workspace):
     uri = (workspace / "main.cpp").as_uri()
     # No didOpen baseline: the edit must be dropped.
@@ -76,6 +95,9 @@ async def test_replay_after_late_handshake(request, executable, tmp_path):
         uri, _ = c.open(ws / "main.cpp")
         hover = await c.hover_at(uri, 0, 4)
         assert hover is not None
+        # Non-vacuous: an ungated push is emitted during the compile the
+        # hover awaits, so it would be on the wire before the hover
+        # response and recorded by the time the hover future resolves.
         assert uri not in c.diagnostics
 
         # A pre-initialized server rejects the initialize request; the
@@ -97,21 +119,22 @@ async def test_replay_after_late_handshake(request, executable, tmp_path):
     check_no_anomaly(request, c)
 
 
-async def test_startup_guidance_replayed(request, executable, tmp_path):
+async def test_startup_guidance_delivered(request, executable, tmp_path):
     ws = tmp_path
     write_source(ws, "main.cpp", "int x = 1;\n")
     (ws / "clice.toml").write_text(TEST_TOML)
     # No compile_commands.json: the headless workspace load emits guidance
-    # before any client is attached; attaching must deliver the backlog.
+    # without waiting for any handshake; the client must still receive it
+    # (drained from the server's notify log).
     c = CliceClient()
     await c.start_io(str(executable), "serve", f"--workspace={ws}")
     try:
-        for _ in range(100):
+        for _ in range(300):
             if any("compile_commands.json" in m for m in guidance_messages(c)):
                 break
             await asyncio.sleep(0.1)
         else:
-            pytest.fail("startup guidance was not replayed to the late client")
+            pytest.fail("startup guidance never reached the client")
     finally:
         c.workspace = ws
         await shutdown_client(c)

--- a/tests/integration/lifecycle/test_protocol_edges.py
+++ b/tests/integration/lifecycle/test_protocol_edges.py
@@ -1,0 +1,118 @@
+"""Document-sync protocol edges: notifications that arrive outside the
+expected lifecycle window, and replay of state that materialized before the
+client handshake completed."""
+
+import asyncio
+
+import pytest
+from lsprotocol.types import ClientCapabilities, InitializedParams, InitializeParams
+
+from tests.conftest import check_no_anomaly, shutdown_client
+from tests.integration.utils.assertions import get_errors, guidance_messages
+from tests.integration.utils.client import CliceClient
+from tests.integration.utils.workspace import did_change, write_cdb, write_source
+
+TEST_TOML = (
+    '[project]\ncache_dir = "${workspace}/.clice"\nenable_indexing = false\n'
+    "\n[tracker]\ncdb_poll_seconds = 0\nworkspace_poll_seconds = 0\n"
+)
+
+
+@pytest.mark.workspace("hello_world")
+async def test_open_before_initialize(request, executable, workspace):
+    c = CliceClient()
+    await c.start_io(str(executable), "serve")
+    try:
+        # didOpen racing ahead of the handshake is accepted; the session
+        # must be fully usable once the server becomes ready.
+        uri, _ = c.open(workspace / "main.cpp")
+        await c.initialize(workspace)
+
+        event = c.wait_for_diagnostics(uri)
+        hover = await c.hover_at(uri, 2, 4)
+        assert hover is not None and hover.contents is not None
+        await asyncio.wait_for(event.wait(), timeout=60.0)
+        assert get_errors(c.diagnostics[uri]) == []
+    finally:
+        await shutdown_client(c)
+    check_no_anomaly(request, c)
+
+
+@pytest.mark.workspace("hello_world")
+async def test_change_without_open(client, workspace):
+    uri = (workspace / "main.cpp").as_uri()
+    # No didOpen baseline: the edit must be dropped.
+    did_change(client, uri, 1, "int broken(")
+    with pytest.raises(Exception, match="Document not open"):
+        await client.hover_at(uri, 0, 0)
+    # The dropped edit must not poison a later open.
+    uri, _ = await client.open_and_wait(workspace / "main.cpp")
+    assert get_errors(client.diagnostics[uri]) == []
+
+
+@pytest.mark.workspace("hello_world")
+async def test_version_regression_tolerated(client, workspace):
+    uri, content = client.open(workspace / "main.cpp", version=5)
+    # A version that goes backwards is a client bug; the edit is applied
+    # anyway (and warned about server-side).
+    event = client.wait_for_diagnostics(uri)
+    did_change(client, uri, 3, content + "\nint bad(\n")
+    await client.hover_at(uri, 0, 0)
+    await asyncio.wait_for(event.wait(), timeout=60.0)
+    assert get_errors(client.diagnostics[uri])
+
+
+async def test_replay_after_late_handshake(request, executable, tmp_path):
+    ws = tmp_path
+    write_source(ws, "main.cpp", "int add(int a, int b) { return a + b; }\n")
+    write_cdb(ws, ["main.cpp"])
+    (ws / "clice.toml").write_text(TEST_TOML)
+
+    c = CliceClient()
+    await c.start_io(str(executable), "serve", f"--workspace={ws}")
+    try:
+        # The server is pre-initialized (ready); the client has not done its
+        # handshake yet. Compile output materializes but must not be pushed.
+        uri, _ = c.open(ws / "main.cpp")
+        hover = await c.hover_at(uri, 0, 4)
+        assert hover is not None
+        assert uri not in c.diagnostics
+
+        # A pre-initialized server rejects the initialize request; the
+        # handshake still completes with the initialized notification, which
+        # replays the materialized output.
+        with pytest.raises(Exception):
+            await c.initialize_async(
+                InitializeParams(
+                    capabilities=ClientCapabilities(), root_uri=ws.as_uri()
+                )
+            )
+        event = c.wait_for_diagnostics(uri)
+        c.initialized(InitializedParams())
+        await asyncio.wait_for(event.wait(), timeout=30.0)
+        assert get_errors(c.diagnostics[uri]) == []
+    finally:
+        c.workspace = ws
+        await shutdown_client(c)
+    check_no_anomaly(request, c)
+
+
+async def test_startup_guidance_replayed(request, executable, tmp_path):
+    ws = tmp_path
+    write_source(ws, "main.cpp", "int x = 1;\n")
+    (ws / "clice.toml").write_text(TEST_TOML)
+    # No compile_commands.json: the headless workspace load emits guidance
+    # before any client is attached; attaching must deliver the backlog.
+    c = CliceClient()
+    await c.start_io(str(executable), "serve", f"--workspace={ws}")
+    try:
+        for _ in range(100):
+            if any("compile_commands.json" in m for m in guidance_messages(c)):
+                break
+            await asyncio.sleep(0.1)
+        else:
+            pytest.fail("startup guidance was not replayed to the late client")
+    finally:
+        c.workspace = ws
+        await shutdown_client(c)
+    check_no_anomaly(request, c)

--- a/tests/integration/lifecycle/test_protocol_edges.py
+++ b/tests/integration/lifecycle/test_protocol_edges.py
@@ -24,11 +24,13 @@ async def test_open_before_initialize(request, executable, workspace):
     await c.start_io(str(executable), "serve")
     try:
         # didOpen racing ahead of the handshake is accepted; the session
-        # must be fully usable once the server becomes ready.
+        # must be fully usable once the server becomes ready. Register the
+        # waiter before the handshake so a push emitted during it cannot
+        # be missed.
         uri, _ = c.open(workspace / "main.cpp")
+        event = c.wait_for_diagnostics(uri)
         await c.initialize(workspace)
 
-        event = c.wait_for_diagnostics(uri)
         hover = await c.hover_at(uri, 2, 4)
         assert hover is not None and hover.contents is not None
         await asyncio.wait_for(event.wait(), timeout=60.0)
@@ -52,6 +54,10 @@ async def test_close_before_initialize(request, executable, workspace):
         assert uri not in c.diagnostics
         with pytest.raises(Exception, match="Document not open"):
             await c.hover_at(uri, 0, 0)
+        # The file closed before ready went through the reindex queue; a
+        # normal open/compile cycle must still work afterwards.
+        uri, _ = await c.open_and_wait(workspace / "main.cpp")
+        assert get_errors(c.diagnostics[uri]) == []
     finally:
         await shutdown_client(c)
     check_no_anomaly(request, c)

--- a/tests/unit/server/notify_log_tests.cpp
+++ b/tests/unit/server/notify_log_tests.cpp
@@ -1,0 +1,46 @@
+#include <string>
+
+#include "test/test.h"
+#include "server/transport/master_server.h"
+#include "support/anomaly.h"
+#include "support/logging.h"
+
+#include "kota/async/async.h"
+
+namespace clice::testing {
+namespace {
+
+TEST_SUITE(NotifyLog) {
+
+TEST_CASE(BoundedRetention) {
+    kota::event_loop loop;
+    MasterServer server(loop, "clice-test");
+
+    // Keep the guidance gate open but silence the console sink: the test
+    // fires well over a hundred reports.
+    auto saved_level = spdlog::get_level();
+    spdlog::set_level(spdlog::level::off);
+
+    std::size_t wakeups = 0;
+    auto conn = server.on_notify.connect([&] { wakeups += 1; });
+
+    for(int i = 0; i < 130; i++) {
+        LOG_GUIDANCE("notify retention probe {}", i);
+    }
+
+    spdlog::set_level(saved_level);
+
+    EXPECT_EQ(server.notify_seq, 130u);
+    EXPECT_EQ(wakeups, 130u);
+    ASSERT_EQ(server.notify_log.size(), 128u);
+    // Drop-oldest: the first two messages were evicted, and the sequence
+    // arithmetic keeps addressing the retained window.
+    EXPECT_TRUE(server.notify_log.front().text.ends_with("probe 2"));
+    EXPECT_TRUE(server.notify_log.back().text.ends_with("probe 129"));
+    EXPECT_EQ(server.notify_seq - server.notify_log.size(), 2u);
+}
+
+};  // TEST_SUITE(NotifyLog)
+
+}  // namespace
+}  // namespace clice::testing


### PR DESCRIPTION
Hardens the LSP transport layer around lifecycle edges and cleans up the server-to-client notification pipeline.

## Behavior changes

- **didOpen before the server is ready is now accepted** (previously silently dropped). Sessions are plain state with no worker dependency, so the buffer is installed immediately and a warning is logged; the first post-ready request compiles it. didChange/didClose in the same window are accepted too, so an early-opened buffer cannot drift or leak. Document-sync notifications are still dropped once shutdown has begun. Persisted context choices for early-opened files are re-validated once the workspace cache is loaded.
- **didChange for a file with no open session logs an error** and is still discarded — without the didOpen baseline there is no buffer to fold edits into.
- **Non-monotonic didChange versions log a warning**; the edit is applied as before.
- **Diagnostics respect the handshake**: publishDiagnostics and progress-token creation are held back until the client sends `initialized` (the LSP spec forbids server-to-client traffic other than window/* before the initialize response). Compile outputs that materialize earlier are replayed right after `initialized` — this is what makes a late-attaching client (server started with `serve --workspace`) see diagnostics for files compiled before it connected.
- **`initialized` no longer re-initializes a pre-initialized server.** Previously a server started with `serve --workspace` would run its initialization a second time when the client completed the handshake, spawning a second worker pool. Side effect: a client that skips `initialize` entirely and sends `initialized` (a hard protocol violation) now leaves the server un-initialized instead of force-initializing it with an empty workspace.
- **didClose before the handshake no longer pushes a diagnostics clear.** Nothing was ever pushed for the file, and publishDiagnostics may not flow before the initialize response.
- **Guidance/anomaly messages are materialized in server state.** The process-wide logging notify hook is now owned by the server composition root for its whole lifetime instead of being set and cleared by each LSP client. Messages land in a bounded sequence-numbered log (drop-oldest) and a payload-free signal wakes subscribers, which keep a cursor and drain the log — so a client that attaches late still receives what a headless server accumulated (e.g. the "no compile_commands.json found" guidance), and a missed wake-up is harmless. This keeps the codebase's signal contract intact: data lives in state, signals only wake.
- **Capabilities now match the implementation** (audit below): workspace-folder support is no longer advertised — there is no `workspace/didChangeWorkspaceFolders` handler.

## Startup crash fix in `serve --workspace`

Separate from the protocol-edge theme: starting the server with `serve --workspace=<dir>` crashed on startup whenever a cache store opened. Pre-initialization ran before the event loop started, but opening the cache store spawns a background checkpoint task whose first suspension requires the running loop, so the process segfaulted before serving a single request. Pre-initialization now runs as the first step inside the event loop — before the peer reads any message — in both pipe and socket modes.

It is delivered in this PR rather than split out because it lives on the exact initialization path this PR reworks, the fix itself is two small moves, and the headless-start flow it repairs is what the new replay tests exercise.

## Capabilities audit

| Advertised capability | Handler | Implementation | Verdict |
|---|---|---|---|
| textDocumentSync (openClose, incremental, save) | didOpen/didChange/didClose/didSave | SessionStore + invalidation dispatch | keep |
| workspace.workspaceFolders (supported, changeNotifications) | none | none | **removed** |
| hoverProvider | yes | stateful worker query | keep |
| completionProvider (trigger characters) | yes | stateless worker build + include/import path completion | keep |
| signatureHelpProvider (trigger characters) | yes | stateless worker build | keep |
| declarationProvider | yes | index query | keep |
| definitionProvider | yes | index query + include-directive resolution | keep |
| implementationProvider | yes | index query | keep |
| typeDefinitionProvider | yes | index query | keep |
| referencesProvider | yes | index query | keep |
| documentSymbolProvider | yes | stateful worker query | keep |
| documentLinkProvider | yes | stateful worker + cached preamble links | keep |
| foldingRangeProvider | yes | stateful worker query | keep |
| inlayHintProvider | yes | stateful worker query | keep |
| callHierarchyProvider (prepare/incoming/outgoing) | yes | index query | keep |
| typeHierarchyProvider (prepare/supertypes/subtypes) | yes | index query | keep |
| workspaceSymbolProvider | yes | index search | keep |
| documentFormattingProvider | yes | stateless worker (clang-format) | keep |
| documentRangeFormattingProvider | yes | stateless worker (clang-format) | keep |
| semanticTokensProvider (full) | yes | stateful worker query | keep |
| codeAction | handler exists; worker side is a stub returning `[]` | correctly **not advertised** (unchanged) |

## Also in this PR

- The TODO about the index-progress `create()` handshake racing connection teardown is replaced with a safety argument: the peer fails all pending outgoing requests before its `run()` returns and the resumption reads only the request's shared completion state; both composition sites destroy the LSP client (which sets the `abandoned` flag) strictly before the peer.

## Tests

- New integration tests (`tests/integration/lifecycle/test_protocol_edges.py`): early didOpen, close before the handshake, orphan didChange, version regression, diagnostics replay after a late handshake, startup-guidance delivery to a late-attaching client.
- New unit test (`tests/unit/server/notify_log_tests.cpp`): bounded retention and sequence arithmetic of the notify log.
- Capability audit anchored in `tests/integration/features/test_server.py`.
- Known coverage gaps, judged low-value to force: the progress-create gate (needs an indexing round racing the handshake — timing-sensitive) and a direct assertion that re-initialization did not spawn a second pool (not observable over LSP; the anomaly teardown gate covers the crash flavor).
- The reconnect flavor of the replay scenario (a second LSP client attaching to a running server) is not covered: the transport currently registers at most one LSP client per process, so that timing cannot be constructed. The `serve --workspace` pre-initialization flow exercises the same replay path end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable guidance/anomaly notification buffering with bounded retention and reliable draining for late subscribers.
  * Improved LSP handshake flow to replay queued outputs/diagnostics for late clients.
* **Bug Fixes**
  * Dropped document-sync notifications/events once shutdown begins and gated publishing until the client is ready.
  * Corrected handling for early/late didOpen/didChange/didClose and session-less edits; tightened capability reporting (no workspace folders support).
* **Tests**
  * Expanded protocol edge integration coverage and added unit tests for bounded notification retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->