### PR TITLE
feat(hover): show include paths and TagDecl members

### DIFF
--- a/docs/en/features/hover.md
+++ b/docs/en/features/hover.md
@@ -237,7 +237,7 @@
 
 ## Special Hover Targets
 
-- [ ] Show struct/enum members on type-level hover ([clangd#959](https://github.com/clangd/clangd/issues/959))
+- [x] Show struct/enum members on type-level hover ([clangd#959](https://github.com/clangd/clangd/issues/959))
 
   ```cpp
   enum Color { Red, Green, Blue };
@@ -266,7 +266,7 @@
   // hover on "nodiscard" → description of the attribute
   ```
 
-- [ ] `#include` directive hover showing resolved header path
+- [x] `#include` directive hover showing resolved header path
 - [x] `this` expression hover showing pointed-to type
 - [x] `__func__` and related predefined identifier hover
 

--- a/docs/zh/features/hover.md
+++ b/docs/zh/features/hover.md
@@ -237,7 +237,7 @@
 
 ## 特殊悬停目标
 
-- [ ] 类型级悬停显示结构体/枚举成员（[clangd#959](https://github.com/clangd/clangd/issues/959)）
+- [x] 类型级悬停显示结构体/枚举成员（[clangd#959](https://github.com/clangd/clangd/issues/959)）
 
   ```cpp
   enum Color { Red, Green, Blue };
@@ -266,7 +266,7 @@
   // 悬停 "nodiscard" → 显示该属性的说明
   ```
 
-- [ ] `#include` 指令悬停显示解析后的头文件路径
+- [x] `#include` 指令悬停显示解析后的头文件路径
 - [x] `this` 表达式悬停显示指向的类型
 - [x] `__func__` 及相关预定义标识符悬停
 

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -10,6 +10,7 @@
 #include "semantic/ast_utility.h"
 #include "semantic/find_target.h"
 #include "semantic/selection.h"
+#include "syntax/lexer.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1044,6 +1045,57 @@ auto attr_hover(const clang::Attr* attr, clang::ASTContext& context) -> std::opt
     return info;
 }
 
+auto include_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::optional<HoverInfo> {
+    auto interested = unit.interested_file();
+    auto directives_it = unit.directives().find(interested);
+    if(directives_it == unit.directives().end()) {
+        return std::nullopt;
+    }
+
+    auto content = unit.interested_content();
+    auto* lang_opts = &unit.lang_options();
+
+    auto header_name = [&](LocalSourceRange range) -> std::string {
+        auto arg = content.substr(range.begin, range.end - range.begin).trim();
+        if(arg.size() >= 2 && ((arg.front() == '"' && arg.back() == '"') ||
+                               (arg.front() == '<' && arg.back() == '>'))) {
+            arg = arg.drop_front().drop_back();
+        }
+        return arg.str();
+    };
+
+    auto try_directive = [&](clang::SourceLocation loc,
+                             clang::FileID target) -> std::optional<HoverInfo> {
+        if(!target.isValid())
+            return std::nullopt;
+        auto [fid, directive_offset] = unit.decompose_location(loc);
+        if(fid != interested || directive_offset >= content.size())
+            return std::nullopt;
+        auto range = find_directive_argument(content, directive_offset, lang_opts);
+        if(!range || !range->contains(offset))
+            return std::nullopt;
+
+        HoverInfo info;
+        info.name = header_name(*range);
+        info.kind = SymbolKind::Header;
+        info.definition = unit.file_path(target);
+        info.symbol_range = *range;
+        return info;
+    };
+
+    for(const auto& include: directives_it->second.includes) {
+        if(auto info = try_directive(include.location, include.fid)) {
+            return info;
+        }
+    }
+    for(const auto& has_include: directives_it->second.has_includes) {
+        if(auto info = try_directive(has_include.location, has_include.fid)) {
+            return info;
+        }
+    }
+    return std::nullopt;
+}
+
 void add_layout_info(const clang::NamedDecl& decl, HoverInfo& info) {
     if(decl.isInvalidDecl()) {
         return;
@@ -1504,6 +1556,11 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const HoverInfo::Param& par
 
 auto hover_info(CompilationUnitRef unit, std::uint32_t offset, const HoverOptions& options)
     -> std::optional<HoverInfo> {
+    /// The hover is over an include directive.
+    if(auto info = include_hover(unit, offset)) {
+        return info;
+    }
+
     auto& context = unit.context();
     auto policy = hover_printing_policy(context.getPrintingPolicy());
 

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -118,6 +118,58 @@ auto namespace_scope(const clang::Decl* decl) -> std::string {
     return "";
 }
 
+void print_tag_name(std::string& definition,
+                    const clang::TagDecl& decl,
+                    clang::PrintingPolicy policy) {
+    /// We only need the full tag name, so truncate the body at the opening brace for later fill-in.
+    llvm::raw_string_ostream os(definition);
+    decl.print(os, policy);
+    auto body = definition.rfind('{');
+    if(body == std::string::npos) {
+        return;
+    }
+    definition.resize(body);
+}
+
+auto print_record_definition(const clang::RecordDecl& decl, clang::PrintingPolicy policy)
+    -> std::string {
+    std::string definition;
+
+    print_tag_name(definition, decl, policy);
+
+    llvm::raw_string_ostream os(definition);
+    os << " {";
+    for(const clang::FieldDecl* field: decl.fields()) {
+        os << '\n';
+        field->print(os, policy);
+        os << ';';
+    }
+    os << "\n}";
+
+    return definition;
+}
+
+auto print_enum_definition(const clang::EnumDecl& decl, clang::PrintingPolicy policy)
+    -> std::string {
+    std::string definition;
+
+    print_tag_name(definition, decl, policy);
+
+    llvm::raw_string_ostream os(definition);
+    os << " {";
+    for(const clang::EnumConstantDecl* enumerator: decl.enumerators()) {
+        os << '\n';
+        enumerator->print(os, policy);
+        if(!enumerator->getInitExpr() && !enumerator->getType()->isDependentType()) {
+            os << " = " << llvm::toString(enumerator->getInitVal(), 10);
+        }
+        os << ',';
+    }
+    os << "\n}";
+
+    return definition;
+}
+
 auto print_definition(const clang::Decl* decl,
                       clang::PrintingPolicy policy,
                       const clang::syntax::TokenBuffer& tb) -> std::string {
@@ -129,6 +181,14 @@ auto print_definition(const clang::Decl* decl,
             if(tb.expandedTokens(init->getSourceRange()).size() > 200) {
                 policy.SuppressInitializers = true;
             }
+        }
+    } else if(auto* record = llvm::dyn_cast<clang::RecordDecl>(decl)) {
+        if(auto* definition = record->getDefinition()) {
+            return print_record_definition(*definition, policy);
+        }
+    } else if(auto* enum_decl = llvm::dyn_cast<clang::EnumDecl>(decl)) {
+        if(auto* definition = enum_decl->getDefinition()) {
+            return print_enum_definition(*definition, policy);
         }
     }
 

--- a/tests/data/hover/tag_decls.cpp
+++ b/tests/data/hover/tag_decls.cpp
@@ -152,3 +152,79 @@ namespace nested_templates_class {
 template <class T> struct cls {};
 $(17_nested_template_class)cls<cls<cls<int>>> foo;
 }
+
+namespace enum_explicit {
+enum Color {
+  RED = -123,
+  GREEN,
+  BLUE = 5,
+};
+void foo() {
+  $(18_enum_explicit)Color color = GREEN;
+}
+}
+
+namespace struct_fields {
+struct Point {
+  int x;
+  int y;
+};
+void foo() {
+  $(19_struct_fields)Point point;
+}
+}
+
+namespace inherited_struct {
+struct base {
+  int a;
+};
+
+struct Point : base {
+  int x;
+  int y;
+};
+void foo() {
+  $(20_inherited_struct)Point point;
+}
+}
+
+namespace inherited_class {
+struct first {};
+struct second {};
+
+class Point : public first, virtual protected second {
+  int value;
+};
+void foo() {
+  $(21_inherited_class)Point point;
+}
+}
+
+namespace template_fields {
+template <typename T>
+struct Box {
+  T value;
+};
+void foo() {
+  $(22_template_fields)Box<int> box;
+}
+}
+
+namespace inline_method_body {
+struct Widget {
+  int value;
+  int get() const { return value; }
+};
+void foo() {
+  $(23_inline_method_body)Widget widget;
+}
+}
+
+namespace lambda_field_body {
+struct Widget {
+  int value = [] { return 42; }();
+};
+void foo() {
+  $(24_lambda_field_body)Widget widget;
+}
+}

--- a/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
@@ -37,7 +37,7 @@ input_file: tag_decls.cpp
   name: "MyUnion"
   kind: Union
   namespace_scope: "union_decl::ns1::"
-  definition: "union MyUnion {}"
+  definition: "union MyUnion {\n  int x;\n  int y;\n}"
   symbol_range: "[541, 548)"
   markdown: |
     ### union `MyUnion`  
@@ -45,7 +45,10 @@ input_file: tag_decls.cpp
     ---
     ```cpp
     // In namespace union_decl::ns1
-    union MyUnion {}
+    union MyUnion {
+      int x;
+      int y;
+    }
     ```
 
 04_forward_class:
@@ -72,7 +75,7 @@ input_file: tag_decls.cpp
   kind: Enum
   namespace_scope: "enum_def::"
   documentation: "Enum declaration"
-  definition: "enum Hello {}"
+  definition: "enum Hello {\n  ONE = 0,\n  TWO = 1,\n  THREE = 2,\n}"
   symbol_range: "[747, 752)"
   markdown: |
     ### enum `Hello`  
@@ -83,7 +86,11 @@ input_file: tag_decls.cpp
     ---
     ```cpp
     // In namespace enum_def
-    enum Hello {}
+    enum Hello {
+      ONE = 0,
+      TWO = 1,
+      THREE = 2,
+    }
     ```
 
 06_enumerator:
@@ -333,6 +340,129 @@ input_file: tag_decls.cpp
     // In namespace nested_templates_class
     template <>
     struct cls<nested_templates_class::cls<nested_templates_class::cls<int>>> {}
+    ```
+
+18_enum_explicit:
+  name: "Color"
+  kind: Enum
+  namespace_scope: "enum_explicit::"
+  definition: "enum Color {\n  RED = -123,\n  GREEN = -122,\n  BLUE = 5,\n}"
+  symbol_range: "[2394, 2399)"
+  markdown: |
+    ### enum `Color`  
+
+    ---
+    ```cpp
+    // In namespace enum_explicit
+    enum Color {
+      RED = -123,
+      GREEN = -122,
+      BLUE = 5,
+    }
+    ```
+
+19_struct_fields:
+  name: "Point"
+  kind: Struct
+  namespace_scope: "struct_fields::"
+  definition: "struct Point {\n  int x;\n  int y;\n}"
+  symbol_range: "[2497, 2502)"
+  markdown: |
+    ### struct `Point`  
+
+    ---
+    ```cpp
+    // In namespace struct_fields
+    struct Point {
+      int x;
+      int y;
+    }
+    ```
+
+20_inherited_struct:
+  name: "Point"
+  kind: Struct
+  namespace_scope: "inherited_struct::"
+  definition: "struct Point : base {\n  int x;\n  int y;\n}"
+  symbol_range: "[2629, 2634)"
+  markdown: |
+    ### struct `Point`  
+
+    ---
+    ```cpp
+    // In namespace inherited_struct
+    struct Point : base {
+      int x;
+      int y;
+    }
+    ```
+
+21_inherited_class:
+  name: "Point"
+  kind: Class
+  namespace_scope: "inherited_class::"
+  definition: "class Point : public first, virtual protected second {\n  int value;\n}"
+  symbol_range: "[2797, 2802)"
+  markdown: |
+    ### class `Point`  
+
+    ---
+    ```cpp
+    // In namespace inherited_class
+    class Point : public first, virtual protected second {
+      int value;
+    }
+    ```
+
+22_template_fields:
+  name: "Box<int>"
+  kind: Struct
+  namespace_scope: "template_fields::"
+  definition: "template <> struct Box<int> {\n  int value;\n}"
+  symbol_range: "[2907, 2910)"
+  markdown: |
+    ### struct `Box<int>`  
+
+    ---
+    ```cpp
+    // In namespace template_fields
+    template <> struct Box<int> {
+      int value;
+    }
+    ```
+
+23_inline_method_body:
+  name: "Widget"
+  kind: Struct
+  namespace_scope: "inline_method_body::"
+  definition: "struct Widget {\n  int value;\n}"
+  symbol_range: "[3040, 3046)"
+  markdown: |
+    ### struct `Widget`  
+
+    ---
+    ```cpp
+    // In namespace inline_method_body
+    struct Widget {
+      int value;
+    }
+    ```
+
+24_lambda_field_body:
+  name: "Widget"
+  kind: Struct
+  namespace_scope: "lambda_field_body::"
+  definition: "struct Widget {\n  int value = [] {}();\n}"
+  symbol_range: "[3159, 3165)"
+  markdown: |
+    ### struct `Widget`  
+
+    ---
+    ```cpp
+    // In namespace lambda_field_body
+    struct Widget {
+      int value = [] {}();
+    }
     ```
 
 

--- a/tests/unit/feature/hover_tests.cpp
+++ b/tests/unit/feature/hover_tests.cpp
@@ -8,6 +8,7 @@
 #include "test/test.h"
 #include "test/tester.h"
 #include "feature/feature.h"
+#include "support/filesystem.h"
 
 #include "kota/meta/enum.h"
 
@@ -1009,6 +1010,43 @@ int $foo = 1;
     ASSERT_EQ(result->range->start.character, 4U);
     ASSERT_EQ(result->range->end.line, 1U);
     ASSERT_EQ(result->range->end.character, 7U);
+}
+
+TEST_CASE(include_header) {
+    add_file("test.h", "#pragma once\n");
+    add_main("main.cpp", R"cpp(
+#include @arg["test.h"]
+$(outside)
+int x = 0;
+)cpp");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    info = feature::hover_info(*unit, arg.begin + 1);
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->kind, SymbolKind::Header);
+    EXPECT_EQ(info->name, "test.h");
+
+    llvm::SmallString<128> path(info->definition);
+    path::remove_dots(path);
+    EXPECT_EQ(path, TestVFS::path("test.h"));
+    ASSERT_TRUE(info->symbol_range.has_value());
+    EXPECT_EQ(info->symbol_range->begin, arg.begin);
+    EXPECT_EQ(info->symbol_range->end, arg.end);
+
+    result = feature::hover(*unit, arg.begin + 1, {}, feature::PositionEncoding::UTF8);
+    ASSERT_TRUE(result.has_value());
+    auto* content = std::get_if<protocol::MarkupContent>(&result->contents);
+    ASSERT_TRUE(content != nullptr);
+    EXPECT_TRUE(content->value.contains("test.h"));
+    EXPECT_TRUE(content->value.contains(TestVFS::path("test.h")));
+    ASSERT_TRUE(result->range.has_value());
+    EXPECT_EQ(result->range->start.line, 1U);
+    EXPECT_EQ(result->range->start.character, 9U);
+    EXPECT_EQ(result->range->end.line, 1U);
+    EXPECT_EQ(result->range->end.character, 17U);
+
+    EXPECT_FALSE(feature::hover_info(*unit, point("outside")).has_value());
 }
 
 TEST_CASE(scoped_attribute) {


### PR DESCRIPTION
This pull request significantly improves the hover feature in the codebase by enhancing the information shown when hovering over struct, enum, and `#include` directives. The main changes include implementing detailed type-level hover for structs/enums, adding hover support for `#include` directives to show resolved header paths, and updating documentation and tests to reflect these new capabilities.

**Hover Feature Enhancements:**

* Added detailed type-level hover for structs and enums, displaying their members and enumerators in the hover popup. This includes handling explicit values, inherited members, template instantiations, and inline/lambda initializers. (`src/feature/hover.cpp`, `tests/data/hover/tag_decls.cpp`, `tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml`) [[1]](diffhunk://#diff-a7b5c07694230d5b5027c09b8a4ae413a79dee49cb84554e7770688ed3434086R121-R172) [[2]](diffhunk://#diff-a7b5c07694230d5b5027c09b8a4ae413a79dee49cb84554e7770688ed3434086R185-R192) [[3]](diffhunk://#diff-dd3e3452f97d5a323a9db21d62bc9e1dc2be194100267327e5e23e84d50fd4a5R155-R230) [[4]](diffhunk://#diff-152c31b00a4bf46814337276fd706201d745df4d416e61109e00519db54f2a96L40-R51) [[5]](diffhunk://#diff-152c31b00a4bf46814337276fd706201d745df4d416e61109e00519db54f2a96L75-R78) [[6]](diffhunk://#diff-152c31b00a4bf46814337276fd706201d745df4d416e61109e00519db54f2a96L86-R93) [[7]](diffhunk://#diff-152c31b00a4bf46814337276fd706201d745df4d416e61109e00519db54f2a96R345-R467)
* Implemented hover support for `#include` directives, showing the resolved header path when hovering over the header name. (`src/feature/hover.cpp`, `tests/unit/feature/hover_tests.cpp`) [[1]](diffhunk://#diff-a7b5c07694230d5b5027c09b8a4ae413a79dee49cb84554e7770688ed3434086R1108-R1158) [[2]](diffhunk://#diff-a7b5c07694230d5b5027c09b8a4ae413a79dee49cb84554e7770688ed3434086R1619-R1623) [[3]](diffhunk://#diff-f1d2685ccc4328ddb9aa188b71f8d4a607f48e3cb67b98dd9005e252daa77a94R11) [[4]](diffhunk://#diff-f1d2685ccc4328ddb9aa188b71f8d4a607f48e3cb67b98dd9005e252daa77a94R1015-R1051)

**Documentation Updates:**

* Updated English and Chinese hover feature documentation to mark struct/enum member hover and `#include` directive hover as implemented. (`docs/en/features/hover.md`, `docs/zh/features/hover.md`) [[1]](diffhunk://#diff-14989b66bc46926fbbecdf67b094a572435719a664acf080b43aa5a66512caefL240-R240) [[2]](diffhunk://#diff-14989b66bc46926fbbecdf67b094a572435719a664acf080b43aa5a66512caefL269-R269) [[3]](diffhunk://#diff-82e3f2cb7a0184a4be0406e9b520daff10d7f58378b776ca6d88f55f08289fc4L240-R240) [[4]](diffhunk://#diff-82e3f2cb7a0184a4be0406e9b520daff10d7f58378b776ca6d88f55f08289fc4L269-R269)

**Testing Improvements:**

* Added comprehensive tests for the new hover features, including various struct and enum scenarios and `#include` directive hover. (`tests/data/hover/tag_decls.cpp`, `tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml`, `tests/unit/feature/hover_tests.cpp`) [[1]](diffhunk://#diff-dd3e3452f97d5a323a9db21d62bc9e1dc2be194100267327e5e23e84d50fd4a5R155-R230) [[2]](diffhunk://#diff-152c31b00a4bf46814337276fd706201d745df4d416e61109e00519db54f2a96R345-R467) [[3]](diffhunk://#diff-f1d2685ccc4328ddb9aa188b71f8d4a607f48e3cb67b98dd9005e252daa77a94R1015-R1051)

These changes collectively provide much richer and more informative hover experiences for users, especially when working with complex types and include directives.