### PR TITLE
feat(server): worker-side dependency hashing and module import edges

### DIFF
--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -7,6 +7,7 @@
 #include "support/logging.h"
 
 #include "llvm/Support/Error.h"
+#include "llvm/Support/xxhash.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -414,6 +415,12 @@ CompilationUnit compile(CompilationParams& params, PCMInfo& out) {
             for(auto& [name, path]: params.pcms) {
                 out.mods.emplace_back(name);
             }
+
+            // The interface source itself is read from disk by this build, so
+            // it is a dependency of the PCM like any header it includes.
+            out.deps = unit.deps();
+            out.deps.push_back(
+                {out.srcPath, llvm::xxh3_64bits(unit.file_content(unit.interested_file()))});
         });
 }
 

--- a/src/compile/compilation.h
+++ b/src/compile/compilation.h
@@ -33,8 +33,8 @@ struct PCHInfo {
     /// The content used to build this PCH.
     std::string preamble;
 
-    /// All files involved in building this PCH.
-    std::vector<std::string> deps;
+    /// All files involved in building this PCH, with consumed-content hashes.
+    std::vector<HashedDep> deps;
 
     /// The command arguments used to build this PCH.
     std::vector<const char*> arguments;
@@ -59,8 +59,10 @@ struct PCMInfo : ModuleInfo {
     /// Source file path.
     std::string srcPath;
 
-    /// Files involved in building this PCM(not include module).
-    std::vector<std::string> deps;
+    /// Files involved in building this PCM, with consumed-content hashes.
+    /// Includes the module's own interface source and the sources of every
+    /// imported module.
+    std::vector<HashedDep> deps;
 };
 
 struct CompilationParams {

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -1,6 +1,7 @@
 #include "compile/implement.h"
 #include "index/usr.h"
 #include "semantic/ast_utility.h"
+#include "support/filesystem.h"
 
 #include "kota/ipc/lsp/text.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -256,16 +257,6 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
     return self->instance->getLangOpts();
 }
 
-/// Hash a file's content with the same scheme the server layer uses for its
-/// dependency snapshots (workspace's `hash_file`). Returns 0 on read failure.
-static std::uint64_t hash_file_content(llvm::StringRef path) {
-    auto buffer = llvm::MemoryBuffer::getFile(path);
-    if(!buffer) {
-        return 0;
-    }
-    return llvm::xxh3_64bits((*buffer)->getBuffer());
-}
-
 std::vector<HashedDep> CompilationUnitRef::deps() {
     llvm::StringMap<std::uint64_t> deps;
 
@@ -316,30 +307,39 @@ std::vector<HashedDep> CompilationUnitRef::deps() {
 }
 
 std::vector<HashedDep> CompilationUnitRef::imported_module_sources() {
-    std::vector<HashedDep> sources;
-    auto reader = self->instance->getASTReader();
-    if(!reader) {
-        return sources;
+    if(self->imported_sources) {
+        return *self->imported_sources;
     }
+
+    std::vector<HashedDep> sources;
 
     // The module manager chain covers every loaded module file, including
     // transitively loaded ones — exactly the set whose interface sources this
     // compilation's semantics depend on. The sources were consumed through
     // their PCMs, never read here, so there is no resident buffer to hash:
-    // read them from disk instead. A save landing between the PCM build and
-    // this hash is caught by the push-side invalidation cascade, not by this
-    // snapshot.
-    for(auto& file: reader->getModuleManager()) {
-        if(!file.StandardCXXModule) {
-            continue;
-        }
-        auto& source = file.ActualOriginalSourceFileName.empty()
-                           ? file.OriginalSourceFileName
-                           : file.ActualOriginalSourceFileName;
-        if(!source.empty()) {
-            sources.push_back({source, hash_file_content(source)});
+    // read them from disk instead. This makes the snapshot after-the-fact
+    // for this one edge class: an interface saved between its PCM build and
+    // this hash is recorded with content the consumed PCM predates. Open
+    // importers recover through the save cascade — the dirty flag survives
+    // an in-flight compile — while a closed importer's index shard can have
+    // its save-triggered redo filtered as fresh, staying stale until the
+    // interface changes again. Closing that narrow window would require the
+    // consumed PCM's identity to travel with the result.
+    if(auto reader = self->instance->getASTReader()) {
+        for(auto& file: reader->getModuleManager()) {
+            if(!file.StandardCXXModule) {
+                continue;
+            }
+            auto& source = file.ActualOriginalSourceFileName.empty()
+                               ? file.OriginalSourceFileName
+                               : file.ActualOriginalSourceFileName;
+            if(!source.empty()) {
+                sources.push_back({source, fs::hash_file(source)});
+            }
         }
     }
+
+    self->imported_sources = sources;
     return sources;
 }
 

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -3,6 +3,10 @@
 #include "semantic/ast_utility.h"
 
 #include "kota/ipc/lsp/text.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/xxhash.h"
+#include "clang/Serialization/ASTReader.h"
+#include "clang/Serialization/ModuleManager.h"
 
 namespace clice {
 
@@ -252,38 +256,91 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
     return self->instance->getLangOpts();
 }
 
-std::vector<std::string> CompilationUnitRef::deps() {
-    llvm::StringSet<> deps;
+/// Hash a file's content with the same scheme the server layer uses for its
+/// dependency snapshots (workspace's `hash_file`). Returns 0 on read failure.
+static std::uint64_t hash_file_content(llvm::StringRef path) {
+    auto buffer = llvm::MemoryBuffer::getFile(path);
+    if(!buffer) {
+        return 0;
+    }
+    return llvm::xxh3_64bits((*buffer)->getBuffer());
+}
+
+std::vector<HashedDep> CompilationUnitRef::deps() {
+    llvm::StringMap<std::uint64_t> deps;
 
     /// FIXME: consider `#embed` and `__has_embed`.
+
+    auto add_resident = [&](clang::FileID fid) {
+        auto path = file_path(fid);
+        if(path.empty()) {
+            return;
+        }
+        auto [it, inserted] = deps.try_emplace(path, 0);
+        if(!inserted) {
+            return;
+        }
+        // Hash the buffer the compiler actually consumed rather than
+        // re-reading the file: a disk change that lands while the compilation
+        // is running can then never be blessed as the built-from content.
+        if(auto buffer = self->SM().getBufferOrNone(fid)) {
+            it->second = llvm::xxh3_64bits(buffer->getBuffer());
+        }
+    };
 
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
             if(!include.skipped) {
-                auto path = file_path(include.fid);
-                if(!path.empty()) {
-                    deps.try_emplace(path);
-                }
+                add_resident(include.fid);
             }
         }
 
         for(auto& has_include: directive.has_includes) {
             if(has_include.fid.isValid()) {
-                auto path = file_path(has_include.fid);
-                if(!path.empty()) {
-                    deps.try_emplace(path);
-                }
+                add_resident(has_include.fid);
             }
         }
     }
 
-    std::vector<std::string> result;
+    for(auto& dep: imported_module_sources()) {
+        deps.try_emplace(dep.path, dep.hash);
+    }
 
-    for(auto& deps: deps) {
-        result.emplace_back(deps.getKey().str());
+    std::vector<HashedDep> result;
+    result.reserve(deps.size());
+    for(auto& entry: deps) {
+        result.push_back({entry.getKey().str(), entry.getValue()});
     }
 
     return result;
+}
+
+std::vector<HashedDep> CompilationUnitRef::imported_module_sources() {
+    std::vector<HashedDep> sources;
+    auto reader = self->instance->getASTReader();
+    if(!reader) {
+        return sources;
+    }
+
+    // The module manager chain covers every loaded module file, including
+    // transitively loaded ones — exactly the set whose interface sources this
+    // compilation's semantics depend on. The sources were consumed through
+    // their PCMs, never read here, so there is no resident buffer to hash:
+    // read them from disk instead. A save landing between the PCM build and
+    // this hash is caught by the push-side invalidation cascade, not by this
+    // snapshot.
+    for(auto& file: reader->getModuleManager()) {
+        if(!file.StandardCXXModule) {
+            continue;
+        }
+        auto& source = file.ActualOriginalSourceFileName.empty()
+                           ? file.OriginalSourceFileName
+                           : file.ActualOriginalSourceFileName;
+        if(!source.empty()) {
+            sources.push_back({source, hash_file_content(source)});
+        }
+    }
+    return sources;
 }
 
 index::SymbolID CompilationUnitRef::getSymbolID(const clang::NamedDecl* decl) {

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -9,6 +9,7 @@
 
 #include "compile/diagnostic.h"
 #include "compile/directive.h"
+#include "compile/hashed_dep.h"
 #include "semantic/resolver.h"
 #include "syntax/token.h"
 
@@ -242,7 +243,19 @@ public:
     /// All files involved in building the unit.
     const llvm::DenseSet<clang::FileID>& files();
 
-    std::vector<std::string> deps();
+    /// All files this compilation consumed, each with the hash of the
+    /// consumed content: include and __has_include targets are hashed from
+    /// their SourceManager-resident buffers, imported C++20 module interface
+    /// sources (see imported_module_sources) from disk. The main file is
+    /// excluded — its content is the caller's input, not a dependency.
+    std::vector<HashedDep> deps();
+
+    /// Source paths of every C++20 module interface unit whose PCM this
+    /// compilation loaded, direct or transitive, as recorded in the module
+    /// files themselves, each hashed from disk (the source has no resident
+    /// buffer — it was consumed through its PCM). Empty when no named
+    /// modules were loaded.
+    std::vector<HashedDep> imported_module_sources();
 
     /// Get symbol ID for given declaration.
     index::SymbolID getSymbolID(const clang::NamedDecl* decl);

--- a/src/compile/hashed_dep.h
+++ b/src/compile/hashed_dep.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace clice {
+
+/// A file a compilation consumed, together with the xxh3_64 hash of the
+/// content the compiler actually read. The hash is computed by the worker at
+/// the end of the compilation from the SourceManager-resident buffer (module
+/// interface sources, which are consumed indirectly through their PCM, are
+/// hashed from disk instead). The master adopts these hashes verbatim for its
+/// staleness snapshots, so "fresh" always means "the artifact was built from
+/// exactly this content" — never "the disk happened to look like this when
+/// the result arrived".
+///
+/// A hash of 0 means the content could not be read (same sentinel as
+/// hash_file); staleness checks treat it conservatively.
+struct HashedDep {
+    std::string path;
+    std::uint64_t hash = 0;
+
+    friend bool operator==(const HashedDep&, const HashedDep&) = default;
+};
+
+}  // namespace clice

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -99,6 +99,11 @@ struct CompilationUnitRef::Self {
     std::chrono::milliseconds build_at;
     std::chrono::milliseconds build_duration;
 
+    /// Cached imported_module_sources() result: deps() and TUIndex::build
+    /// both need it for the same unit, and the disk read + hash per module
+    /// interface source need not repeat.
+    std::optional<std::vector<HashedDep>> imported_sources;
+
     auto& SM() {
         return instance->getSourceManager();
     }

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -13,7 +13,7 @@ static std::uint32_t addIncludeChain(CompilationUnitRef unit,
         return -1;
     }
 
-    auto& [paths, locations, file_table] = graph;
+    auto& [paths, path_hashes, locations, file_table] = graph;
 
     auto [iter, success] = file_table.try_emplace(fid, locations.size());
     if(!success) {
@@ -52,6 +52,18 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit) {
         graph.file_table[fid] = addIncludeChain(unit, fid, graph, path_table);
     }
     graph.paths.emplace_back(unit.file_path(unit.interested_file()));
+
+    // Hash every path's resident buffer — the content this compilation
+    // actually consumed, immune to concurrent disk writes.
+    graph.path_hashes.assign(graph.paths.size(), 0);
+    for(auto [fid, location]: graph.file_table) {
+        if(location != std::uint32_t(-1)) {
+            graph.path_hashes[graph.locations[location].path_id] =
+                llvm::xxh3_64bits(unit.file_content(fid));
+        }
+    }
+    graph.path_hashes.back() = llvm::xxh3_64bits(unit.file_content(unit.interested_file()));
+
     return graph;
 }
 

--- a/src/index/include_graph.h
+++ b/src/index/include_graph.h
@@ -36,6 +36,12 @@ struct IncludeGraph {
     /// don't want to save its path repeatedly, so cache it here.
     std::vector<std::string> paths;
 
+    /// xxh3 hash of each path's content as the compilation consumed it
+    /// (parallel to `paths`), taken from the SourceManager-resident buffers
+    /// at index-build time. The merge side adopts these as staleness
+    /// baselines instead of re-reading the files from disk. 0 = unknown.
+    std::vector<std::uint64_t> path_hashes;
+
     /// All include locations in this tu.
     std::vector<IncludeLocation> locations;
 

--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -670,6 +670,10 @@ void MergedIndex::lookup(this const Self& self,
 }
 
 bool MergedIndex::need_update(this const Self& self) {
+    // compilation_contexts holds at most one entry — the shard's own TU
+    // (merge() is only ever called with tu_path == the shard's file; header
+    // contributions go through header_contexts instead) — so begin() below
+    // reads the whole story, not an arbitrary sample.
     if(self.impl) {
         if(self.impl->compilation_contexts.empty()) {
             return true;
@@ -869,14 +873,12 @@ void MergedIndex::merge(this Self& self,
     self.impl->content = content.str();
     self.impl->line_starts = kota::ipc::lsp::build_line_starts(self.impl->content);
 
-    // Intern the dependencies into the shard's own path table, and capture a
-    // content hash for each distinct one so a later staleness check can tell
-    // a real edit apart from a mere touch (mtime bumped, bytes unchanged).
-    // Only re-hashing at check time can prove that, so the baseline is
-    // recorded here.
-    // TODO: this re-reads every dependency on the event-loop thread even
-    // though the indexer worker already read them; if it shows up on large
-    // cold-start profiles, have the worker ship the hashes in the TUIndex.
+    // Intern the dependencies into the shard's own path table, adopting the
+    // hash of the content the indexing compilation actually consumed as the
+    // staleness baseline: the shard's rows are a function of exactly that
+    // content, so a later mtime bump with matching bytes is provably a mere
+    // touch, and any divergence — including a write that landed during the
+    // indexing run — makes the shard look stale. No disk I/O here.
     std::vector<IncludeLocation> include_locations;
     llvm::SmallVector<DepHash> dep_hashes;
     llvm::DenseSet<std::uint32_t> seen;
@@ -887,19 +889,11 @@ void MergedIndex::merge(this Self& self,
         if(!seen.insert(local_id).second) {
             continue;
         }
-        // A dep modified after the indexed snapshot was built must not
-        // contribute a baseline: hashing it now would bless content the
-        // rows were never built from, hiding the edit forever. With no
-        // stored hash the staleness check stays conservative and the TU
-        // simply reindexes once more.
-        fs::file_status status;
-        if(auto err = fs::status(dep.path, status)) {
-            continue;
-        }
-        auto mtime = std::chrono::duration_cast<std::chrono::milliseconds>(
-            status.getLastModificationTime().time_since_epoch());
-        if(mtime <= build_at) {
-            dep_hashes.emplace_back(local_id, hash_file(dep.path));
+        // A dep the worker could not hash contributes no baseline: the
+        // staleness check then stays conservative (one extra reindex when
+        // its mtime moves) instead of trusting a hash of nothing.
+        if(dep.hash != 0) {
+            dep_hashes.emplace_back(local_id, dep.hash);
         }
     }
 

--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -90,16 +90,6 @@ struct DepHash {
 
 namespace {
 
-/// Hash a file's content with the same scheme the server layer uses for its
-/// dependency snapshots (`workspace::hash_file`). Returns 0 on read failure.
-std::uint64_t hash_file(llvm::StringRef path) {
-    auto buffer = llvm::MemoryBuffer::getFile(path);
-    if(!buffer) {
-        return 0;
-    }
-    return llvm::xxh3_64bits((*buffer)->getBuffer());
-}
-
 /// Two-layer staleness test for a single dependency, mirroring the server's
 /// `deps_changed`: Layer 1 trusts an unchanged mtime (no file read); Layer 2
 /// re-hashes a file whose mtime moved and treats a matching hash as a mere
@@ -129,7 +119,7 @@ bool dep_stale(llvm::StringRef path,
     // the whole shard just to skip a rebuild. So a touched-but-unchanged file is
     // re-hashed on every check until a real edit forces a genuine reindex — a
     // cheap single read, far cheaper than a needless full reindex.
-    return hash_file(path) != *stored_hash;
+    return fs::hash_file(path) != *stored_hash;
 }
 
 }  // namespace

--- a/src/index/merged_index.h
+++ b/src/index/merged_index.h
@@ -14,11 +14,14 @@
 namespace clice::index {
 
 /// A dependency of a compilation context: where it was included and the
-/// file's path, interned into the shard's own path table on merge.
+/// file's path, interned into the shard's own path table on merge, plus the
+/// xxh3 hash of the content the indexing compilation consumed (0 = unknown),
+/// stored as the staleness baseline.
 struct DepLocation {
     llvm::StringRef path;
     std::uint32_t line = 0;
     std::uint32_t include_id = 0;
+    std::uint64_t hash = 0;
 };
 
 class MergedIndex {

--- a/src/index/schema.fbs
+++ b/src/index/schema.fbs
@@ -173,6 +173,14 @@ file_indices:
     [TUFileIndexEntry];
 main_file_index:
     TUFileIndexEntry;
+
+// Consumed-content hash per path (parallel to `paths`), and path ids of
+// imported C++20 module interface sources. See index/include_graph.h and
+// index/tu_index.h.
+path_hashes:
+    [ulong];
+imports:
+    [uint];
 }
 
 // The blob's path table is compact: only paths referenced by the symbol

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -30,6 +30,25 @@ public:
     Builder(TUIndex& result, CompilationUnitRef unit, bool interested_only) :
         SemanticVisitor<Builder>(unit, interested_only), result(result) {
         result.graph = IncludeGraph::from(unit);
+
+        // Imported module interface sources join the path table as
+        // dependencies of this TU's shard. This must happen before build()
+        // computes any path id (reference bitmaps bake them in), and the
+        // main file must stay the last path — an IncludeGraph convention
+        // consumers rely on — so imports are inserted just before it.
+        // Existing location path_ids are unaffected: they never reference
+        // the main file.
+        auto& graph = result.graph;
+        for(auto& dep: unit.imported_module_sources()) {
+            auto it = std::ranges::find(graph.paths, dep.path);
+            if(it == graph.paths.end()) {
+                graph.paths.insert(graph.paths.end() - 1, dep.path);
+                graph.path_hashes.insert(graph.path_hashes.end() - 1, dep.hash);
+                result.imports.push_back(static_cast<std::uint32_t>(graph.paths.size() - 2));
+            } else {
+                result.imports.push_back(static_cast<std::uint32_t>(it - graph.paths.begin()));
+            }
+        }
     }
 
     void handleDeclOccurrence(const clang::NamedDecl* decl,
@@ -260,6 +279,23 @@ public:
 
         index_modules();
 
+        // Rows can land in files this TU never preprocessed: locations
+        // inside an imported module's AST resolve to the module's own
+        // source files, which the include graph does not know. Those rows
+        // belong to the module's own index run (the merge side could not
+        // attribute them here anyway — they carry no include location in
+        // this TU), so drop them instead of handing path_id an unknown
+        // FileID below.
+        llvm::SmallVector<clang::FileID> foreign;
+        for(auto& [fid, index]: result.file_indices) {
+            if(!result.graph.file_table.contains(fid)) {
+                foreign.push_back(fid);
+            }
+        }
+        for(auto fid: foreign) {
+            result.file_indices.erase(fid);
+        }
+
         for(auto& [fid, index]: result.file_indices) {
             for(auto& [symbol_id, relations]: index.relations) {
                 std::ranges::sort(relations, [](const Relation& lhs, const Relation& rhs) {
@@ -423,7 +459,9 @@ void TUIndex::serialize(llvm::raw_ostream& os) const {
                               CreateStructVector<binary::IncludeLocation>(builder, graph.locations),
                               CreateVector(builder, syms),
                               builder.CreateVector(file_idx_vec.data(), file_idx_vec.size()),
-                              main_idx);
+                              main_idx,
+                              builder.CreateVector(graph.path_hashes),
+                              builder.CreateVector(imports));
 
     builder.Finish(tu_index);
     os.write(safe_cast<const char>(builder.GetBufferPointer()), builder.GetSize());
@@ -437,6 +475,15 @@ TUIndex TUIndex::from(const void* data) {
 
     for(auto p: *root->paths()) {
         index.graph.paths.emplace_back(p->str());
+    }
+
+    if(root->path_hashes()) {
+        index.graph.path_hashes.assign(root->path_hashes()->begin(), root->path_hashes()->end());
+    }
+    index.graph.path_hashes.resize(index.graph.paths.size(), 0);
+
+    if(root->imports()) {
+        index.imports.assign(root->imports()->begin(), root->imports()->end());
     }
 
     for(auto loc: *root->locations()) {

--- a/src/index/tu_index.h
+++ b/src/index/tu_index.h
@@ -98,6 +98,12 @@ struct TUIndex {
     /// The include information of this file.
     IncludeGraph graph;
 
+    /// Indices into graph.paths of the C++20 module interface sources this
+    /// TU consumed (through their PCMs, direct or transitive). They carry no
+    /// include location but are dependencies of the TU's index shard: a
+    /// module interface change must make the shard look stale.
+    std::vector<std::uint32_t> imports;
+
     SymbolTable symbols;
 
     llvm::DenseMap<clang::FileID, FileIndex> file_indices;

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -785,7 +785,9 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 
             if(indicates_missing_context(diagnostics)) {
                 LOG_INFO("Header {} needs includer context, re-compiling with prefix", uri_str);
-                contexts.record_header_mode(pid, HeaderMode::NeedsContext, hash_file(file_path));
+                contexts.record_header_mode(pid,
+                                            HeaderMode::NeedsContext,
+                                            fs::hash_file(file_path));
                 workspace.save_cache(contexts);
                 contexts.drop_header_context(pid);
                 session->pch_ref.reset();

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -251,10 +251,11 @@ void Compiler::init_compile_graph() {
 
         auto pcm_path = std::move(committed.value().value());
         workspace.pcm_paths[path_id] = pcm_path;
-        workspace.pcm_cache[path_id] = {
-            pcm_path,
-            pcm_key,
-            capture_deps_snapshot(workspace.path_pool, result.value().deps)};
+        workspace.pcm_cache[path_id] = {pcm_path,
+                                        pcm_key,
+                                        capture_deps_snapshot(workspace.path_pool,
+                                                              result.value().deps,
+                                                              result.value().build_at)};
         LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
         // Persist cache metadata after successful build.
@@ -453,7 +454,8 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
     auto& st = workspace.pch_cache[pch_key];
     st.path = committed.value().value();
     st.bound = bound;
-    st.deps = capture_deps_snapshot(workspace.path_pool, result.value().deps);
+    st.deps =
+        capture_deps_snapshot(workspace.path_pool, result.value().deps, result.value().build_at);
     st.preamble_links = std::move(result.value().preamble_links);
     st.inactive_regions = std::move(result.value().inactive_regions);
     st.open_conditionals = std::move(result.value().open_conditionals);
@@ -612,8 +614,10 @@ bool Compiler::is_stale(const Session& session) {
     return false;
 }
 
-void Compiler::record_deps(Session& session, llvm::ArrayRef<std::string> deps) {
-    session.ast_deps = capture_deps_snapshot(workspace.path_pool, deps);
+void Compiler::record_deps(Session& session,
+                           llvm::ArrayRef<HashedDep> deps,
+                           std::int64_t build_at) {
+    session.ast_deps = capture_deps_snapshot(workspace.path_pool, deps, build_at);
 }
 
 /// Pull-based compilation entry point for user-opened files.
@@ -795,7 +799,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // not declare it fresh; the next request recompiles.
         session->settle_compile(epoch);
         pc->succeeded = true;
-        record_deps(*session, result.value().deps);
+        record_deps(*session, result.value().deps, result.value().build_at);
 
         if(!result.value().tu_index_data.empty()) {
             auto tu_index = index::TUIndex::from(result.value().tu_index_data.data());

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -145,7 +145,7 @@ private:
                                 const std::vector<std::string>& arguments);
 
     bool is_stale(const Session& session);
-    void record_deps(Session& session, llvm::ArrayRef<std::string> deps);
+    void record_deps(Session& session, llvm::ArrayRef<HashedDep> deps, std::int64_t build_at);
 
     kota::event_loop& loop;
     Workspace& workspace;

--- a/src/server/compiler/context_resolver.cpp
+++ b/src/server/compiler/context_resolver.cpp
@@ -184,7 +184,7 @@ void
             continue;
         // The verdict is tied to the header's contents — a file edited
         // while the server was down must re-earn its trial.
-        if(entry.content_hash != 0 && hash_file(file) != entry.content_hash)
+        if(entry.content_hash != 0 && fs::hash_file(file) != entry.content_hash)
             continue;
         auto id = workspace.path_pool.intern(file);
         header_modes[id] = HeaderMode::NeedsContext;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -112,11 +112,13 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
             if(!buf) {
                 // Overwriting the shard's stored content with nothing would
                 // silently break every position mapping for this TU; keep the
-                // old snapshot, the staleness check re-enqueues it later.
+                // old snapshot and queue an explicit redo — nothing else
+                // would revisit this TU after a transient read failure.
                 LOG_WARN("Skip merge for {}: cannot read content: {}",
                          file_path,
                          buf.getError().message());
                 touched.insert(global_path_id);
+                enqueue(global_path_id);
                 return;
             }
             if(stale_against_worker(tu_path_id, (*buf)->getBuffer(), file_path)) {

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -55,19 +55,57 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
     // must be swept below like a dropped one.
     llvm::DenseSet<std::uint32_t> touched;
 
+    // The hash the indexing compilation reported for a graph path; 0 when
+    // the worker could not hash it (or an old-format TUIndex).
+    auto worker_hash = [&](std::uint32_t tu_path_id) -> std::uint64_t {
+        return tu_path_id < tu_index.graph.path_hashes.size()
+                   ? tu_index.graph.path_hashes[tu_path_id]
+                   : 0;
+    };
+
+    // The shard stores file content read from disk here, next to index rows
+    // the worker built from the content it read back then. If the two
+    // diverge — the file changed while the indexing ran — storing either
+    // would pair rows with content they were not built from and corrupt
+    // every position mapping. Skip the file, keep its previous snapshot
+    // (protected from the sweep below), and re-enqueue the TU so the round
+    // redoes it against the new disk state: an explicit redo instead of a
+    // silently wrong store.
+    auto stale_against_worker =
+        [&](std::uint32_t tu_path_id, llvm::StringRef disk_content, llvm::StringRef file_path) {
+            auto expected = worker_hash(tu_path_id);
+            if(expected == 0 || llvm::xxh3_64bits(disk_content) == expected) {
+                return false;
+            }
+            LOG_INFO("Skip merge for {}: disk changed during indexing, re-enqueueing TU {}",
+                     file_path,
+                     main_tu_path);
+            enqueue(file_ids_map[main_tu_path_id]);
+            return true;
+        };
+
     auto merge_file_index = [&](std::uint32_t tu_path_id, index::FileIndex& file_idx) {
         auto global_path_id = file_ids_map[tu_path_id];
         auto& shard = workspace.merged_indices[global_path_id];
 
         if(tu_path_id == main_tu_path_id) {
             llvm::SmallVector<index::DepLocation> deps;
-            deps.reserve(tu_index.graph.locations.size() + 1);
+            deps.reserve(tu_index.graph.locations.size() + tu_index.imports.size() + 1);
             // The TU's own content is a dependency of its shard too: without
             // it, a closed TU edited on disk with unchanged includes would
             // never look stale.
-            deps.push_back({main_tu_path, 0, 0});
+            deps.push_back({main_tu_path, 0, 0, worker_hash(main_tu_path_id)});
             for(auto& loc: tu_index.graph.locations) {
-                deps.push_back({tu_index.graph.paths[loc.path_id], loc.line, loc.include});
+                deps.push_back({tu_index.graph.paths[loc.path_id],
+                                loc.line,
+                                loc.include,
+                                worker_hash(loc.path_id)});
+            }
+            // Imported module interface sources have no include location but
+            // are dependencies all the same: their change must make this
+            // shard look stale.
+            for(auto import_id: tu_index.imports) {
+                deps.push_back({tu_index.graph.paths[import_id], 0, 0, worker_hash(import_id)});
             }
             auto file_path = workspace.path_pool.resolve(global_path_id);
             auto buf = llvm::MemoryBuffer::getFile(file_path);
@@ -78,6 +116,11 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
                 LOG_WARN("Skip merge for {}: cannot read content: {}",
                          file_path,
                          buf.getError().message());
+                touched.insert(global_path_id);
+                return;
+            }
+            if(stale_against_worker(tu_path_id, (*buf)->getBuffer(), file_path)) {
+                touched.insert(global_path_id);
                 return;
             }
             shard.merge(main_tu_path, tu_index.built_at, deps, file_idx, (*buf)->getBuffer());
@@ -102,6 +145,10 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
             if(header_buf) {
                 header_content_storage = (*header_buf)->getBuffer().str();
                 header_content = header_content_storage;
+            }
+            if(stale_against_worker(tu_path_id, header_content, header_path)) {
+                touched.insert(global_path_id);
+                return;
             }
             // Keyed by the including TU so a reindex of that TU replaces its
             // prior contribution to this header's shard.
@@ -389,10 +436,26 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
     if(!need_update(file_path))
         co_return;
 
-    // For module interface units, compile their PCM (and transitive deps)
-    // first so the stateless worker has the artifacts it needs.
-    if(workspace.compile_graph && workspace.path_to_module.contains(server_path_id)) {
-        co_await workspace.compile_graph->compile(server_path_id);
+    // For module units, compile their PCM (and transitive deps) first so the
+    // stateless worker has the artifacts it needs. An importer needs its
+    // modules' PCMs the same way — fill_pcm_deps below only hands over
+    // already-built paths, and after an interface save those were just
+    // invalidated.
+    if(workspace.compile_graph) {
+        bool awaited = false;
+        if(workspace.path_to_module.contains(server_path_id)) {
+            co_await workspace.compile_graph->compile(server_path_id);
+            awaited = true;
+        } else if(!workspace.dep_graph.imports_of(server_path_id).empty()) {
+            co_await workspace.compile_graph->compile_deps(server_path_id);
+            awaited = true;
+        }
+        // The PCM builds can suspend for a long time: the file may have been
+        // opened meanwhile (its session owns the truth now) or its shard
+        // refreshed by a concurrent round — re-check both before dispatching.
+        if(awaited && (sessions.find(server_path_id) != nullptr || !need_update(file_path))) {
+            co_return;
+        }
     }
 
     worker::BuildParams params;
@@ -511,6 +574,12 @@ kota::task<> Indexer::run_background_indexing() {
         assert(pending_ids.empty() && "drained queue must have no pending ids");
         index_queue.clear();
         index_queue_pos = 0;
+    } else {
+        // Leftovers arrived while the workers ran (e.g. a merge that skipped
+        // a file whose disk changed mid-indexing re-enqueues its TU). No one
+        // else is guaranteed to reschedule — a schedule() call during the
+        // round was swallowed by indexing_active — so kick the next round.
+        schedule();
     }
 
     LOG_PERF("index",

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "compile/hashed_dep.h"
 #include "feature/document_link.h"
 #include "syntax/token.h"
 
@@ -38,6 +40,15 @@ constexpr inline protocol::integer worker_unavailable = -33000;
 inline bool is_operational_error(const protocol::Error& error) {
     return error.code == dispatch_errc::cancelled ||
            error.code == dispatch_errc::worker_unavailable;
+}
+
+/// Convert a compile start timestamp to the whole-second `build_at` a result
+/// reports. Backs off one second: the master compares file mtimes at second
+/// granularity, and flooring alone would let a file saved within the same
+/// second as compile start slip past the mtime fast layer without ever
+/// reaching the hash comparison.
+inline std::int64_t to_build_at(std::chrono::milliseconds start) {
+    return std::chrono::duration_cast<std::chrono::seconds>(start).count() - 1;
 }
 
 /// Kind of AST query dispatched to a stateful worker.
@@ -80,7 +91,18 @@ struct CompileResult {
     /// Diagnostics serialized as JSON (RawValue) to avoid bincode/serde annotation conflicts.
     kota::codec::RawValue diagnostics;
     std::size_t memory_usage;
-    std::vector<std::string> deps;
+
+    /// Files the compilation consumed, hashed by the worker from the buffers
+    /// it actually read (see HashedDep). The master adopts these hashes for
+    /// its staleness snapshots instead of re-reading the disk.
+    std::vector<HashedDep> deps;
+
+    /// When the compilation started (seconds since epoch, worker clock). The
+    /// mtime fast layer of the master's staleness check must use this rather
+    /// than the result's arrival time: a file saved mid-compile has an mtime
+    /// inside the compile window, and only a build-start baseline forces the
+    /// hash comparison that catches it.
+    std::int64_t build_at = 0;
     /// Serialized TUIndex for the main file (interested_only=true).
     std::string tu_index_data;
 
@@ -145,7 +167,12 @@ struct BuildResult {
     /// without user errors indicates clice infrastructure breakage (anomaly).
     bool has_user_errors = false;
     std::string output_path;  ///< PCH or PCM path
-    std::vector<std::string> deps;
+
+    /// Consumed files with worker-side content hashes, and the build start
+    /// time — same contract as the corresponding CompileResult fields.
+    std::vector<HashedDep> deps;
+    std::int64_t build_at = 0;
+
     std::string tu_index_data;
     /// Include directives of the PCH preamble. Structured so the master can
     /// serve both document links and go-to-definition on preamble lines.

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <utility>
 
+#include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/timer.h"
 
@@ -186,7 +187,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 if(exists) {
                     state.size = status.getSize();
                     state.mtime_ns = to_nanoseconds(status.getLastModificationTime());
-                    state.hash = hash_file(path);
+                    state.hash = fs::hash_file(path);
                     if(state.hash == 0) {
                         // Read failure (hash_file's sentinel): don't seed a
                         // baseline that would later compare as a change.
@@ -216,7 +217,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
 
             // The stamp moved: only a confirmed content change counts, so
             // touches and checkouts of identical bytes stay silent.
-            auto hash = hash_file(path);
+            auto hash = fs::hash_file(path);
             if(hash == 0) {
                 // The file stats fine but cannot be read right now (e.g. an
                 // antivirus scanner briefly holding a fresh file on Windows).

--- a/src/server/state/invalidator.cpp
+++ b/src/server/state/invalidator.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 
@@ -86,8 +87,38 @@ void Invalidator::cascade_disk_content_change(std::uint32_t path_id, DirtySet& d
             }
         }
     };
+    auto new_dependents = workspace.dep_graph.find_host_sources(path_id);
     split_dependents(old_dependents);
-    split_dependents(workspace.dep_graph.find_host_sources(path_id));
+    split_dependents(new_dependents);
+
+    // A module interface among the affected roots (or the saved file itself)
+    // is a compile input of every TU importing its module, transitively
+    // through importing interfaces. The compile-graph cascade inside
+    // rescan_after_save only reaches units that compiled this session; the
+    // scan-built import edges also cover closed TUs that never did.
+    llvm::SmallVector<std::uint32_t> module_seeds(old_dependents.begin(), old_dependents.end());
+    module_seeds.append(new_dependents.begin(), new_dependents.end());
+    module_seeds.push_back(path_id);
+    llvm::DenseSet<std::uint32_t> visited(module_seeds.begin(), module_seeds.end());
+    while(!module_seeds.empty()) {
+        auto seed = module_seeds.pop_back_val();
+        auto module_it = workspace.path_to_module.find(seed);
+        if(module_it == workspace.path_to_module.end()) {
+            continue;
+        }
+        // Only interface units provide a module; an implementation unit
+        // shares the name but its content never reaches importers.
+        auto providers = workspace.dep_graph.lookup_module(module_it->second);
+        if(llvm::find(providers, seed) == providers.end()) {
+            continue;
+        }
+        for(auto importer: workspace.dep_graph.importers_of(module_it->second)) {
+            if(visited.insert(importer).second) {
+                split_dependents(importer);
+                module_seeds.push_back(importer);
+            }
+        }
+    }
 
     // Headers whose resolved context embeds the file through its include
     // chain must re-synthesize their preamble: it copies the chain files'
@@ -210,6 +241,7 @@ DirtySet Invalidator::apply(llvm::ArrayRef<FileEvent> events) {
                 // within-batch cascades tolerate a stale reverse map by
                 // design (they union the pre/post snapshots).
                 workspace.dep_graph.clear_includes(path_id);
+                workspace.dep_graph.set_imports(path_id, {});
                 rebuild_reverse_map = true;
                 workspace.context_epoch += 1;
                 // Contexts hosted by (or chained through) the removed file

--- a/src/server/state/workspace.cpp
+++ b/src/server/state/workspace.cpp
@@ -154,6 +154,23 @@ llvm::SmallVector<std::uint32_t> Workspace::rescan_after_save(std::uint32_t path
     auto file_path = path_pool.resolve(path_id);
     if(auto buf = llvm::MemoryBuffer::getFile(file_path)) {
         auto result = scan((*buf)->getBuffer());
+
+        // The save may have added or removed import declarations; keep the
+        // import edges in sync with the include rescan above.
+        llvm::SmallVector<std::string> imports(result.modules.begin(), result.modules.end());
+        if(!result.module_name.empty() && !result.is_interface_unit) {
+            imports.push_back(result.module_name);
+        }
+        dep_graph.set_imports(path_id, imports);
+
+        // A save can also introduce a module declaration; register it so
+        // name-based lookups (the importer cascade's interface check) see
+        // it. Removal is left alone: a stale provider entry only makes the
+        // cascade conservative.
+        if(result.is_interface_unit) {
+            dep_graph.add_module(result.module_name, path_id);
+        }
+
         if(!result.module_name.empty()) {
             path_to_module[path_id] = std::move(result.module_name);
         } else {
@@ -229,16 +246,16 @@ std::uint64_t hash_file(llvm::StringRef path) {
     return llvm::xxh3_64bits((*buf)->getBuffer());
 }
 
-DepsSnapshot capture_deps_snapshot(PathPool& pool, llvm::ArrayRef<std::string> deps) {
+DepsSnapshot capture_deps_snapshot(PathPool& pool,
+                                   llvm::ArrayRef<HashedDep> deps,
+                                   std::int64_t build_at) {
     DepsSnapshot snap;
-    // Capture timestamp BEFORE hashing to avoid TOCTOU: if a file is modified
-    // during hashing, its mtime will be > build_at, triggering Layer 2 re-hash.
-    snap.build_at = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    snap.build_at = build_at;
     snap.path_ids.reserve(deps.size());
     snap.hashes.reserve(deps.size());
-    for(const auto& file: deps) {
-        snap.path_ids.push_back(pool.intern(file));
-        snap.hashes.push_back(hash_file(file));
+    for(const auto& dep: deps) {
+        snap.path_ids.push_back(pool.intern(dep.path));
+        snap.hashes.push_back(dep.hash);
     }
     return snap;
 }

--- a/src/server/state/workspace.cpp
+++ b/src/server/state/workspace.cpp
@@ -239,13 +239,6 @@ std::string discover_compile_commands(const Config& config, llvm::StringRef work
     return {};
 }
 
-std::uint64_t hash_file(llvm::StringRef path) {
-    auto buf = llvm::MemoryBuffer::getFile(path);
-    if(!buf)
-        return 0;
-    return llvm::xxh3_64bits((*buf)->getBuffer());
-}
-
 DepsSnapshot capture_deps_snapshot(PathPool& pool,
                                    llvm::ArrayRef<HashedDep> deps,
                                    std::int64_t build_at) {
@@ -277,7 +270,7 @@ bool deps_changed(const PathPool& pool, const DepsSnapshot& snap) {
             continue;
 
         // Layer 2: mtime is newer — re-hash content to confirm actual change.
-        auto current_hash = hash_file(path);
+        auto current_hash = fs::hash_file(path);
         if(current_hash != snap.hashes[i])
             return true;
     }

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -10,6 +10,7 @@
 
 #include "command/command.h"
 #include "command/toolchain.h"
+#include "compile/hashed_dep.h"
 #include "feature/document_link.h"
 #include "index/merged_index.h"
 #include "index/project_index.h"
@@ -260,9 +261,15 @@ std::string discover_compile_commands(const Config& config, llvm::StringRef work
 /// Hash a file's content using xxh3_64bits. Returns 0 on read failure.
 std::uint64_t hash_file(llvm::StringRef path);
 
-/// Capture a two-layer staleness snapshot after a successful compilation.
-/// Interns dependency paths into the PathPool and hashes each file's content.
-DepsSnapshot capture_deps_snapshot(PathPool& pool, llvm::ArrayRef<std::string> deps);
+/// Capture a two-layer staleness snapshot from a worker's dependency report.
+/// Interns dependency paths into the PathPool and adopts the worker-computed
+/// content hashes verbatim — the snapshot describes what the compilation
+/// actually consumed, not what the disk holds now. `build_at` must be the
+/// compile start time (the worker reports it): with an arrival-time baseline
+/// the mtime fast layer would wave through files saved mid-compile.
+DepsSnapshot capture_deps_snapshot(PathPool& pool,
+                                   llvm::ArrayRef<HashedDep> deps,
+                                   std::int64_t build_at);
 
 /// Two-layer staleness check.
 /// Layer 1 (fast): stat each dep file, compare mtime against build_at.

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -258,9 +258,6 @@ struct Workspace {
 /// exists yet — the file tracker keeps looking on its CDB poll.
 std::string discover_compile_commands(const Config& config, llvm::StringRef workspace_root);
 
-/// Hash a file's content using xxh3_64bits. Returns 0 on read failure.
-std::uint64_t hash_file(llvm::StringRef path);
-
 /// Capture a two-layer staleness snapshot from a worker's dependency report.
 /// Interns dependency paths into the PathPool and adopts the worker-computed
 /// content hashes verbatim — the snapshot describes what the compilation

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -1,5 +1,6 @@
 #include "server/worker/stateful_worker.h"
 
+#include <chrono>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -192,6 +193,7 @@ void StatefulWorker::register_handlers() {
                     feature::inactive_regions(doc->unit, params.open_conditionals, doc->pch.second)
                         .regions;
                 result.deps = doc->unit.deps();
+                result.build_at = worker::to_build_at(doc->unit.build_at());
 
                 // Build index for main file only (interested_only=true).
                 auto tu_index = index::TUIndex::build(doc->unit, true);

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -1,5 +1,6 @@
 #include "server/worker/stateless_worker.h"
 
+#include <chrono>
 #include <cstdlib>
 
 #include "compile/compilation.h"
@@ -89,6 +90,7 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
     PCHInfo pch_info;
     auto unit = compile(cp, pch_info);
     bool success = unit.completed();
+    auto build_at = worker::to_build_at(unit.build_at());
 
     std::string errors;
     if(!success)
@@ -111,7 +113,8 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
-        result.deps = pch_info.deps;
+        result.deps = std::move(pch_info.deps);
+        result.build_at = build_at;
         result.tu_index_data = std::move(tu_index_data);
         result.preamble_links = std::move(preamble_links);
         result.inactive_regions = std::move(inactive.regions);
@@ -155,6 +158,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
     PCMInfo pcm_info;
     auto unit = compile(cp, pcm_info);
     bool success = unit.completed();
+    auto build_at = worker::to_build_at(unit.build_at());
 
     std::string errors;
     if(!success)
@@ -171,7 +175,8 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
-        result.deps = pcm_info.deps;
+        result.deps = std::move(pcm_info.deps);
+        result.build_at = build_at;
         result.tu_index_data = std::move(tu_index_data);
         return result;
     } else {

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -13,6 +13,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice {
 
@@ -72,6 +73,19 @@ inline std::expected<std::string, std::error_code> read(llvm::StringRef path) {
         return std::unexpected(buffer.getError());
     }
     return buffer.get()->getBuffer().str();
+}
+
+/// Hash a file's content with xxh3_64bits. Returns 0 on read failure.
+///
+/// The single definition matters: workers hash consumed content with this
+/// scheme and the master compares those hashes against its own disk reads,
+/// so every layer must stay in lockstep.
+inline std::uint64_t hash_file(llvm::StringRef path) {
+    auto buffer = llvm::MemoryBuffer::getFile(path);
+    if(!buffer) {
+        return 0;
+    }
+    return llvm::xxh3_64bits((*buffer)->getBuffer());
 }
 
 inline std::expected<void, std::error_code> rename(llvm::StringRef from, llvm::StringRef to) {

--- a/src/syntax/dependency_graph.cpp
+++ b/src/syntax/dependency_graph.cpp
@@ -36,6 +36,57 @@ llvm::ArrayRef<std::uint32_t> DependencyGraph::lookup_module(llvm::StringRef mod
     return {};
 }
 
+void DependencyGraph::set_imports(std::uint32_t path_id, llvm::ArrayRef<std::string> module_names) {
+    if(auto it = file_imports.find(path_id); it != file_imports.end()) {
+        for(auto& name: it->second) {
+            auto rev = module_importers.find(name);
+            if(rev == module_importers.end()) {
+                continue;
+            }
+            auto& importers = rev->second;
+            if(auto pos = llvm::find(importers, path_id); pos != importers.end()) {
+                importers.erase(pos);
+            }
+            if(importers.empty()) {
+                module_importers.erase(rev);
+            }
+        }
+        file_imports.erase(it);
+    }
+
+    if(module_names.empty()) {
+        return;
+    }
+
+    auto& imports = file_imports[path_id];
+    for(auto& name: module_names) {
+        if(llvm::find(imports, name) != imports.end()) {
+            continue;
+        }
+        imports.push_back(name);
+        auto& importers = module_importers[name];
+        if(llvm::find(importers, path_id) == importers.end()) {
+            importers.push_back(path_id);
+        }
+    }
+}
+
+llvm::ArrayRef<std::string> DependencyGraph::imports_of(std::uint32_t path_id) const {
+    auto it = file_imports.find(path_id);
+    if(it != file_imports.end()) {
+        return it->second;
+    }
+    return {};
+}
+
+llvm::ArrayRef<std::uint32_t> DependencyGraph::importers_of(llvm::StringRef module_name) const {
+    auto it = module_importers.find(module_name);
+    if(it != module_importers.end()) {
+        return it->second;
+    }
+    return {};
+}
+
 void DependencyGraph::set_includes(std::uint32_t path_id,
                                    std::uint32_t config_id,
                                    llvm::SmallVector<std::uint32_t> included_ids) {
@@ -636,6 +687,21 @@ kota::task<> scan_impl(CompilationDatabase& cdb,
 
             if(scan_result.scan_result.is_interface_unit) {
                 graph.add_module(scan_result.scan_result.module_name, scan_result.path_id);
+            }
+
+            // Record import edges (a module implementation unit implicitly
+            // imports its interface) so invalidation can reach a module's
+            // importers by name.
+            {
+                auto& sr = scan_result.scan_result;
+                bool implicit_interface_dep = !sr.module_name.empty() && !sr.is_interface_unit;
+                if(!sr.modules.empty() || implicit_interface_dep) {
+                    llvm::SmallVector<std::string> imports(sr.modules.begin(), sr.modules.end());
+                    if(implicit_interface_dep) {
+                        imports.push_back(sr.module_name);
+                    }
+                    graph.set_imports(scan_result.path_id, imports);
+                }
             }
 
             report.includes_found += scan_result.scan_result.includes.size();

--- a/src/syntax/dependency_graph.h
+++ b/src/syntax/dependency_graph.h
@@ -61,6 +61,18 @@ public:
     /// Look up all PathIDs that provide a given module (may have multiple candidates).
     llvm::ArrayRef<std::uint32_t> lookup_module(llvm::StringRef module_name) const;
 
+    /// Set the modules a file imports (C++20 `import` declarations, plus the
+    /// implicit interface dependency of a module implementation unit).
+    /// Replaces the file's previous set and maintains the reverse map. An
+    /// empty list clears the file's import edges.
+    void set_imports(std::uint32_t path_id, llvm::ArrayRef<std::string> module_names);
+
+    /// The modules a file imports, as recorded by set_imports.
+    llvm::ArrayRef<std::string> imports_of(std::uint32_t path_id) const;
+
+    /// Files that directly import the given module.
+    llvm::ArrayRef<std::uint32_t> importers_of(llvm::StringRef module_name) const;
+
     /// Set the direct include list for a (file, config) pair.
     void set_includes(std::uint32_t path_id,
                       std::uint32_t config_id,
@@ -117,6 +129,17 @@ public:
 private:
     /// Module name -> PathIDs (multiple candidates possible, e.g. different targets).
     llvm::StringMap<llvm::SmallVector<std::uint32_t, 2>> module_to_path;
+
+    /// PathID -> imported module names. Import edges live here (not in the
+    /// include maps): imports are name-resolved, carry no search config, and
+    /// must never leak into include-chain queries (host inference, preamble
+    /// synthesis).
+    llvm::DenseMap<std::uint32_t, llvm::SmallVector<std::string, 2>> file_imports;
+
+    /// Module name -> PathIDs of files importing it (reverse of
+    /// file_imports). Lets invalidation reach importers of a saved module
+    /// interface even when they never compiled this session.
+    llvm::StringMap<llvm::SmallVector<std::uint32_t, 2>> module_importers;
 
     /// (PathID, ConfigID) -> list of directly included PathIDs.
     /// Each PathID may have bit 31 set to indicate conditional include.

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -82,6 +82,46 @@ ScanResult scan(llvm::StringRef content) {
                 }
                 break;
             }
+            case dds::cxx_import_decl:
+            case dds::cxx_export_import_decl: {
+                // import a.b; / export import a.b; — collect the dotted
+                // name. Header-unit imports (import <h>; / import "h";)
+                // carry no identifiers and are skipped.
+                std::string name;
+                bool seen_import_keyword = false;
+                for(auto& tok: dir.Tokens) {
+                    if(!seen_import_keyword) {
+                        if(tok.is(clang::tok::raw_identifier) &&
+                           content.substr(tok.Offset, tok.Length) == "import") {
+                            seen_import_keyword = true;
+                        }
+                        continue;
+                    }
+                    if(tok.is(clang::tok::raw_identifier)) {
+                        name += content.substr(tok.Offset, tok.Length);
+                    } else if(tok.is(clang::tok::period)) {
+                        name += '.';
+                    } else if(tok.is(clang::tok::colon)) {
+                        name += ':';
+                    } else {
+                        break;
+                    }
+                }
+
+                if(name.starts_with(':')) {
+                    // A partition import names its own primary module
+                    // implicitly; the module declaration precedes any import.
+                    if(result.module_name.empty()) {
+                        break;
+                    }
+                    auto primary = llvm::StringRef(result.module_name).split(':').first;
+                    name.insert(0, primary.str());
+                }
+                if(!name.empty()) {
+                    result.modules.push_back(std::move(name));
+                }
+                break;
+            }
             case dds::cxx_module_decl:
             case dds::cxx_export_module_decl: {
                 if(conditional_depth > 0) {

--- a/tests/integration/modules/test_module_reindex.py
+++ b/tests/integration/modules/test_module_reindex.py
@@ -1,0 +1,70 @@
+"""Saving a module interface must reindex the closed TUs that import it."""
+
+import asyncio
+
+from lsprotocol.types import (
+    DidChangeTextDocumentParams,
+    DidSaveTextDocumentParams,
+    TextDocumentContentChangeWholeDocument,
+    TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
+)
+
+from tests.integration.utils import write_cdb
+from tests.integration.utils.wait import (
+    MTIME_GRANULARITY,
+    wait_for_recompile,
+    wait_for_reference,
+)
+
+INTERFACE_V1 = """\
+export module mod;
+export inline int pick() { return 1; }
+"""
+
+# Changes pick's signature (and thus its symbol identity) while keeping the
+# closed importer's call valid and the declaration at the same position —
+# only a reindex against the new interface can retarget the call.
+INTERFACE_V2 = """\
+export module mod;
+export inline int pick(int x = 0) { return 2; }
+"""
+
+CLOSED_IMPORTER = "import mod;\nint run() { return pick(); }\n"
+
+
+async def test_interface_save_reindexes_importers(client, tmp_path):
+    (tmp_path / "mod.cppm").write_text(INTERFACE_V1, newline="\n")
+    (tmp_path / "main.cpp").write_text(CLOSED_IMPORTER, newline="\n")
+    write_cdb(tmp_path, ["main.cpp", "mod.cppm"], std="c++20")
+    await client.initialize(tmp_path)
+
+    mod_uri = (tmp_path / "mod.cppm").as_uri()
+    main_uri = (tmp_path / "main.cpp").as_uri()
+    await client.open_and_wait(tmp_path / "mod.cppm")
+
+    # Initial background index: the closed importer's call resolves to pick.
+    assert await wait_for_reference(client, mod_uri, 1, 18, main_uri), (
+        "initial index never produced the closed importer's pick reference"
+    )
+
+    await asyncio.sleep(MTIME_GRANULARITY)
+    (tmp_path / "mod.cppm").write_text(INTERFACE_V2, newline="\n")
+    client.text_document_did_change(
+        DidChangeTextDocumentParams(
+            text_document=VersionedTextDocumentIdentifier(uri=mod_uri, version=2),
+            content_changes=[TextDocumentContentChangeWholeDocument(text=INTERFACE_V2)],
+        )
+    )
+    client.text_document_did_save(
+        DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=mod_uri))
+    )
+
+    # References resolve against the open interface's compiled index.
+    await wait_for_recompile(client, mod_uri)
+
+    # The closed importer is reindexed against the saved interface: its call
+    # now targets the new pick signature, which only a rebuilt shard can know.
+    assert await wait_for_reference(client, mod_uri, 1, 18, main_uri), (
+        "closed importer was not reindexed after the interface save"
+    )

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -6,6 +6,7 @@
 #include "command/command.h"
 #include "command/toolchain.h"
 #include "compile/compilation.h"
+#include "index/tu_index.h"
 #include "support/filesystem.h"
 #include "syntax/scan.h"
 
@@ -106,8 +107,14 @@ int main() { return 0; }
     // PCHInfo.preamble should be non-empty (contains the #include directives).
     ASSERT_FALSE(info.preamble.empty());
 
-    // PCHInfo.deps should list files involved in building the PCH.
+    // PCHInfo.deps should list files involved in building the PCH, each
+    // hashed from the buffer the compiler consumed.
     ASSERT_FALSE(info.deps.empty());
+    auto dep = llvm::find_if(info.deps, [](const HashedDep& dep) {
+        return llvm::StringRef(dep.path).ends_with("preamble.h");
+    });
+    ASSERT_TRUE(dep != info.deps.end());
+    ASSERT_EQ(dep->hash, llvm::xxh3_64bits(sources.all_files["preamble.h"].content));
 
     // PCHInfo.arguments should match what was passed in.
     ASSERT_EQ(info.arguments.size(), params.arguments.size());
@@ -180,17 +187,19 @@ TEST_CASE(PCMBuildChain) {
     TempDir tmp;
 
     // Module B: no dependencies.
-    tmp.touch("mod_b.cppm", R"(
+    llvm::StringRef b_content = R"(
 export module mod_b;
 export int b_value() { return 42; }
-)");
+)";
+    tmp.touch("mod_b.cppm", b_content);
 
     // Module A: imports B.
-    tmp.touch("mod_a.cppm", R"(
+    llvm::StringRef a_content = R"(
 export module mod_a;
 import mod_b;
 export int a_value() { return b_value() + 1; }
-)");
+)";
+    tmp.touch("mod_a.cppm", a_content);
 
     CompilationDatabase cdb;
     Toolchain tc;
@@ -239,9 +248,106 @@ export int a_value() { return b_value() + 1; }
     // info_a should record mod_b as a dependency.
     ASSERT_TRUE(llvm::find(info_a.mods, "mod_b") != info_a.mods.end());
 
+    // Each PCM's deps carry its own interface source, and A's also carry
+    // B's interface source (the import edge), all with content hashes.
+    auto has_dep = [](const PCMInfo& info, llvm::StringRef path, std::uint64_t hash) {
+        return llvm::any_of(info.deps, [&](const HashedDep& dep) {
+            return dep.path == path && dep.hash == hash;
+        });
+    };
+    ASSERT_TRUE(has_dep(info_b, tmp.path("mod_b.cppm"), llvm::xxh3_64bits(b_content)));
+    ASSERT_TRUE(has_dep(info_a, tmp.path("mod_a.cppm"), llvm::xxh3_64bits(a_content)));
+    ASSERT_TRUE(has_dep(info_a, tmp.path("mod_b.cppm"), llvm::xxh3_64bits(b_content)));
+
     // Clean up temp PCM files.
     llvm::sys::fs::remove(*pcm_b_path);
     llvm::sys::fs::remove(*pcm_a_path);
+}
+
+TEST_CASE(IndexImporterTUIndex) {
+    // Index-kind compile of a TU importing a module: the TUIndex must carry
+    // the interface source as an import dependency and serialize cleanly.
+    TempDir tmp;
+
+    llvm::StringRef iface_content = R"(
+export module mod_x;
+export inline int x_value() { return 42; }
+)";
+    tmp.touch("mod_x.cppm", iface_content);
+    tmp.touch("user.cpp", R"(
+import mod_x;
+int use_x() { return x_value(); }
+)");
+
+    CompilationDatabase cdb;
+    Toolchain tc;
+
+    cdb.add_command(tmp.root.str(),
+                    tmp.path("mod_x.cppm"),
+                    std::format("clang++ -std=c++20 {}", tmp.path("mod_x.cppm")));
+    auto cmds_x = cdb.lookup(tmp.path("mod_x.cppm"));
+    ASSERT_TRUE(tc.resolve(cmds_x.front()).has_value());
+    CompilationParams params_x;
+    params_x.kind = CompilationKind::ModuleInterface;
+    params_x.arguments = cmds_x.front().to_argv();
+
+    auto pcm_path = fs::createTemporaryFile("mod_x", "pcm");
+    ASSERT_TRUE(pcm_path.operator bool());
+    params_x.output_file = *pcm_path;
+
+    PCMInfo info_x;
+    auto unit_x = clice::compile(params_x, info_x);
+    ASSERT_TRUE(unit_x.completed());
+
+    cdb.add_command(tmp.root.str(),
+                    tmp.path("user.cpp"),
+                    std::format("clang++ -std=c++20 {}", tmp.path("user.cpp")));
+    auto cmds_u = cdb.lookup(tmp.path("user.cpp"));
+    ASSERT_TRUE(tc.resolve(cmds_u.front()).has_value());
+    CompilationParams params_u;
+    params_u.kind = CompilationKind::Indexing;
+    params_u.arguments = cmds_u.front().to_argv();
+    params_u.pcms.try_emplace("mod_x", *pcm_path);
+
+    auto unit_u = clice::compile(params_u);
+    ASSERT_TRUE(unit_u.completed());
+
+    auto tu_index = index::TUIndex::build(unit_u);
+    ASSERT_EQ(tu_index.imports.size(), std::size_t(1));
+    auto import_id = tu_index.imports[0];
+    ASSERT_EQ(tu_index.graph.paths[import_id], tmp.path("mod_x.cppm"));
+    ASSERT_EQ(tu_index.graph.path_hashes[import_id], llvm::xxh3_64bits(iface_content));
+
+    // The module symbol must have the same identity on both sides of the
+    // PCM boundary, or cross-TU references could never connect.
+    auto iface_index = index::TUIndex::build(unit_x);
+    auto find_symbol = [](const index::TUIndex& idx, llvm::StringRef name) -> std::uint64_t {
+        for(auto& [hash, symbol]: idx.symbols) {
+            if(symbol.name == name) {
+                return hash;
+            }
+        }
+        return 0;
+    };
+    auto hash_in_iface = find_symbol(iface_index, "x_value");
+    auto hash_in_user = find_symbol(tu_index, "x_value");
+    ASSERT_TRUE(hash_in_iface != 0);
+    ASSERT_EQ(hash_in_iface, hash_in_user);
+
+    // Round-trip through the wire format, as the indexer receives it.
+    std::string data;
+    llvm::raw_string_ostream os(data);
+    tu_index.serialize(os);
+    auto restored = index::TUIndex::from(data.data());
+    ASSERT_EQ(restored.imports, tu_index.imports);
+    ASSERT_EQ(restored.graph.path_hashes, tu_index.graph.path_hashes);
+
+    // Rows located inside the imported module's own files belong to the
+    // module's index run, not this TU's: the import edge is a dependency
+    // only, never a contribution.
+    ASSERT_FALSE(restored.path_file_indices.contains(import_id));
+
+    llvm::sys::fs::remove(*pcm_path);
 }
 
 TEST_CASE(PCHContentDifference) {

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -250,9 +250,14 @@ export int a_value() { return b_value() + 1; }
 
     // Each PCM's deps carry its own interface source, and A's also carry
     // B's interface source (the import edge), all with content hashes.
+    // Compare separator-normalized: on Windows the driver records forward
+    // slashes while TempDir hands out native paths, and the consuming
+    // staleness checks are stat-based, so either form is functional.
     auto has_dep = [](const PCMInfo& info, llvm::StringRef path, std::uint64_t hash) {
         return llvm::any_of(info.deps, [&](const HashedDep& dep) {
-            return dep.path == path && dep.hash == hash;
+            return llvm::sys::path::convert_to_slash(dep.path) ==
+                       llvm::sys::path::convert_to_slash(path) &&
+                   dep.hash == hash;
         });
     };
     ASSERT_TRUE(has_dep(info_b, tmp.path("mod_b.cppm"), llvm::xxh3_64bits(b_content)));

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -7,6 +7,7 @@
 #include "index/merged_index.h"
 
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice::testing {
 
@@ -570,12 +571,12 @@ TEST_CASE(LocalSymbolSerialization) {
     }
 }
 
-// The dep is backdated an hour so the merge (build_at = one minute ago)
-// records its baseline hash; a later write bumps the mtime past build_at,
-// so staleness reaches the Layer 2 content-hash check — exactly the branch
-// these tests exercise. A dep newer than build_at gets no baseline at all
-// (its content may postdate the indexed snapshot).
-index::MergedIndex build_ctx_shard(llvm::StringRef dep_path) {
+// The dep is backdated an hour and the merge stamps build_at = one minute
+// ago, so any later write bumps the mtime past build_at and staleness
+// reaches the Layer 2 content-hash comparison — exactly the branch these
+// tests exercise. The baseline is the worker-reported consumed-content
+// hash carried in DepLocation, adopted verbatim by merge().
+index::MergedIndex build_ctx_shard(llvm::StringRef dep_path, std::uint64_t consumed_hash) {
     namespace stdfs = std::filesystem;
     stdfs::last_write_time(dep_path.str(),
                            stdfs::file_time_type::clock::now() - std::chrono::hours(1));
@@ -585,7 +586,7 @@ index::MergedIndex build_ctx_shard(llvm::StringRef dep_path) {
     index::MergedIndex merged;
     index::FileIndex file_idx;
     index::DepLocation deps[] = {
-        {.path = dep_path, .line = 1}
+        {.path = dep_path, .line = 1, .hash = consumed_hash}
     };
     merged.merge("tu0", build_at, deps, file_idx, "");
     return merged;
@@ -593,12 +594,14 @@ index::MergedIndex build_ctx_shard(llvm::StringRef dep_path) {
 
 TEST_CASE(TouchNoUpdate) {
     TempDir dir;
+    llvm::StringRef content = "int shared = 1;";
     auto dep = dir.path("dep.h");
-    dir.touch("dep.h", "int shared = 1;");
+    dir.touch("dep.h", content);
 
-    auto merged = build_ctx_shard(dep);
+    auto merged = build_ctx_shard(dep, llvm::xxh3_64bits(content));
 
     // Same content, newer mtime — a pure touch must not trigger a reindex.
+    dir.touch("dep.h", content);
     ASSERT_FALSE(merged.need_update());
 
     // The buffer path (serialized shard) must reach the same conclusion.
@@ -611,13 +614,40 @@ TEST_CASE(TouchNoUpdate) {
 
 TEST_CASE(ContentChangeUpdate) {
     TempDir dir;
+    llvm::StringRef content = "int shared = 1;";
     auto dep = dir.path("dep.h");
-    dir.touch("dep.h", "int shared = 1;");
+    dir.touch("dep.h", content);
 
-    auto merged = build_ctx_shard(dep);
+    auto merged = build_ctx_shard(dep, llvm::xxh3_64bits(content));
 
     // Real edit: content hash diverges from the stored baseline.
     dir.touch("dep.h", "int shared = 2;");
+    ASSERT_TRUE(merged.need_update());
+}
+
+TEST_CASE(ConsumedHashIsBaseline) {
+    TempDir dir;
+    auto dep = dir.path("dep.h");
+    dir.touch("dep.h", "int shared = 1;");
+
+    // The indexing compilation consumed different content than the disk
+    // holds now (a write landed during the run): the shard must look stale
+    // even though the disk was never touched after the merge.
+    auto merged = build_ctx_shard(dep, llvm::xxh3_64bits("int shared = 0;"));
+    dir.touch("dep.h", "int shared = 1;");
+    ASSERT_TRUE(merged.need_update());
+}
+
+TEST_CASE(NoBaselineConservative) {
+    TempDir dir;
+    llvm::StringRef content = "int shared = 1;";
+    auto dep = dir.path("dep.h");
+    dir.touch("dep.h", content);
+
+    // Hash 0 = the worker could not read the dep: no baseline is stored, so
+    // an mtime bump cannot be proven harmless and must trigger a rebuild.
+    auto merged = build_ctx_shard(dep, 0);
+    dir.touch("dep.h", content);
     ASSERT_TRUE(merged.need_update());
 }
 

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -484,6 +484,36 @@ TEST_CASE(CrossFileHeaderIndex) {
     ASSERT_TRUE(found_in_header);
 }
 
+TEST_CASE(PathHashesRecorded) {
+    add_file("header.h", R"(
+            int helper();
+        )");
+    add_main("main.cpp", R"(
+            #include "header.h"
+            int main() { return helper(); }
+        )");
+    ASSERT_TRUE(compile());
+    tu_index = index::TUIndex::build(*unit);
+
+    // One consumed-content hash per path, all known.
+    auto& graph = tu_index.graph;
+    ASSERT_EQ(graph.path_hashes.size(), graph.paths.size());
+    for(auto hash: graph.path_hashes) {
+        ASSERT_TRUE(hash != 0);
+    }
+
+    // The main file (last path by convention) is hashed from its buffer.
+    ASSERT_EQ(graph.path_hashes.back(), llvm::xxh3_64bits(unit->interested_content()));
+
+    // Hashes and imports survive the serialization round-trip.
+    std::string data;
+    llvm::raw_string_ostream os(data);
+    tu_index.serialize(os);
+    auto restored = index::TUIndex::from(data.data());
+    ASSERT_EQ(restored.graph.path_hashes, tu_index.graph.path_hashes);
+    ASSERT_EQ(restored.imports, tu_index.imports);
+}
+
 TEST_CASE(SymbolKinds) {
     build_index(R"(
             struct $(cls)MyClass {};

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -1,0 +1,70 @@
+#include <chrono>
+
+#include "test/temp_dir.h"
+#include "test/test.h"
+#include "server/state/workspace.h"
+
+#include "llvm/Support/xxhash.h"
+
+namespace clice::testing {
+namespace {
+
+std::int64_t now_seconds() {
+    return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+}
+
+TEST_SUITE(DepsSnapshot) {
+
+TEST_CASE(AdoptsWorkerHash) {
+    TempDir dir;
+    dir.touch("dep.h", "int value = 1;");
+    PathPool pool;
+
+    // The worker consumed different content than the disk holds (the file
+    // was written during the compile window): the artifact must look stale.
+    // Only the worker-reported hash can reveal this — the master never saw
+    // the consumed bytes.
+    HashedDep stale_dep{dir.path("dep.h"), llvm::xxh3_64bits("int value = 0;")};
+    auto snap = capture_deps_snapshot(pool, stale_dep, now_seconds() - 60);
+    ASSERT_TRUE(deps_changed(pool, snap));
+
+    // Consumed content matches the disk: fresh, even though the mtime is
+    // newer than build_at (the hash comparison proves it was a mere touch).
+    HashedDep fresh_dep{dir.path("dep.h"), llvm::xxh3_64bits("int value = 1;")};
+    snap = capture_deps_snapshot(pool, fresh_dep, now_seconds() - 60);
+    ASSERT_FALSE(deps_changed(pool, snap));
+}
+
+TEST_CASE(MtimeFastLayer) {
+    TempDir dir;
+    dir.touch("dep.h", "int value = 1;");
+    PathPool pool;
+
+    // An mtime at or before build_at short-circuits the hash comparison.
+    // This is why build_at must be the compile start time: with a later
+    // baseline (result arrival), a save landing mid-compile would pass
+    // this layer and its divergence would never be checked.
+    HashedDep dep{dir.path("dep.h"), llvm::xxh3_64bits("something else entirely")};
+    auto snap = capture_deps_snapshot(pool, dep, now_seconds() + 60);
+    ASSERT_FALSE(deps_changed(pool, snap));
+}
+
+TEST_CASE(MissingDepFile) {
+    TempDir dir;
+    PathPool pool;
+
+    // Missing at build time (hash 0) and still missing: unchanged.
+    HashedDep never_existed{dir.path("ghost.h"), 0};
+    auto snap = capture_deps_snapshot(pool, never_existed, now_seconds() - 60);
+    ASSERT_FALSE(deps_changed(pool, snap));
+
+    // Consumed at build time but deleted since: changed.
+    HashedDep deleted{dir.path("ghost.h"), llvm::xxh3_64bits("int value = 1;")};
+    snap = capture_deps_snapshot(pool, deleted, now_seconds() - 60);
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+};  // TEST_SUITE(DepsSnapshot)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/server/indexer_merge_tests.cpp
+++ b/tests/unit/server/indexer_merge_tests.cpp
@@ -1,0 +1,135 @@
+#include <chrono>
+#include <string>
+
+#include "test/temp_dir.h"
+#include "test/test.h"
+#include "index/tu_index.h"
+#include "server/compiler/context_resolver.h"
+#include "server/compiler/indexer.h"
+#include "server/state/session_store.h"
+#include "server/worker/worker_pool.h"
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/xxhash.h"
+
+namespace clice::testing {
+namespace {
+
+/// A serialized TUIndex as a worker would ship it: one main TU including one
+/// header, with the consumed-content hashes the indexing compilation took
+/// from its resident buffers.
+std::string make_tu_index(llvm::StringRef header_path,
+                          std::uint64_t header_hash,
+                          llvm::StringRef main_path,
+                          std::uint64_t main_hash) {
+    index::TUIndex tu_index;
+    tu_index.built_at = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch());
+    tu_index.graph.paths = {header_path.str(), main_path.str()};
+    tu_index.graph.path_hashes = {header_hash, main_hash};
+    tu_index.graph.locations = {
+        {.path_id = 0, .line = 1, .include = std::uint32_t(-1)}
+    };
+
+    std::string data;
+    llvm::raw_string_ostream os(data);
+    tu_index.serialize(os);
+    return data;
+}
+
+TEST_SUITE(IndexerMerge) {
+
+TEST_CASE(MatchingHashMerges) {
+    TempDir dir;
+    llvm::StringRef header = "int shared = 1;";
+    llvm::StringRef main = "int value = shared;";
+    dir.touch("dep.h", header);
+    dir.touch("main.cpp", main);
+
+    kota::event_loop loop;
+    Workspace workspace;
+    WorkerPool pool(loop);
+    ContextResolver contexts(workspace);
+    SessionStore sessions;
+    Indexer indexer(loop, workspace, pool, contexts, sessions);
+
+    auto data = make_tu_index(dir.path("dep.h"),
+                              llvm::xxh3_64bits(header),
+                              dir.path("main.cpp"),
+                              llvm::xxh3_64bits(main));
+    indexer.merge(data.data(), data.size());
+
+    auto main_id = workspace.path_pool.intern(dir.path("main.cpp"));
+    auto it = workspace.merged_indices.find(main_id);
+    ASSERT_TRUE(it != workspace.merged_indices.end());
+    ASSERT_TRUE(it->second.has_contribution(dir.path("main.cpp")));
+    ASSERT_EQ(it->second.content(), main);
+    ASSERT_FALSE(it->second.need_update());
+}
+
+TEST_CASE(MismatchSkipsMerge) {
+    TempDir dir;
+    dir.touch("dep.h", "int shared = 1;");
+    dir.touch("main.cpp", "int value = shared;");
+
+    kota::event_loop loop;
+    Workspace workspace;
+    WorkerPool pool(loop);
+    ContextResolver contexts(workspace);
+    SessionStore sessions;
+    Indexer indexer(loop, workspace, pool, contexts, sessions);
+
+    // The worker consumed an older main file than the disk holds (a write
+    // landed during the indexing run): storing disk content next to rows
+    // built from other content would corrupt position mapping, so the merge
+    // must skip this TU instead.
+    auto data = make_tu_index(dir.path("dep.h"),
+                              llvm::xxh3_64bits("int shared = 1;"),
+                              dir.path("main.cpp"),
+                              llvm::xxh3_64bits("int value = 0;"));
+    indexer.merge(data.data(), data.size());
+
+    auto main_id = workspace.path_pool.intern(dir.path("main.cpp"));
+    auto it = workspace.merged_indices.find(main_id);
+    ASSERT_TRUE(it != workspace.merged_indices.end());
+    ASSERT_FALSE(it->second.has_contribution(dir.path("main.cpp")));
+
+    // The skip is only safe because the TU is queued for an explicit redo.
+    ASSERT_EQ(indexer.pending_files(), std::size_t(1));
+}
+
+TEST_CASE(SkipKeepsOldContribution) {
+    TempDir dir;
+    llvm::StringRef header = "int shared = 1;";
+    llvm::StringRef old_main = "int value = shared;";
+    dir.touch("dep.h", header);
+    dir.touch("main.cpp", old_main);
+
+    kota::event_loop loop;
+    Workspace workspace;
+    WorkerPool pool(loop);
+    ContextResolver contexts(workspace);
+    SessionStore sessions;
+    Indexer indexer(loop, workspace, pool, contexts, sessions);
+
+    auto data = make_tu_index(dir.path("dep.h"),
+                              llvm::xxh3_64bits(header),
+                              dir.path("main.cpp"),
+                              llvm::xxh3_64bits(old_main));
+    indexer.merge(data.data(), data.size());
+
+    // The disk moves on; a re-merge of the same stale result must neither
+    // store the new content nor sweep away the TU's previous contribution.
+    dir.touch("main.cpp", "int value = 2;");
+    indexer.merge(data.data(), data.size());
+
+    auto main_id = workspace.path_pool.intern(dir.path("main.cpp"));
+    auto& shard = workspace.merged_indices[main_id];
+    ASSERT_TRUE(shard.has_contribution(dir.path("main.cpp")));
+    ASSERT_EQ(shard.content(), old_main);
+}
+
+};  // TEST_SUITE(IndexerMerge)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/server/invalidator_tests.cpp
+++ b/tests/unit/server/invalidator_tests.cpp
@@ -175,6 +175,113 @@ TEST_CASE(TransitiveDependentsEnqueue) {
     ASSERT_TRUE(dirty.mark_ast_dirty.empty());
 }
 
+TEST_CASE(ModuleSaveReachesImporters) {
+    Workspace workspace;
+    SessionStore store;
+    auto iface = workspace.path_pool.intern("/proj/m.cppm");
+    auto open_user = workspace.path_pool.intern("/proj/open.cpp");
+    auto closed_user = workspace.path_pool.intern("/proj/closed.cpp");
+    workspace.dep_graph.add_module("m", iface);
+    workspace.dep_graph.set_imports(open_user, {"m"});
+    workspace.dep_graph.set_imports(closed_user, {"m"});
+    workspace.path_to_module[iface] = "m";
+    store.open(open_user);
+
+    ContextResolver resolver(workspace);
+    Invalidator invalidator(workspace, store, resolver);
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(iface));
+
+    // Importers never compiled this session — the compile graph cannot know
+    // them; the scan-built import edges must. Open ones recompile, closed
+    // ones reindex.
+    ASSERT_TRUE(llvm::is_contained(dirty.mark_ast_dirty, open_user));
+    ASSERT_TRUE(llvm::is_contained(dirty.enqueue_reindex, closed_user));
+}
+
+TEST_CASE(SaveUpdatesImportEdges) {
+    TempDir dir;
+    Workspace workspace;
+    SessionStore store;
+    dir.touch("m.cppm", "export module m;\nexport int f();\n");
+    dir.touch("use.cpp", "import m;\nint run();\n");
+    auto iface = workspace.path_pool.intern(dir.path("m.cppm"));
+    auto importer = workspace.path_pool.intern(dir.path("use.cpp"));
+    workspace.dep_graph.add_module("m", iface);
+    workspace.path_to_module[iface] = "m";
+
+    ContextResolver resolver(workspace);
+    Invalidator invalidator(workspace, store, resolver);
+
+    // The importer's save rescans its imports from disk; only then does the
+    // interface save reach it.
+    invalidator.apply(FileEvent::buffer_saved(importer));
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(iface));
+    ASSERT_TRUE(llvm::is_contained(dirty.enqueue_reindex, importer));
+
+    // Dropping the import on a later save removes the edge again.
+    dir.touch("use.cpp", "int run();\n");
+    invalidator.apply(FileEvent::buffer_saved(importer));
+    dirty = invalidator.apply(FileEvent::buffer_saved(iface));
+    ASSERT_FALSE(llvm::is_contained(dirty.enqueue_reindex, importer));
+}
+
+TEST_CASE(DiskRemovedClearsImports) {
+    Workspace workspace;
+    SessionStore store;
+    auto importer = workspace.path_pool.intern("/proj/use.cpp");
+    workspace.dep_graph.set_imports(importer, {"m"});
+
+    ContextResolver resolver(workspace);
+    Invalidator invalidator(workspace, store, resolver);
+    invalidator.apply(FileEvent::disk_removed(importer));
+
+    ASSERT_TRUE(workspace.dep_graph.importers_of("m").empty());
+    ASSERT_TRUE(workspace.dep_graph.imports_of(importer).empty());
+}
+
+TEST_CASE(TransitiveImportersEnqueue) {
+    Workspace workspace;
+    SessionStore store;
+    auto iface_b = workspace.path_pool.intern("/proj/b.cppm");
+    auto iface_a = workspace.path_pool.intern("/proj/a.cppm");
+    auto user = workspace.path_pool.intern("/proj/use.cpp");
+    workspace.dep_graph.add_module("b", iface_b);
+    workspace.dep_graph.add_module("a", iface_a);
+    workspace.dep_graph.set_imports(iface_a, {"b"});
+    workspace.dep_graph.set_imports(user, {"a"});
+    workspace.path_to_module[iface_b] = "b";
+    workspace.path_to_module[iface_a] = "a";
+
+    ContextResolver resolver(workspace);
+    Invalidator invalidator(workspace, store, resolver);
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(iface_b));
+
+    // b's change reaches a (imports b) and, through a's interface, user.
+    ASSERT_TRUE(llvm::is_contained(dirty.enqueue_reindex, iface_a));
+    ASSERT_TRUE(llvm::is_contained(dirty.enqueue_reindex, user));
+}
+
+TEST_CASE(ImplUnitNoCascade) {
+    Workspace workspace;
+    SessionStore store;
+    auto iface = workspace.path_pool.intern("/proj/m.cppm");
+    auto impl = workspace.path_pool.intern("/proj/m.cpp");
+    auto user = workspace.path_pool.intern("/proj/use.cpp");
+    workspace.dep_graph.add_module("m", iface);
+    workspace.dep_graph.set_imports(impl, {"m"});
+    workspace.dep_graph.set_imports(user, {"m"});
+    workspace.path_to_module[iface] = "m";
+    workspace.path_to_module[impl] = "m";
+
+    ContextResolver resolver(workspace);
+    Invalidator invalidator(workspace, store, resolver);
+    auto dirty = invalidator.apply(FileEvent::buffer_saved(impl));
+
+    // An implementation unit shares the module name but its content never
+    // reaches importers — only interface saves cascade.
+    ASSERT_FALSE(llvm::is_contained(dirty.enqueue_reindex, user));
+}
+
 TEST_CASE(StaleReverseMapUnion) {
     Workspace workspace;
     SessionStore store;

--- a/tests/unit/server/module_worker_tests.cpp
+++ b/tests/unit/server/module_worker_tests.cpp
@@ -2,8 +2,11 @@
 #include <vector>
 
 #include "test/test.h"
+#include "index/tu_index.h"
 #include "server/protocol/worker.h"
 #include "server/worker_test_helpers.h"
+
+#include "llvm/ADT/STLExtras.h"
 
 namespace clice::testing {
 
@@ -88,6 +91,15 @@ TEST_CASE(BuildPCMThenCompileWithImport) {
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().version, 1);
 
+        // The imported module's interface source is a dependency of the
+        // consumer, hashed from its on-disk content, with the compile start
+        // time alongside for the mtime fast layer.
+        auto& deps = result.value().deps;
+        auto dep = llvm::find_if(deps, [&](const HashedDep& dep) { return dep.path == iface; });
+        CO_ASSERT_TRUE(dep != deps.end());
+        EXPECT_TRUE(dep->hash != 0);
+        EXPECT_TRUE(result.value().build_at > 0);
+
         phase2_done = true;
         sf.peer->close_output();
     });
@@ -96,6 +108,83 @@ TEST_CASE(BuildPCMThenCompileWithImport) {
 
     // Cleanup PCM temp file.
     std::remove(pcm_path.c_str());
+}
+
+TEST_CASE(IndexImporterReportsImports) {
+    TempDir tmp;
+    tmp.touch("mod_iface.cppm",
+              "export module Hello;\n" R"(export inline int hello() { return 1; })" "\n");
+    auto iface = tmp.path("mod_iface.cppm");
+    tmp.touch("consumer.cpp", "import Hello;\n" "int use_hello() { return hello(); }\n");
+    auto consumer = tmp.path("consumer.cpp");
+
+    WorkerHandle sl;
+    ASSERT_TRUE(sl.spawn());
+
+    bool done = false;
+
+    sl.run([&]() -> kota::task<> {
+        std::string pcm_path;
+        {
+            worker::BuildParams params;
+            params.kind = worker::BuildKind::BuildPCM;
+            params.file = iface;
+            params.directory = "/tmp";
+            params.arguments = {"clang++",
+                                "-resource-dir",
+                                std::string(resource_dir()),
+                                "-std=c++20",
+                                "--precompile",
+                                iface};
+            params.module_name = "Hello";
+            params.output_path = tmp.path("Hello.pcm");
+
+            auto result = co_await sl.peer->send_request(params);
+            CO_ASSERT_TRUE(result.has_value() && result.value().success);
+            pcm_path = result.value().output_path;
+
+            // Build results carry the compile start time and the interface
+            // source with its consumed-content hash.
+            EXPECT_TRUE(result.value().build_at > 0);
+            auto& deps = result.value().deps;
+            auto dep = llvm::find_if(deps, [&](const HashedDep& dep) { return dep.path == iface; });
+            CO_ASSERT_TRUE(dep != deps.end());
+            EXPECT_TRUE(dep->hash != 0);
+        }
+
+        // Background-index the consumer against the PCM: the TUIndex must
+        // carry the interface source as an import dependency with a hash.
+        worker::BuildParams params;
+        params.kind = worker::BuildKind::Index;
+        params.file = consumer;
+        params.directory = "/tmp";
+        params.arguments = {"clang++",
+                            "-resource-dir",
+                            std::string(resource_dir()),
+                            "-std=c++20",
+                            "-fsyntax-only",
+                            consumer};
+        params.pcms = {
+            {"Hello", pcm_path}
+        };
+
+        auto result = co_await sl.peer->send_request(params);
+        CO_ASSERT_TRUE(result.has_value());
+        CO_ASSERT_TRUE(result.value().success);
+        CO_ASSERT_FALSE(result.value().tu_index_data.empty());
+
+        auto tu_index = index::TUIndex::from(result.value().tu_index_data.data());
+        CO_ASSERT_EQ(tu_index.imports.size(), 1u);
+        auto import_id = tu_index.imports[0];
+        EXPECT_EQ(tu_index.graph.paths[import_id], iface);
+        EXPECT_TRUE(tu_index.graph.path_hashes[import_id] != 0);
+
+        std::remove(pcm_path.c_str());
+        done = true;
+        sl.peer->close_output();
+    });
+
+    ASSERT_TRUE(done);
 }
 
 TEST_CASE(BuildPCMChainThenCompile) {
@@ -196,6 +285,15 @@ TEST_CASE(BuildPCMChainThenCompile) {
         auto result = co_await sf.peer->send_request(params);
         CO_ASSERT_TRUE(result.has_value());
         EXPECT_EQ(result.value().version, 1);
+
+        // The consumer spells only `import B;`, but loading B's PCM pulls
+        // A's too — both interface sources must be reported as deps.
+        auto has_dep = [&](llvm::StringRef path) {
+            return llvm::any_of(result.value().deps,
+                                [&](const HashedDep& dep) { return dep.path == path; });
+        };
+        EXPECT_TRUE(has_dep(mod_a));
+        EXPECT_TRUE(has_dep(mod_b));
 
         compile_done = true;
         sf.peer->close_output();

--- a/tests/unit/syntax/dependency_graph_tests.cpp
+++ b/tests/unit/syntax/dependency_graph_tests.cpp
@@ -74,6 +74,40 @@ TEST_CASE(ModuleCount) {
     EXPECT_EQ(graph.module_count(), 2u);
 }
 
+TEST_CASE(ImportEdges) {
+    clice::DependencyGraph graph;
+    EXPECT_TRUE(graph.importers_of("m").empty());
+    EXPECT_TRUE(graph.imports_of(1).empty());
+
+    graph.set_imports(1, {"m", "n"});
+    graph.set_imports(2, {"m"});
+    EXPECT_EQ(graph.imports_of(1).size(), 2u);
+    EXPECT_EQ(graph.importers_of("m").size(), 2u);
+    EXPECT_EQ(graph.importers_of("n").size(), 1u);
+}
+
+TEST_CASE(SetImportsReplaces) {
+    clice::DependencyGraph graph;
+    graph.set_imports(1, {"m", "n"});
+
+    // A rescan replaces the file's whole import set; dropped edges must
+    // leave the reverse map too.
+    graph.set_imports(1, {"n"});
+    EXPECT_TRUE(graph.importers_of("m").empty());
+    EXPECT_EQ(graph.importers_of("n").size(), 1u);
+
+    graph.set_imports(1, {});
+    EXPECT_TRUE(graph.importers_of("n").empty());
+    EXPECT_TRUE(graph.imports_of(1).empty());
+}
+
+TEST_CASE(DuplicateImportsDedup) {
+    clice::DependencyGraph graph;
+    graph.set_imports(1, {"m", "m"});
+    EXPECT_EQ(graph.imports_of(1).size(), 1u);
+    EXPECT_EQ(graph.importers_of("m").size(), 1u);
+}
+
 // ============================================================================
 // Include edge tests
 // ============================================================================

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -129,6 +129,58 @@ export module foo;
     EXPECT_TRUE(result.need_preprocess);
 }
 
+TEST_CASE(ImportDeclarations) {
+    auto result = scan(R"(
+import foo;
+import bar.baz;
+)");
+
+    ASSERT_EQ(result.modules.size(), 2u);
+    EXPECT_EQ(result.modules[0], "foo");
+    EXPECT_EQ(result.modules[1], "bar.baz");
+}
+
+TEST_CASE(ExportImport) {
+    auto result = scan(R"(
+export module my.module;
+export import foo;
+import bar;
+)");
+
+    ASSERT_EQ(result.modules.size(), 2u);
+    EXPECT_EQ(result.modules[0], "foo");
+    EXPECT_EQ(result.modules[1], "bar");
+}
+
+TEST_CASE(PartitionImport) {
+    // A partition import implicitly names its primary module, also when the
+    // importer is itself a partition.
+    auto result = scan(R"(
+export module my.module;
+import :part;
+)");
+    ASSERT_EQ(result.modules.size(), 1u);
+    EXPECT_EQ(result.modules[0], "my.module:part");
+
+    result = scan(R"(
+export module my.module:other;
+import :part;
+)");
+    ASSERT_EQ(result.modules.size(), 1u);
+    EXPECT_EQ(result.modules[0], "my.module:part");
+}
+
+TEST_CASE(HeaderUnitImportSkipped) {
+    auto result = scan(R"(
+import <vector>;
+import "header.h";
+import real.module;
+)");
+
+    ASSERT_EQ(result.modules.size(), 1u);
+    EXPECT_EQ(result.modules[0], "real.module");
+}
+
 TEST_CASE(GlobalModuleFragment) {
     auto result = scan(R"(
 module;


### PR DESCRIPTION
## Problem

The master validates compilation artifacts (AST, PCH, PCM, index shards)
against dependency snapshots it captures by **re-reading files from disk when
a worker result arrives**. That snapshot describes the disk at completion
time, not the content the worker actually compiled. If a file is saved while
a compilation is in flight, the master can bless the *new* disk content as
the baseline of an artifact built from the *old* content — the artifact then
looks permanently fresh and the pull-side staleness check can never recover.
For PCH and PCM blobs this even survives a restart, because the wrong
baseline is persisted in cache.json.

Separately, C++20 `import` edges were invisible to all three invalidation
mechanisms (the include reverse-graph, worker-reported deps, and index shard
dependencies). Saving a module interface only reached importers that had
already compiled this session; a closed importer that never compiled kept
serving stale cross-file references indefinitely.

## Changes

### Consumed-content hashing (worker side)

- The worker protocol's dependency lists (`CompileResult::deps`,
  `BuildResult::deps`) now carry `{path, xxh3 hash}` entries plus the compile
  start time. The worker hashes each dependency's SourceManager-resident
  buffer at the end of the compilation — the bytes the compiler actually
  consumed — instead of the master re-reading disk later. This is an internal
  protocol: master and workers ship from the same build, so there is no
  compatibility concern.
- `TUIndex` ships a consumed-content hash per path
  (`IncludeGraph::path_hashes`), resolving the existing TODO in
  `MergedIndex::merge` about re-reading every dependency on the event loop.
- `capture_deps_snapshot` adopts the worker hashes verbatim and stamps the
  snapshot with the compile start time. The previous arrival-time baseline
  let the mtime fast layer wave through files saved mid-compile; with a
  start-time baseline such saves fall through to the hash comparison and are
  detected. The reported time additionally backs off one second, since file
  mtimes compare at second granularity.
- PCM dependency lists were previously never populated at all (the field
  existed but nothing filled it); they now carry the module's own interface
  source, every header it includes, and the interfaces of imported modules —
  so pull-side PCM revalidation actually works.

### Index merge: explicit redo instead of silently wrong stores

`Indexer::merge` stores file content read from disk next to index rows the
worker built from the content *it* read. The two can diverge when a write
lands during the indexing run; storing either would corrupt position
mapping. The merge now compares the disk content's hash against the
worker-reported hash and, on mismatch, skips that file, keeps the previous
snapshot (now also protected from the stale-contribution sweep, which
previously deleted the very snapshot the read-failure path meant to keep),
and re-enqueues the TU. An indexing round that ends with such leftovers
reschedules itself.

### Module import edges

- `CompilationUnitRef::deps()` reports the interface sources of every loaded
  module file (direct and transitive), so AST, PCH/PCM, and index shard
  dependencies all see `import` edges.
- The dependency scanner records per-file import edges (the lexer-based scan
  previously never populated `ScanResult::modules` — `import` declarations
  were skipped entirely), and `DependencyGraph` keeps a module → importers
  reverse map, updated on save rescans and file removal.
- The invalidator extends the save cascade through that reverse map: saving
  a module interface (or a header embedded in one) now recompiles open
  importers and re-enqueues closed ones, transitively through importing
  interfaces — including importers that never compiled this session.
- Background indexing builds a TU's module PCMs before indexing it
  (previously only module units themselves got this treatment, so an
  importer's index run compiled against nothing after its PCMs were
  invalidated, producing junk shards full of errors).

### Pre-existing crash fix

Indexing any TU that imports a module crashed the stateless worker: index
rows can land in the module's own source files (via the loaded AST), whose
FileIDs the include graph does not know, and `IncludeGraph::path_id`
dereferenced a not-found iterator. Those rows belong to the module's own
index run and are now dropped, with a comment explaining why.

### Small items in the same area

- `MergedIndex::need_update` documents why checking
  `compilation_contexts.begin()` is exhaustive (the map holds at most one
  entry — the shard's own TU; header contributions live in a separate table).
- `Indexer::index_one` re-checks the session table and shard freshness after
  awaiting module PCM builds, which can suspend for a long time.
- A save that introduces a module interface declaration registers the module
  name, so the importer cascade recognizes the file as a provider.

## Behavioral notes

- Staleness semantics move from "the artifact is probably fresh" to "the
  artifact was provably built from exactly this content".
- A module interface saved *during* an importer's compile window can still be
  blessed with the new source hash (the source is consumed indirectly through
  its PCM, so there is no resident buffer to hash); the save-side cascade
  covers that window, and `imported_module_sources` documents the contract.
- Old persisted index shards remain loadable: a missing per-dep hash falls
  back to the conservative rebuild path, same as before.
- Deleting a module interface from disk clears its own import edges but does
  not yet cascade to importers; that belongs with the close/removal semantics
  work and is left for a follow-up.

## Tests

- Unit: hash adoption and detection in `capture_deps_snapshot`/`deps_changed`
  (including the mid-compile-save recovery the arrival-time baseline could
  not detect); merge mismatch skip/keep/re-enqueue; import edge storage,
  replacement and importer lookup in `DependencyGraph`; the lexer scan's new
  import parsing (dotted names, export import, partitions, header units);
  save cascades reaching open/closed/transitive importers (and not cascading
  from implementation units); save-rescan updating import edges from disk;
  PCH/PCM dep hashes against real compilations; module symbol identity across
  the PCM boundary; TUIndex hash/import serialization round-trip; end-to-end
  worker IPC assertions for compile, PCM build, and index results.
- Integration: `test_module_reindex.py` — cross-file references from a
  closed importer resolve, the interface is saved with a changed symbol, and
  the closed importer's references update after the automatic reindex.

Local verification on top of the rebased main: format, RelWithDebInfo build,
873 unit tests, 261 integration tests, 3/3 smoke replays — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C++20 module import tracking, including recording imported module sources and propagating module-based dependencies through reindexing.
  * Extended index metadata to retain per-path content hashes and imported module references for more accurate invalidation.
* **Bug Fixes**
  * Improved rebuild/staleness detection by using content hashes (not just mtimes) alongside a build timestamp baseline.
  * Updated dependency snapshotting and merge behavior to avoid reusing outdated compiled data and to trigger correct updates for imported modules and transitive module chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->