### PR TITLE
feat(hover): show include paths and TagDecl member info

### DIFF
--- a/docs/en/features/hover.md
+++ b/docs/en/features/hover.md
@@ -237,7 +237,7 @@
 
 ## Special Hover Targets
 
-- [ ] Show struct/enum members on type-level hover ([clangd#959](https://github.com/clangd/clangd/issues/959))
+- [x] Show struct/enum members on type-level hover ([clangd#959](https://github.com/clangd/clangd/issues/959))
 
   ```cpp
   enum Color { Red, Green, Blue };
@@ -266,7 +266,7 @@
   // hover on "nodiscard" → description of the attribute
   ```
 
-- [ ] `#include` directive hover showing resolved header path
+- [x] `#include` directive hover showing resolved header path
 - [x] `this` expression hover showing pointed-to type
 - [x] `__func__` and related predefined identifier hover
 

--- a/docs/zh/features/hover.md
+++ b/docs/zh/features/hover.md
@@ -237,7 +237,7 @@
 
 ## 特殊悬停目标
 
-- [ ] 类型级悬停显示结构体/枚举成员（[clangd#959](https://github.com/clangd/clangd/issues/959)）
+- [x] 类型级悬停显示结构体/枚举成员（[clangd#959](https://github.com/clangd/clangd/issues/959)）
 
   ```cpp
   enum Color { Red, Green, Blue };
@@ -266,7 +266,7 @@
   // 悬停 "nodiscard" → 显示该属性的说明
   ```
 
-- [ ] `#include` 指令悬停显示解析后的头文件路径
+- [x] `#include` 指令悬停显示解析后的头文件路径
 - [x] `this` 表达式悬停显示指向的类型
 - [x] `__func__` 及相关预定义标识符悬停
 

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -337,9 +337,7 @@ std::vector<DepFile> CompilationUnitRef::deps() {
         /// pipeline: persist unresolved lookups and match them against
         /// file-creation events from the workspace watcher.
         for(auto& has_include: directive.has_includes) {
-            if(has_include.fid.isValid()) {
-                add_fid(has_include.fid);
-            }
+            add_file(has_include.file);
         }
 
         for(auto& embed: directive.embeds) {

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -139,6 +139,10 @@ public:
     /// them out first, see `is_builtin_file`.
     auto file_path(clang::FileID fid) -> llvm::StringRef;
 
+    /// Get the normalized path of a file entry that may not have a FileID,
+    /// such as a file only probed by __has_include.
+    auto file_path(clang::FileEntryRef file) -> std::string;
+
     /// Get the file content of the file ID.
     auto file_content(clang::FileID fid) -> llvm::StringRef;
 

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -139,10 +139,6 @@ public:
     /// them out first, see `is_builtin_file`.
     auto file_path(clang::FileID fid) -> llvm::StringRef;
 
-    /// Get the normalized path of a file entry that may not have a FileID,
-    /// such as a file only probed by __has_include.
-    auto file_path(clang::FileEntryRef file) -> std::string;
-
     /// Get the file content of the file ID.
     auto file_content(clang::FileID fid) -> llvm::StringRef;
 

--- a/src/compile/directive.cpp
+++ b/src/compile/directive.cpp
@@ -174,13 +174,7 @@ public:
                     bool,
                     clang::OptionalFileEntryRef file,
                     clang::SrcMgr::CharacteristicKind) override {
-        std::string target;
-        if(file) {
-            target = unit.file_path(*file);
-        }
-
-        unit->directives[unit.file_id(location)].has_includes.emplace_back(std::move(target),
-                                                                           location);
+        unit->directives[unit.file_id(location)].has_includes.emplace_back(file, location);
     }
 
     void PragmaDirective(clang::SourceLocation loc,

--- a/src/compile/directive.cpp
+++ b/src/compile/directive.cpp
@@ -174,12 +174,13 @@ public:
                     bool,
                     clang::OptionalFileEntryRef file,
                     clang::SrcMgr::CharacteristicKind) override {
-        clang::FileID fid;
+        std::string target;
         if(file) {
-            fid = unit.file_id(*file);
+            target = unit.file_path(*file);
         }
 
-        unit->directives[unit.file_id(location)].has_includes.emplace_back(fid, location);
+        unit->directives[unit.file_id(location)].has_includes.emplace_back(std::move(target),
+                                                                           location);
     }
 
     void PragmaDirective(clang::SourceLocation loc,

--- a/src/compile/directive.h
+++ b/src/compile/directive.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <vector>
 
 #include "syntax/token.h"
@@ -26,8 +25,8 @@ struct Include {
 
 /// Information about `__has_include` directive.
 struct HasInclude {
-    /// Resolved path of the probed file, empty when it does not exist.
-    std::string target;
+    /// The actual file found by the probe, if any.
+    clang::OptionalFileEntryRef file;
 
     /// Location of the filename token start.
     clang::SourceLocation location;

--- a/src/compile/directive.h
+++ b/src/compile/directive.h
@@ -26,9 +26,8 @@ struct Include {
 
 /// Information about `__has_include` directive.
 struct HasInclude {
-    /// The file id of included file, may be empty if there is
-    /// not such file.
-    clang::FileID fid;
+    /// Resolved path of the probed file, empty when it does not exist.
+    std::string target;
 
     /// Location of the filename token start.
     clang::SourceLocation location;

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -37,8 +37,8 @@ auto document_links(CompilationUnitRef unit) -> std::vector<DocumentLink> {
     }
 
     for(const auto& has_include: directives.has_includes) {
-        if(has_include.fid.isValid()) {
-            add_link(has_include.location, unit.file_path(has_include.fid));
+        if(!has_include.target.empty()) {
+            add_link(has_include.location, has_include.target);
         }
     }
 
@@ -70,8 +70,8 @@ auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
     auto content = unit.interested_content();
     auto* lang_opts = &unit.lang_options();
 
-    auto try_directive = [&](clang::SourceLocation loc, clang::FileID target) {
-        if(!locations.empty() || !target.isValid()) {
+    auto try_directive = [&](clang::SourceLocation loc, llvm::StringRef target) {
+        if(!locations.empty() || target.empty()) {
             return;
         }
         auto [fid, directive_offset] = unit.decompose_location(loc);
@@ -83,16 +83,16 @@ auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
             return;
         }
         locations.push_back(protocol::Location{
-            .uri = to_uri(unit.file_path(target)),
+            .uri = to_uri(target),
             .range = protocol::Range{},
         });
     };
 
     for(const auto& include: directives_it->second.includes) {
-        try_directive(include.location, include.fid);
+        try_directive(include.location, unit.file_path(include.fid));
     }
     for(const auto& has_include: directives_it->second.has_includes) {
-        try_directive(has_include.location, has_include.fid);
+        try_directive(has_include.location, has_include.target);
     }
     return locations;
 }

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -37,8 +37,8 @@ auto document_links(CompilationUnitRef unit) -> std::vector<DocumentLink> {
     }
 
     for(const auto& has_include: directives.has_includes) {
-        if(!has_include.target.empty()) {
-            add_link(has_include.location, has_include.target);
+        if(has_include.file) {
+            add_link(has_include.location, unit.file_path(*has_include.file));
         }
     }
 
@@ -89,10 +89,14 @@ auto include_definition(CompilationUnitRef unit, std::uint32_t offset)
     };
 
     for(const auto& include: directives_it->second.includes) {
-        try_directive(include.location, unit.file_path(include.fid));
+        if(include.fid.isValid()) {
+            try_directive(include.location, unit.file_path(include.fid));
+        }
     }
     for(const auto& has_include: directives_it->second.has_includes) {
-        try_directive(has_include.location, has_include.target);
+        if(has_include.file) {
+            try_directive(has_include.location, unit.file_path(*has_include.file));
+        }
     }
     return locations;
 }

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -120,6 +120,21 @@ auto namespace_scope(const clang::Decl* decl) -> std::string {
 
 constexpr std::size_t max_record_members = 20;
 constexpr std::size_t max_nested_enumerators = 8;
+constexpr std::size_t max_initializer_tokens = 200;
+
+bool has_large_initializer(const clang::Expr* init, const clang::syntax::TokenBuffer& tb) {
+    return init && tb.expandedTokens(init->getSourceRange()).size() > max_initializer_tokens;
+}
+
+auto member_initializer(const clang::Decl& decl) -> const clang::Expr* {
+    if(const auto* field = llvm::dyn_cast<clang::FieldDecl>(&decl)) {
+        return field->getInClassInitializer();
+    }
+    if(const auto* var = llvm::dyn_cast<clang::VarDecl>(&decl)) {
+        return var->getInit();
+    }
+    return nullptr;
+}
 
 auto print_decl_head(const clang::Decl& decl, clang::PrintingPolicy policy) -> std::string {
     std::string definition;
@@ -201,8 +216,9 @@ bool is_included_member_definition(const clang::Decl& decl) {
     return llvm::isa<clang::TagDecl, clang::ClassTemplateDecl>(decl);
 }
 
-auto print_record_definition(const clang::RecordDecl& decl, clang::PrintingPolicy policy)
-    -> std::string {
+auto print_record_definition(const clang::RecordDecl& decl,
+                             clang::PrintingPolicy policy,
+                             const clang::syntax::TokenBuffer& tb) -> std::string {
     std::string definition = print_decl_head(decl, policy);
 
     llvm::raw_string_ostream os(definition);
@@ -238,7 +254,11 @@ auto print_record_definition(const clang::RecordDecl& decl, clang::PrintingPolic
             continue;
         }
 
-        member->print(os, policy);
+        clang::PrintingPolicy member_policy = policy;
+        if(has_large_initializer(member_initializer(*member), tb)) {
+            member_policy.SuppressInitializers = true;
+        }
+        member->print(os, member_policy);
         os << ';';
     }
     os << "\n}";
@@ -250,17 +270,15 @@ auto print_definition(const clang::Decl* decl,
                       clang::PrintingPolicy policy,
                       const clang::syntax::TokenBuffer& tb) -> std::string {
     if(auto* var = llvm::dyn_cast<clang::VarDecl>(decl)) {
-        if(auto* init = var->getInit()) {
-            /// Initializers might be huge and result in lots of memory allocations
-            /// in some catastrophic cases. Such long lists are not useful in hover
-            /// cards anyway.
-            if(tb.expandedTokens(init->getSourceRange()).size() > 200) {
-                policy.SuppressInitializers = true;
-            }
+        /// Initializers might be huge and result in lots of memory allocations
+        /// in some catastrophic cases. Such long lists are not useful in hover
+        /// cards anyway.
+        if(has_large_initializer(var->getInit(), tb)) {
+            policy.SuppressInitializers = true;
         }
     } else if(auto* record = llvm::dyn_cast<clang::RecordDecl>(decl)) {
         if(auto* definition = record->getDefinition()) {
-            return print_record_definition(*definition, policy);
+            return print_record_definition(*definition, policy, tb);
         }
     } else if(auto* enum_decl = llvm::dyn_cast<clang::EnumDecl>(decl)) {
         if(auto* definition = enum_decl->getDefinition()) {

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -1218,12 +1218,18 @@ auto include_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::option
         return arg.str();
     };
 
+    auto line_start = content.rfind('\n', offset);
+    line_start = line_start == llvm::StringRef::npos ? 0 : line_start + 1;
+
+    auto line_end = content.find('\n', offset);
+    line_end = line_end == llvm::StringRef::npos ? content.size() : line_end;
+
     auto try_directive = [&](clang::SourceLocation loc,
-                             clang::FileID target) -> std::optional<HoverInfo> {
-        if(!target.isValid())
+                             llvm::StringRef target) -> std::optional<HoverInfo> {
+        if(target.empty())
             return std::nullopt;
         auto [fid, directive_offset] = unit.decompose_location(loc);
-        if(fid != interested || directive_offset >= content.size())
+        if(fid != interested || directive_offset < line_start || directive_offset >= line_end)
             return std::nullopt;
         auto range = find_directive_argument(content, directive_offset, lang_opts);
         if(!range || !range->contains(offset))
@@ -1232,18 +1238,18 @@ auto include_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::option
         HoverInfo info;
         info.name = header_name(*range);
         info.kind = SymbolKind::Header;
-        info.definition = unit.file_path(target);
+        info.definition = target;
         info.symbol_range = *range;
         return info;
     };
 
     for(const auto& include: directives_it->second.includes) {
-        if(auto info = try_directive(include.location, include.fid)) {
+        if(auto info = try_directive(include.location, unit.file_path(include.fid))) {
             return info;
         }
     }
     for(const auto& has_include: directives_it->second.has_includes) {
-        if(auto info = try_directive(has_include.location, has_include.fid)) {
+        if(auto info = try_directive(has_include.location, has_include.target)) {
             return info;
         }
     }

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -118,6 +118,134 @@ auto namespace_scope(const clang::Decl* decl) -> std::string {
     return "";
 }
 
+constexpr std::size_t max_record_members = 20;
+constexpr std::size_t max_nested_enumerators = 8;
+
+auto print_decl_head(const clang::Decl& decl, clang::PrintingPolicy policy) -> std::string {
+    std::string definition;
+    llvm::raw_string_ostream os(definition);
+    decl.print(os, policy);
+
+    /// TerseOutput leaves tag definitions with an empty body. Keep Clang's rendering of the
+    /// template prefix, attributes and bases, then replace that body with our summary.
+    auto body = definition.rfind('{');
+    if(body != std::string::npos) {
+        definition.resize(body);
+    }
+    return definition;
+}
+
+auto print_enum_definition(const clang::EnumDecl& decl,
+                           clang::PrintingPolicy policy,
+                           std::optional<std::size_t> limit = std::nullopt) -> std::string {
+    std::string definition = print_decl_head(decl, policy);
+
+    llvm::raw_string_ostream os(definition);
+    os << " {";
+    std::size_t count = 0;
+    for(const clang::EnumConstantDecl* enumerator: decl.enumerators()) {
+        if(limit && count == *limit) {
+            os << "\n...";
+            break;
+        }
+        ++count;
+        os << '\n';
+        enumerator->print(os, policy);
+        if(!enumerator->getInitExpr() && !enumerator->getType()->isDependentType()) {
+            os << " = " << llvm::toString(enumerator->getInitVal(), 10);
+        }
+        os << ',';
+    }
+    os << "\n}";
+
+    return definition;
+}
+
+void print_nested_type(const clang::Decl& decl,
+                       const clang::PrintingPolicy& policy,
+                       llvm::raw_ostream& os) {
+    /// Enumerators remain useful in a type summary, but cap them independently from members.
+    if(const auto* enum_decl = llvm::dyn_cast<clang::EnumDecl>(&decl)) {
+        if(enum_decl->isCompleteDefinition()) {
+            os << print_enum_definition(*enum_decl, policy, max_nested_enumerators) << ';';
+        } else {
+            decl.print(os, policy);
+            os << ';';
+        }
+        return;
+    }
+
+    /// Preserve forward declarations. Collapse definitions so deeply nested types do not
+    /// dominate the hover card.
+    const auto* record = llvm::dyn_cast<clang::RecordDecl>(&decl);
+    if(const auto* template_decl = llvm::dyn_cast<clang::ClassTemplateDecl>(&decl)) {
+        record = template_decl->getTemplatedDecl();
+    }
+    if(record && !record->isCompleteDefinition()) {
+        decl.print(os, policy);
+        os << ';';
+        return;
+    }
+
+    os << print_decl_head(decl, policy) << " { ... };";
+}
+
+bool is_included_member_definition(const clang::Decl& decl) {
+    /// Methods are intentionally omitted: this is a compact data/type summary, not a member list.
+    if(llvm::isa<clang::FieldDecl, clang::TypedefNameDecl, clang::TypeAliasTemplateDecl>(decl)) {
+        return true;
+    }
+    if(const auto* var = llvm::dyn_cast<clang::VarDecl>(&decl)) {
+        return var->isStaticDataMember();
+    }
+    return llvm::isa<clang::TagDecl, clang::ClassTemplateDecl>(decl);
+}
+
+auto print_record_definition(const clang::RecordDecl& decl, clang::PrintingPolicy policy)
+    -> std::string {
+    std::string definition = print_decl_head(decl, policy);
+
+    llvm::raw_string_ostream os(definition);
+    os << " {";
+    std::size_t count = 0;
+    const clang::AccessSpecDecl* pending_access = nullptr;
+    for(const clang::Decl* member: decl.decls()) {
+        if(member->isImplicit()) {
+            continue;
+        }
+        if(const auto* access = llvm::dyn_cast<clang::AccessSpecDecl>(member)) {
+            pending_access = access;
+            continue;
+        }
+        if(!is_included_member_definition(*member)) {
+            continue;
+        }
+        if(count++ == max_record_members) {
+            os << "\n// ...";
+            break;
+        }
+
+        /// Delay the label until a visible member follows it. This avoids a dangling `private:`
+        /// section when that section contains methods only.
+        if(pending_access) {
+            os << '\n' << clang::getAccessSpelling(pending_access->getAccess()) << ':';
+            pending_access = nullptr;
+        }
+        os << '\n';
+
+        if(llvm::isa<clang::TagDecl, clang::ClassTemplateDecl>(*member)) {
+            print_nested_type(*member, policy, os);
+            continue;
+        }
+
+        member->print(os, policy);
+        os << ';';
+    }
+    os << "\n}";
+
+    return definition;
+}
+
 auto print_definition(const clang::Decl* decl,
                       clang::PrintingPolicy policy,
                       const clang::syntax::TokenBuffer& tb) -> std::string {
@@ -129,6 +257,14 @@ auto print_definition(const clang::Decl* decl,
             if(tb.expandedTokens(init->getSourceRange()).size() > 200) {
                 policy.SuppressInitializers = true;
             }
+        }
+    } else if(auto* record = llvm::dyn_cast<clang::RecordDecl>(decl)) {
+        if(auto* definition = record->getDefinition()) {
+            return print_record_definition(*definition, policy);
+        }
+    } else if(auto* enum_decl = llvm::dyn_cast<clang::EnumDecl>(decl)) {
+        if(auto* definition = enum_decl->getDefinition()) {
+            return print_enum_definition(*definition, policy);
         }
     }
 

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -10,6 +10,7 @@
 #include "semantic/ast_utility.h"
 #include "semantic/find_target.h"
 #include "semantic/selection.h"
+#include "syntax/lexer.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
@@ -1044,6 +1045,57 @@ auto attr_hover(const clang::Attr* attr, clang::ASTContext& context) -> std::opt
     return info;
 }
 
+auto include_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::optional<HoverInfo> {
+    auto interested = unit.interested_file();
+    auto directives_it = unit.directives().find(interested);
+    if(directives_it == unit.directives().end()) {
+        return std::nullopt;
+    }
+
+    auto content = unit.interested_content();
+    auto* lang_opts = &unit.lang_options();
+
+    auto header_name = [&](LocalSourceRange range) -> std::string {
+        auto arg = content.substr(range.begin, range.end - range.begin).trim();
+        if(arg.size() >= 2 && ((arg.front() == '"' && arg.back() == '"') ||
+                               (arg.front() == '<' && arg.back() == '>'))) {
+            arg = arg.drop_front().drop_back();
+        }
+        return arg.str();
+    };
+
+    auto try_directive = [&](clang::SourceLocation loc,
+                             clang::FileID target) -> std::optional<HoverInfo> {
+        if(!target.isValid())
+            return std::nullopt;
+        auto [fid, directive_offset] = unit.decompose_location(loc);
+        if(fid != interested || directive_offset >= content.size())
+            return std::nullopt;
+        auto range = find_directive_argument(content, directive_offset, lang_opts);
+        if(!range || !range->contains(offset))
+            return std::nullopt;
+
+        HoverInfo info;
+        info.name = header_name(*range);
+        info.kind = SymbolKind::Header;
+        info.definition = unit.file_path(target);
+        info.symbol_range = *range;
+        return info;
+    };
+
+    for(const auto& include: directives_it->second.includes) {
+        if(auto info = try_directive(include.location, include.fid)) {
+            return info;
+        }
+    }
+    for(const auto& has_include: directives_it->second.has_includes) {
+        if(auto info = try_directive(has_include.location, has_include.fid)) {
+            return info;
+        }
+    }
+    return std::nullopt;
+}
+
 void add_layout_info(const clang::NamedDecl& decl, HoverInfo& info) {
     if(decl.isInvalidDecl()) {
         return;
@@ -1504,6 +1556,11 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const HoverInfo::Param& par
 
 auto hover_info(CompilationUnitRef unit, std::uint32_t offset, const HoverOptions& options)
     -> std::optional<HoverInfo> {
+    /// The hover is over an include directive.
+    if(auto info = include_hover(unit, offset)) {
+        return info;
+    }
+
     auto& context = unit.context();
     auto policy = hover_printing_policy(context.getPrintingPolicy());
 

--- a/src/feature/hover.cpp
+++ b/src/feature/hover.cpp
@@ -1244,13 +1244,17 @@ auto include_hover(CompilationUnitRef unit, std::uint32_t offset) -> std::option
     };
 
     for(const auto& include: directives_it->second.includes) {
-        if(auto info = try_directive(include.location, unit.file_path(include.fid))) {
-            return info;
+        if(include.fid.isValid()) {
+            if(auto info = try_directive(include.location, unit.file_path(include.fid))) {
+                return info;
+            }
         }
     }
     for(const auto& has_include: directives_it->second.has_includes) {
-        if(auto info = try_directive(has_include.location, has_include.target)) {
-            return info;
+        if(has_include.file) {
+            if(auto info = try_directive(has_include.location, unit.file_path(*has_include.file))) {
+                return info;
+            }
         }
     }
     return std::nullopt;

--- a/src/index/preamble_state.h
+++ b/src/index/preamble_state.h
@@ -19,7 +19,7 @@ namespace clice::index {
 /// carrying a different value loads as "missing" and the PCH pair is
 /// rebuilt. cache.json records it so a version change is caught at load
 /// time instead of on the first overlay query.
-constexpr inline std::uint32_t preamble_format_version = 3;
+constexpr inline std::uint32_t preamble_format_version = 4;
 
 /// All master-visible state derived from one PCH build.
 ///

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -215,9 +215,17 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
 
 FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
                                               const protocol::Position& position) {
+    if(!session) {
+        co_return kota::outcome_error(document_not_open());
+    }
+
     /// Like document_links, the preamble and the worker's AST are disjoint, so merge the two
     /// sources.
+    auto gen = session->generation;
     auto raw = co_await compiler.forward_query(worker::QueryKind::Hover, session, position);
+    if(session->generation != gen) {
+        co_return serde_raw{"null"};
+    }
     if(raw.has_value() && raw.value().data == "null" && !session->ast_dirty) {
         if(auto hover = resolve_preamble_hover(*session, position)) {
             co_return to_raw(*hover);

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -81,6 +81,51 @@ std::vector<protocol::Location>
     return locations;
 }
 
+std::optional<protocol::Hover>
+    FeatureRouter::resolve_preamble_hover(Session& session, const protocol::Position& position) {
+    auto links = find_preamble_links(session);
+    if(links.empty())
+        return std::nullopt;
+
+    auto map = session.line_map();
+    auto offset = map.to_offset(position);
+    if(!offset)
+        return std::nullopt;
+
+    for(const auto& link: links) {
+        if(!link.range.contains(*offset))
+            continue;
+
+        if(link.range.end > session.text.size())
+            return std::nullopt;
+
+        llvm::StringRef name(session.text.data() + link.range.begin, link.range.length());
+        name = name.trim();
+        if(name.size() >= 2 && ((name.front() == '"' && name.back() == '"') ||
+                                (name.front() == '<' && name.back() == '>'))) {
+            name = name.drop_front().drop_back();
+        }
+
+        auto range = map.to_range(link.range.begin, link.range.end);
+        if(!range)
+            return std::nullopt;
+
+        feature::HoverInfo info;
+        info.name = name.str();
+        info.kind = SymbolKind::Header;
+        info.definition = link.target;
+
+        protocol::MarkupContent content;
+        content.kind = protocol::MarkupKind::markdown;
+        content.value = info.present().as_markdown();
+        return protocol::Hover{
+            .contents = std::move(content),
+            .range = *range,
+        };
+    }
+    return std::nullopt;
+}
+
 kota::task<std::vector<protocol::DocumentLink>, kota::ipc::Error>
     FeatureRouter::document_links(std::shared_ptr<Session> session) {
     auto result = co_await compiler.forward_document_links(session);
@@ -170,7 +215,15 @@ kota::task<kota::codec::RawValue, kota::ipc::Error>
 
 FeatureRouter::RawResult FeatureRouter::hover(std::shared_ptr<Session> session,
                                               const protocol::Position& position) {
-    co_return co_await compiler.forward_query(worker::QueryKind::Hover, session, position);
+    /// Like document_links, the preamble and the worker's AST are disjoint, so merge the two
+    /// sources.
+    auto raw = co_await compiler.forward_query(worker::QueryKind::Hover, session, position);
+    if(raw.has_value() && raw.value().data == "null" && !session->ast_dirty) {
+        if(auto hover = resolve_preamble_hover(*session, position)) {
+            co_return to_raw(*hover);
+        }
+    }
+    co_return std::move(raw);
 }
 
 FeatureRouter::RawResult FeatureRouter::semantic_tokens(std::shared_ptr<Session> session) {

--- a/src/server/service/feature_router.h
+++ b/src/server/service/feature_router.h
@@ -150,6 +150,10 @@ private:
     std::vector<protocol::Location>
         resolve_directive_definition(Session& session, const protocol::Position& position);
 
+    /// Resolve hover on a preamble include from the links cached with the PCH.
+    std::optional<protocol::Hover> resolve_preamble_hover(Session& session,
+                                                          const protocol::Position& position);
+
     Compiler& compiler;
     IndexQuery& index_query;
     Workspace& workspace;

--- a/src/syntax/lexer.cpp
+++ b/src/syntax/lexer.cpp
@@ -150,7 +150,7 @@ std::optional<LocalSourceRange> find_directive_argument(llvm::StringRef content,
             continue;
         }
 
-        if(abs_begin < offset || !ready)
+        if(abs_end <= offset || !ready)
             continue;
 
         if(tok.is_header_name() || tok.kind == clang::tok::string_literal)

--- a/tests/data/hover/tag_decls.cpp
+++ b/tests/data/hover/tag_decls.cpp
@@ -152,3 +152,84 @@ namespace nested_templates_class {
 template <class T> struct cls {};
 $(17_nested_template_class)cls<cls<cls<int>>> foo;
 }
+
+namespace inherited_class {
+struct first {};
+struct second {};
+
+class Point : public first, virtual protected second {
+  int value;
+};
+void foo() {
+  $(18_inherited_class)Point point;
+}
+}
+
+namespace template_fields {
+template <typename T>
+struct Box {
+  using value_type = T;
+  T value;
+};
+void foo() {
+  $(19_template_fields)Box<int> box;
+}
+}
+
+namespace record_members {
+struct Traits {
+public:
+  static constexpr int extent = 4;
+  using value_type = int;
+  template <typename T> using pointer = T*;
+  enum class Kind { first, second, third, fourth, fifth, sixth, seventh, eighth, ninth };
+  struct Node { int hidden; };
+  struct Forward;
+  template <typename T> struct Nested { T hidden; };
+
+private:
+  static int instances;
+  int value = [] { return 42; }();
+  static int create();
+  void reset() {}
+};
+void foo() {
+  $(20_record_members)Traits traits;
+}
+}
+
+namespace record_member_limit {
+struct Values {
+  int v01;
+  int v02;
+  int v03;
+  int v04;
+  int v05;
+  int v06;
+  int v07;
+  int v08;
+  int v09;
+  int v10;
+  int v11;
+  int v12;
+  int v13;
+  int v14;
+  int v15;
+  int v16;
+  int v17;
+  int v18;
+  int v19;
+  int v20;
+  int v21;
+};
+void foo() {
+  $(21_record_member_limit)Values values;
+}
+}
+
+namespace top_level_enum {
+enum Value { v01, v02, v03, v04, v05, v06, v07, v08, v09 };
+void foo() {
+  $(22_top_level_enum)Value value = v01;
+}
+}

--- a/tests/data/hover/tag_decls.cpp
+++ b/tests/data/hover/tag_decls.cpp
@@ -233,3 +233,21 @@ void foo() {
   $(22_top_level_enum)Value value = v01;
 }
 }
+
+#define HOVER_REPEAT_4(x) x, x, x, x
+#define HOVER_REPEAT_256(x) HOVER_REPEAT_4(HOVER_REPEAT_4(HOVER_REPEAT_4(HOVER_REPEAT_4(x))))
+
+namespace large_record_initializer {
+struct Tables {
+  int large_field[256] = { HOVER_REPEAT_256(0) };
+  inline static int large_static[256] = { HOVER_REPEAT_256(0) };
+  int small_field = 1;
+  inline static int small_static = 2;
+};
+void foo() {
+  $(23_large_record_initializer)Tables tables;
+}
+}
+
+#undef HOVER_REPEAT_256
+#undef HOVER_REPEAT_4

--- a/tests/integration/compilation/test_pch.py
+++ b/tests/integration/compilation/test_pch.py
@@ -63,6 +63,23 @@ async def test_hover_on_local_symbol(client, workspace):
 
 
 @pytest.mark.workspace("pch_test")
+async def test_hover_on_preamble_include(client, workspace):
+    """Hover on an include compiled into the PCH should resolve its target."""
+    uri, _ = await client.open_and_wait(workspace / "main.cpp")
+
+    result = await client.text_document_hover_async(
+        HoverParams(text_document=doc(uri), position=Position(line=0, character=12))
+    )
+
+    assert result is not None
+    assert "common.h" in result.contents.value
+    assert result.range is not None
+    assert result.range.start == Position(line=0, character=9)
+    assert result.range.end == Position(line=0, character=19)
+    client.text_document_did_close(DidCloseTextDocumentParams(text_document=doc(uri)))
+
+
+@pytest.mark.workspace("pch_test")
 async def test_completion_with_pch(client, workspace):
     """Completion should see symbols from PCH headers."""
     uri, content = await client.open_and_wait(workspace / "main.cpp")

--- a/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
@@ -481,4 +481,24 @@ input_file: tag_decls.cpp
     }
     ```
 
+23_large_record_initializer:
+  name: "Tables"
+  kind: Struct
+  namespace_scope: "large_record_initializer::"
+  definition: "struct Tables {\n  int large_field[256];\n  static int large_static[256];\n  int small_field = 1;\n  static int small_static = 2;\n}"
+  symbol_range: "[3923, 3929)"
+  markdown: |
+    ### struct `Tables`  
+
+    ---
+    ```cpp
+    // In namespace large_record_initializer
+    struct Tables {
+      int large_field[256];
+      static int large_static[256];
+      int small_field = 1;
+      static int small_static = 2;
+    }
+    ```
+
 

--- a/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
+++ b/tests/snapshots/hover/snapshot/tag_decls.cpp.snap.yml
@@ -37,7 +37,7 @@ input_file: tag_decls.cpp
   name: "MyUnion"
   kind: Union
   namespace_scope: "union_decl::ns1::"
-  definition: "union MyUnion {}"
+  definition: "union MyUnion {\n  int x;\n  int y;\n}"
   symbol_range: "[541, 548)"
   markdown: |
     ### union `MyUnion`  
@@ -45,7 +45,10 @@ input_file: tag_decls.cpp
     ---
     ```cpp
     // In namespace union_decl::ns1
-    union MyUnion {}
+    union MyUnion {
+      int x;
+      int y;
+    }
     ```
 
 04_forward_class:
@@ -72,7 +75,7 @@ input_file: tag_decls.cpp
   kind: Enum
   namespace_scope: "enum_def::"
   documentation: "Enum declaration"
-  definition: "enum Hello {}"
+  definition: "enum Hello {\n  ONE = 0,\n  TWO = 1,\n  THREE = 2,\n}"
   symbol_range: "[747, 752)"
   markdown: |
     ### enum `Hello`  
@@ -83,7 +86,11 @@ input_file: tag_decls.cpp
     ---
     ```cpp
     // In namespace enum_def
-    enum Hello {}
+    enum Hello {
+      ONE = 0,
+      TWO = 1,
+      THREE = 2,
+    }
     ```
 
 06_enumerator:
@@ -333,6 +340,145 @@ input_file: tag_decls.cpp
     // In namespace nested_templates_class
     template <>
     struct cls<nested_templates_class::cls<nested_templates_class::cls<int>>> {}
+    ```
+
+18_inherited_class:
+  name: "Point"
+  kind: Class
+  namespace_scope: "inherited_class::"
+  definition: "class Point : public first, virtual protected second {\n  int value;\n}"
+  symbol_range: "[2452, 2457)"
+  markdown: |
+    ### class `Point`  
+
+    ---
+    ```cpp
+    // In namespace inherited_class
+    class Point : public first, virtual protected second {
+      int value;
+    }
+    ```
+
+19_template_fields:
+  name: "Box<int>"
+  kind: Struct
+  namespace_scope: "template_fields::"
+  definition: "template <> struct Box<int> {\n  using value_type = int;\n  int value;\n}"
+  symbol_range: "[2586, 2589)"
+  markdown: |
+    ### struct `Box<int>`  
+
+    ---
+    ```cpp
+    // In namespace template_fields
+    template <> struct Box<int> {
+      using value_type = int;
+      int value;
+    }
+    ```
+
+20_record_members:
+  name: "Traits"
+  kind: Struct
+  namespace_scope: "record_members::"
+  definition: "struct Traits {\npublic:\n  static constexpr int extent = 4;\n  using value_type = int;\n  template <typename T> using pointer = T *;\n  enum class Kind : int {\n    first = 0,\n    second = 1,\n    third = 2,\n    fourth = 3,\n    fifth = 4,\n    sixth = 5,\n    seventh = 6,\n    eighth = 7,\n    ...\n  };\n  struct Node {\n    ...\n  };\n  struct Forward;\n  template <typename T> struct Nested {\n    ...\n  };\n\nprivate:\n  static int instances;\n  int value = [] {}();\n}"
+  symbol_range: "[3081, 3087)"
+  markdown: |
+    ### struct `Traits`  
+
+    ---
+    ```cpp
+    // In namespace record_members
+    struct Traits {
+    public:
+      static constexpr int extent = 4;
+      using value_type = int;
+      template <typename T> using pointer = T *;
+      enum class Kind : int {
+        first = 0,
+        second = 1,
+        third = 2,
+        fourth = 3,
+        fifth = 4,
+        sixth = 5,
+        seventh = 6,
+        eighth = 7,
+        ...
+      };
+      struct Node {
+        ...
+      };
+      struct Forward;
+      template <typename T> struct Nested {
+        ...
+      };
+
+    private:
+      static int instances;
+      int value = [] {}();
+    }
+    ```
+
+21_record_member_limit:
+  name: "Values"
+  kind: Struct
+  namespace_scope: "record_member_limit::"
+  definition: "struct Values {\n  int v01;\n  int v02;\n  int v03;\n  int v04;\n  int v05;\n  int v06;\n  int v07;\n  int v08;\n  int v09;\n  int v10;\n  int v11;\n  int v12;\n  int v13;\n  int v14;\n  int v15;\n  int v16;\n  int v17;\n  int v18;\n  int v19;\n  int v20;\n  // ...\n}"
+  symbol_range: "[3398, 3404)"
+  markdown: |
+    ### struct `Values`  
+
+    ---
+    ```cpp
+    // In namespace record_member_limit
+    struct Values {
+      int v01;
+      int v02;
+      int v03;
+      int v04;
+      int v05;
+      int v06;
+      int v07;
+      int v08;
+      int v09;
+      int v10;
+      int v11;
+      int v12;
+      int v13;
+      int v14;
+      int v15;
+      int v16;
+      int v17;
+      int v18;
+      int v19;
+      int v20;
+      // ...
+    }
+    ```
+
+22_top_level_enum:
+  name: "Value"
+  kind: Enum
+  namespace_scope: "top_level_enum::"
+  definition: "enum Value {\n  v01 = 0,\n  v02 = 1,\n  v03 = 2,\n  v04 = 3,\n  v05 = 4,\n  v06 = 5,\n  v07 = 6,\n  v08 = 7,\n  v09 = 8,\n}"
+  symbol_range: "[3520, 3525)"
+  markdown: |
+    ### enum `Value`  
+
+    ---
+    ```cpp
+    // In namespace top_level_enum
+    enum Value {
+      v01 = 0,
+      v02 = 1,
+      v03 = 2,
+      v04 = 3,
+      v05 = 4,
+      v06 = 5,
+      v07 = 6,
+      v08 = 7,
+      v09 = 8,
+    }
     ```
 
 

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -49,8 +49,7 @@ void EXPECT_HAS_INL(u32 index, llvm::StringRef position, llvm::StringRef path) {
     ASSERT_EQ(offset, point(position));
 
     /// FIXME:
-    llvm::SmallString<64> target =
-        has_include.fid.isValid() ? unit->file_path(has_include.fid) : "";
+    llvm::SmallString<64> target(has_include.target.begin(), has_include.target.end());
     path::remove_dots(target);
 
     ASSERT_EQ(target, path);

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -48,8 +48,10 @@ void EXPECT_HAS_INL(u32 index, llvm::StringRef position, llvm::StringRef path) {
     auto [_, offset] = unit->decompose_location(has_include.location);
     ASSERT_EQ(offset, point(position));
 
-    /// FIXME:
-    llvm::SmallString<64> target(has_include.target.begin(), has_include.target.end());
+    llvm::SmallString<64> target;
+    if(has_include.file) {
+        target = unit->file_path(*has_include.file);
+    }
     path::remove_dots(target);
 
     ASSERT_EQ(target, path);

--- a/tests/unit/feature/document_link_tests.cpp
+++ b/tests/unit/feature/document_link_tests.cpp
@@ -147,6 +147,17 @@ int x = 0;
     EXPECT_TRUE(feature::include_definition(*unit, point("inside")).empty());
 }
 
+TEST_CASE(MissingIncludeDefinition) {
+    add_main("main.cpp", R"(
+/* error-ok */
+#include @arg["missing.h"]
+)");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    EXPECT_TRUE(feature::include_definition(*unit, arg.begin + 1).empty());
+}
+
 };  // TEST_SUITE(document_link)
 
 }  // namespace

--- a/tests/unit/feature/hover_tests.cpp
+++ b/tests/unit/feature/hover_tests.cpp
@@ -8,6 +8,7 @@
 #include "test/test.h"
 #include "test/tester.h"
 #include "feature/feature.h"
+#include "support/filesystem.h"
 
 #include "kota/meta/enum.h"
 
@@ -1009,6 +1010,43 @@ int $foo = 1;
     ASSERT_EQ(result->range->start.character, 4U);
     ASSERT_EQ(result->range->end.line, 1U);
     ASSERT_EQ(result->range->end.character, 7U);
+}
+
+TEST_CASE(include_header) {
+    add_file("test.h", "#pragma once\n");
+    add_main("main.cpp", R"cpp(
+#include @arg["test.h"]
+$(outside)
+int x = 0;
+)cpp");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    info = feature::hover_info(*unit, arg.begin + 1);
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->kind, SymbolKind::Header);
+    EXPECT_EQ(info->name, "test.h");
+
+    llvm::SmallString<128> path(info->definition);
+    path::remove_dots(path);
+    EXPECT_EQ(path, TestVFS::path("test.h"));
+    ASSERT_TRUE(info->symbol_range.has_value());
+    EXPECT_EQ(info->symbol_range->begin, arg.begin);
+    EXPECT_EQ(info->symbol_range->end, arg.end);
+
+    result = feature::hover(*unit, arg.begin + 1, {}, feature::PositionEncoding::UTF8);
+    ASSERT_TRUE(result.has_value());
+    auto* content = std::get_if<protocol::MarkupContent>(&result->contents);
+    ASSERT_TRUE(content != nullptr);
+    EXPECT_TRUE(content->value.contains("test.h"));
+    EXPECT_TRUE(content->value.contains(TestVFS::path("test.h")));
+    ASSERT_TRUE(result->range.has_value());
+    EXPECT_EQ(result->range->start.line, 1U);
+    EXPECT_EQ(result->range->start.character, 9U);
+    EXPECT_EQ(result->range->end.line, 1U);
+    EXPECT_EQ(result->range->end.character, 17U);
+
+    EXPECT_FALSE(feature::hover_info(*unit, point("outside")).has_value());
 }
 
 TEST_CASE(scoped_attribute) {

--- a/tests/unit/feature/hover_tests.cpp
+++ b/tests/unit/feature/hover_tests.cpp
@@ -1049,6 +1049,57 @@ int x = 0;
     EXPECT_FALSE(feature::hover_info(*unit, point("outside")).has_value());
 }
 
+TEST_CASE(has_include_header) {
+    add_file("test.h", "#pragma once\n");
+    add_main("main.cpp", R"cpp(
+#if __has_include(@arg["test.h"])
+#endif
+)cpp");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    auto hover = feature::hover_info(*unit, arg.begin + 1);
+    ASSERT_TRUE(hover.has_value());
+    EXPECT_EQ(hover->kind, SymbolKind::Header);
+    EXPECT_EQ(hover->name, "test.h");
+
+    llvm::SmallString<128> path(hover->definition);
+    path::remove_dots(path);
+    EXPECT_EQ(path, TestVFS::path("test.h"));
+    EXPECT_EQ(hover->symbol_range, arg);
+}
+
+TEST_CASE(macro_include_header) {
+    add_file("test.h", "#pragma once\n");
+    add_main("main.cpp", R"cpp(
+#define HEADER "test.h"
+#include @arg[HEADER]
+)cpp");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    auto hover = feature::hover_info(*unit, arg.begin + 1);
+    ASSERT_TRUE(hover.has_value());
+    EXPECT_EQ(hover->kind, SymbolKind::Header);
+    EXPECT_EQ(hover->name, "HEADER");
+
+    llvm::SmallString<128> path(hover->definition);
+    path::remove_dots(path);
+    EXPECT_EQ(path, TestVFS::path("test.h"));
+    EXPECT_EQ(hover->symbol_range, arg);
+}
+
+TEST_CASE(missing_include_header) {
+    add_main("main.cpp", R"cpp(
+/* error-ok */
+#include @arg["missing.h"]
+)cpp");
+    ASSERT_TRUE(compile());
+
+    auto arg = range("arg", "main.cpp");
+    EXPECT_FALSE(feature::hover_info(*unit, arg.begin + 1).has_value());
+}
+
 TEST_CASE(scoped_attribute) {
     run_info(R"cpp(
 [[gnu::no$inline]] void foo();

--- a/tests/unit/syntax/lexer_tests.cpp
+++ b/tests/unit/syntax/lexer_tests.cpp
@@ -153,6 +153,11 @@ TEST_CASE(HasIncludeFromLineStart) {
     EXPECT_RANGE(src, 0, "<vector>");
 }
 
+TEST_CASE(HasIncludeFromFilename) {
+    llvm::StringRef src = "#if __has_include(\"test.h\")";
+    EXPECT_RANGE(src, src.find("test.h"), "\"test.h\"");
+}
+
 TEST_CASE(HasEmbedFromLineStart) {
     llvm::StringRef src = R"(#if __has_embed("data.bin"))";
     EXPECT_RANGE(src, 0, R"("data.bin")");


### PR DESCRIPTION
## Summary

This PR improves hover information for two common C/C++ navigation targets:

- Header names in `#include` and `__has_include` expressions now show the resolved file path.
- Type-level hovers for records and enums now include a compact declaration summary with useful members.

The output is intentionally bounded so generated declarations and large initializers do not produce oversized or expensive hover cards.

## Changes

### Include hover

- Resolve the directive under the cursor through the compilation unit's recorded include data.
- Support both regular include directives and successful `__has_include` checks.
- Return a `Header` hover containing the written header name, resolved path, and exact header-name range.
- Run include detection before AST-based hover resolution, since preprocessor directives are not represented by normal declaration or expression nodes.
- Leave unresolved headers and cursor positions outside the header argument without a hover result.

### Tag declaration summaries

- Show enum constants on enum type hovers, including computed values when no initializer was written.
- Show record fields, static data members, type aliases, alias templates, nested tags, and nested class templates in source order.
- Preserve the declaration header emitted by Clang, including template specializations, attributes, and base clauses.
- Preserve explicit access sections while avoiding empty sections that contain only omitted methods.
- Omit methods to keep the hover focused on data and type structure.
- Collapse nested record definitions and preserve nested forward declarations.
- Limit record summaries to 20 members and nested enums to 8 enumerators, adding an ellipsis when truncated.

### Large initializer handling

- Reuse the existing 200 expanded-token threshold for both standalone variables and record members.
- Suppress oversized in-class initializers independently for each field or static data member.
- Keep small initializers visible even when another member in the same record exceeds the limit.
- Avoid sending large generated initializer lists through declaration printing and `clang-format` on every type hover.

### Documentation and tests

- Mark include hover and type-level struct/enum member hover as implemented in the English and Chinese feature documentation.
- Add direct unit coverage for include hover contents, resolved paths, symbol ranges, protocol ranges, and non-header cursor positions.
- Expand tag-declaration snapshots to cover inheritance, template instantiation, access sections, aliases, static data, nested and forward-declared types, member limits, enum limits, and large initializers.

## Testing

```bash
./build/RelWithDebInfo/bin/unit_tests \
  --test-dir=./tests/data \
  --snapshot-dir=./tests/snapshots \
  --corpus-dir=./tests/corpus \
  --test-filter=hover.* \
  --verbose

./build/RelWithDebInfo/bin/unit_tests \
  --test-dir=./tests/data \
  --snapshot-dir=./tests/snapshots \
  --corpus-dir=./tests/corpus \
  --test-filter=document_link.* \
  --verbose
```

Results:

- 26 hover tests passed.
- 6 document-link tests passed.

## Commit breakdown

- `6870597 feat(server): hover on includes`
- `9efe305 feat(hover): show all members of tag decls, except for methods`
- `3477bc4 fix(hover): suppress printing large initializer in records`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hovering over structs and enums now displays their members, with concise output for large declarations.
  * Hovering over `#include` and `__has_include` directives shows the resolved header path.
  * Preamble include directives now support hover information.
* **Bug Fixes**
  * Improved header path resolution and document links for include directives.
  * Added safeguards to prevent overly large hover results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->