### PR TITLE
refactor(server): overhaul worker pool scheduling and lifecycle

### DIFF
--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -25,6 +25,7 @@
 #include "kota/ipc/lsp/uri.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/xxhash.h"
 #include "clang/Basic/Version.h"
@@ -289,14 +290,18 @@ void Compiler::init_compile_graph() {
                  pcm_key,
                  module_name);
 
-        // Same shared-artifact budget as the PCH: a module interface whose
-        // PCM build keeps killing workers is refused instead of killing two
-        // more per dependent compile. Editing the module starts a fresh
-        // key with a fresh budget.
-        if(workspace.build_crashes.blocked(pcm_key)) {
+        // Same shared-artifact budget as the PCH, but keyed with the
+        // module's current content: unlike pch_key (which embeds the
+        // preamble text), pcm_key is content-free, and a blocked budget
+        // must unlock the moment the poison is edited.
+        auto content = llvm::MemoryBuffer::getFile(file_path);
+        auto budget_key = std::format("{}-{:016x}",
+                                      pcm_key,
+                                      content ? llvm::xxh3_64bits((*content)->getBuffer()) : 0);
+        if(workspace.build_crashes.blocked(budget_key)) {
             LOG_WARN("PCM build for module {} refused: key {} keeps crashing workers",
                      module_name,
-                     pcm_key);
+                     budget_key);
             co_return false;
         }
 
@@ -314,7 +319,7 @@ void Compiler::init_compile_graph() {
             workspace.store->abort(pending);
             if(!result.has_value() &&
                result.error().code == worker::dispatch_errc::worker_crashed) {
-                workspace.build_crashes.on_crash(pcm_key);
+                workspace.build_crashes.on_crash(budget_key);
             }
             if(expected_build_failure(result)) {
                 LOG_WARN("BuildPCM failed for module {}: {}",
@@ -898,7 +903,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 
         // A quarantined document's probe is a known risk: tell the pool so
         // the crash, if it comes, does not spend the slot's budget.
-        bool suspect = session->quarantine.active();
+        auto suspect = session->quarantine.active() ? Suspect::Isolated : Suspect::No;
         session->quarantine.spend_probe();
         auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
@@ -910,7 +915,8 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         if(!result.has_value()) {
             if(result.error().code == worker::dispatch_errc::worker_crashed) {
                 session->quarantine.on_crash(worker::death_of(result.error()));
-            } else if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
+            } else if(suspect == Suspect::Isolated &&
+                      result.error().code == worker::dispatch_errc::worker_unavailable) {
                 // The probe never ran: keep it armed so a later request
                 // retries once an expendable worker frees up.
                 session->quarantine.re_arm_probe();
@@ -1193,7 +1199,11 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
     }
 
-    auto result = co_await pool.send_stateful(path_id, wp);
+    // A recovery query after a query-crash quarantine is still distrusted:
+    // it needs the owner (the AST lives there), but its crash spends no
+    // slot budget and new documents avoid the worker while it flies.
+    auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
+    auto result = co_await pool.send_stateful(path_id, wp, {}, suspect);
     if(!result.has_value()) {
         // A query that kills the worker is this document's doing even
         // though its compile landed: separate ledger, since only a query
@@ -1210,7 +1220,12 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
-    session->quarantine.on_query_land();
+    // The reply proves queries on the DISPATCHED content answer; an edit
+    // that landed mid-flight must not launder the new content's ledger —
+    // crashes count regardless of staleness, successes only when fresh.
+    if(session->generation == gen) {
+        session->quarantine.on_query_land();
+    }
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value());
 }
@@ -1230,7 +1245,9 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     }
     auto wait_ms = timer.ms();
 
-    auto result = co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path});
+    auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
+    auto result =
+        co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path}, {}, suspect);
     if(!result.has_value()) {
         if(result.error().code == worker::dispatch_errc::worker_crashed) {
             session->quarantine.on_query_crash(worker::death_of(result.error()));
@@ -1243,14 +1260,15 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
-    session->quarantine.on_query_land();
     // The result carries byte offsets against the compiled buffer; a
     // didChange that landed during the await makes them describe text the
     // session no longer holds — the reply edge would map them onto the
-    // edited buffer at wrong positions.
+    // edited buffer at wrong positions. The same staleness gates the query
+    // ledger: a stale success must not launder the new content's evidence.
     if(session->generation != gen) {
         co_return std::vector<feature::DocumentLink>{};
     }
+    session->quarantine.on_query_land();
     LOG_PERF("request",
              "kind=DocumentLink file={} wait_ms={} total_ms={}",
              path,

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -114,7 +114,14 @@ template <typename Params>
 static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool, Params params) {
     auto result = co_await pool.send_stateless(params);
     if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-        result = co_await pool.send_stateless(params);
+        auto retry = co_await pool.send_stateless(params);
+        // A failed retry must not launder the crash: the first attempt
+        // killed a worker, and callers count that evidence toward the
+        // document's quarantine no matter how the retry failed.
+        if(retry.has_value()) {
+            co_return std::move(retry);
+        }
+        co_return std::move(result);
     }
     co_return std::move(result);
 }
@@ -740,6 +747,14 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     auto uri = lsp::URI::from_file_path(file_path);
     std::string uri_str = uri.has_value() ? uri->str() : file_path;
 
+    // The streak this request inherited. Crashes recorded past this point
+    // (a PCH build inside ensure_deps, a concurrent completion build) are
+    // fresh evidence about the current content: a successful landing clears
+    // only the inherited history, never them — or a preamble that reliably
+    // kills the PCH builder while the no-PCH fallback compile succeeds
+    // would burn one stateless worker per edit without ever quarantining.
+    auto entry_streak = session->compile_crash_streak;
+
     // At most two rounds: a header with unknown self-containment compiles
     // without a prefix first; if the diagnostics indicate missing includer
     // context, the second round re-compiles with a synthesized prefix.
@@ -771,7 +786,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                            header_context->preamble_path.empty() &&
                            contexts.header_mode(file_path, pid) == HeaderMode::Unknown;
 
-        auto entry_streak = session->compile_crash_streak;
         bool deps_ok = co_await ensure_deps(*session,
                                             gen,
                                             epoch,
@@ -806,6 +820,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
            session->compile_crash_streak >= Session::quarantine_threshold) {
             LOG_WARN("ensure_compiled: {} quarantined during dependency prep", uri_str);
             session->quarantine_probe = false;
+            session->quarantine_announced = true;
             session->output = CompileOutput{
                 .version = std::nullopt,
                 .source = source,
@@ -878,6 +893,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                             result.error().message);
             }
             bool quarantined = session->compile_crash_streak >= Session::quarantine_threshold;
+            session->quarantine_announced = quarantined;
             // Clear path: empty diagnostics without a version, and no
             // inactive-regions update. A quarantined document announces
             // itself instead of hiding behind the empty list.
@@ -937,7 +953,10 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // a stale world — record it, publish it (bounded staleness), but do
         // not declare it fresh; the next request recompiles.
         session->settle_compile(epoch);
-        session->compile_crash_streak = 0;
+        // Success clears the inherited streak but keeps crashes recorded
+        // during this request (see entry_streak above): they will recur on
+        // the next request and must keep accumulating toward quarantine.
+        session->compile_crash_streak -= std::min(entry_streak, session->compile_crash_streak);
         pc->succeeded = true;
         record_deps(*session, result.value().deps, result.value().build_at);
 
@@ -965,6 +984,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         inactive.insert(inactive.end(),
                         result.value().inactive_regions.begin(),
                         result.value().inactive_regions.end());
+        session->quarantine_announced = false;
         session->output = CompileOutput{
             .version = version,
             .source = source,
@@ -1022,6 +1042,22 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
         LOG_WARN("ensure_compiled: {} quarantined after {} worker crashes",
                  workspace.path_pool.resolve(path_id),
                  session->compile_crash_streak);
+        // A quarantine reached outside the compile-failure landing (a
+        // completion or PCH build tipped the streak, or the crash landed on
+        // a superseded generation) never materialized its diagnostic;
+        // announce it once here instead of leaving the file silently dead.
+        if(!session->quarantine_announced) {
+            session->quarantine_announced = true;
+            session->output = CompileOutput{
+                .version = std::nullopt,
+                .source =
+                    session->output.has_value() ? session->output->source : CommandSource::CDBExact,
+                .diagnostics = quarantine_diagnostics(session->compile_crash_streak),
+                .line_limit = std::nullopt,
+                .inactive_regions = std::nullopt,
+            };
+            on_output.emit(session);
+        }
         co_return false;
     }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -105,6 +105,24 @@ static kota::codec::RawValue quarantine_diagnostics(unsigned crashes) {
     return kota::codec::RawValue{json ? std::move(*json) : "[]"};
 }
 
+/// Publish the quarantine diagnostic as the session's current output. The
+/// single materialization point for quarantine visibility: a quarantined
+/// document must never sit behind stale or missing diagnostics.
+void Compiler::publish_quarantined(const std::shared_ptr<Session>& session,
+                                   std::optional<CommandSource> source,
+                                   std::optional<std::uint32_t> line_limit) {
+    session->quarantine.mark_announced();
+    session->output = CompileOutput{
+        .version = std::nullopt,
+        .source = source.value_or(session->output.has_value() ? session->output->source
+                                                              : CommandSource::CDBExact),
+        .diagnostics = quarantine_diagnostics(session->quarantine.crashes()),
+        .line_limit = line_limit,
+        .inactive_regions = std::nullopt,
+    };
+    on_output.emit(session);
+}
+
 /// Send a stateless request, resending once if the worker died mid-request.
 /// The pool does not retry on its own — it marks the dead slot and surfaces
 /// worker_crashed, so the resend lands on a healthy worker. Build tasks are
@@ -122,6 +140,21 @@ static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool
             co_return std::move(retry);
         }
         co_return std::move(result);
+    }
+    co_return std::move(result);
+}
+
+/// Every stateless build carrying an open document's content goes through
+/// here: a dispatch that killed a worker is blamed on the session before
+/// the caller sees the result, so no site can forget the accounting.
+/// Grep for build_for to enumerate every such site.
+template <typename Params>
+static kota::ipc::RequestResult<Params> build_for(WorkerPool& pool,
+                                                  Session& session,
+                                                  Params params) {
+    auto result = co_await send_stateless_retrying(pool, std::move(params));
+    if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
+        session.quarantine.on_crash();
     }
     co_return std::move(result);
 }
@@ -256,6 +289,17 @@ void Compiler::init_compile_graph() {
                  pcm_key,
                  module_name);
 
+        // Same shared-artifact budget as the PCH: a module interface whose
+        // PCM build keeps killing workers is refused instead of killing two
+        // more per dependent compile. Editing the module starts a fresh
+        // key with a fresh budget.
+        if(workspace.build_crashes.blocked(pcm_key)) {
+            LOG_WARN("PCM build for module {} refused: key {} keeps crashing workers",
+                     module_name,
+                     pcm_key);
+            co_return false;
+        }
+
         bp.module_name = module_name;
         auto pending = workspace.store->begin_store("pcm", pcm_key);
         bp.output_path = pending.tmp_path;
@@ -268,6 +312,10 @@ void Compiler::init_compile_graph() {
         auto result = co_await send_stateless_retrying(pool, bp);
         if(!result.has_value() || !result.value().success) {
             workspace.store->abort(pending);
+            if(!result.has_value() &&
+               result.error().code == worker::dispatch_errc::worker_crashed) {
+                workspace.build_crashes.on_crash(pcm_key);
+            }
             if(expected_build_failure(result)) {
                 LOG_WARN("BuildPCM failed for module {}: {}",
                          module_name,
@@ -449,6 +497,16 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         co_return false;
     }
 
+    // A preamble whose PCH build keeps killing workers is refused before
+    // the dispatch: the artifact is shared, so one document's quarantine
+    // cannot contain it — every session with this preamble would burn
+    // workers of its own. The key is content-derived: editing the poison
+    // starts a fresh key with a fresh budget.
+    if(workspace.build_crashes.blocked(pch_key)) {
+        LOG_WARN("PCH build for {} refused: key {} keeps crashing workers", path, pch_key);
+        co_return false;
+    }
+
     // Register in-flight build so concurrent requests wait on us.  The
     // guard wakes them on every exit, including cancellation mid-await.
     auto completion = std::make_shared<kota::event>();
@@ -479,17 +537,16 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     LOG_DEBUG("Building PCH for {}, bound={}, key={}", path, bound, pch_key);
 
-    auto result = co_await send_stateless_retrying(pool, bp);
+    auto result = co_await build_for(pool, session, bp);
 
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
         workspace.store->abort(pending_idx);
-        // The preamble is this document's content too: a PCH build that
-        // crashes workers counts toward the same quarantine streak as the
-        // stateful compile, or a poison preamble would keep killing two
-        // stateless slots per feature request without ever quarantining.
+        // The preamble is this document's content too — build_for blamed
+        // the session. The shared-key budget additionally stops other
+        // sessions with the same preamble from re-triggering the build.
         if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-            session.compile_crash_streak += 1;
+            workspace.build_crashes.on_crash(pch_key);
         }
         if(expected_build_failure(result)) {
             LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
@@ -747,13 +804,11 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     auto uri = lsp::URI::from_file_path(file_path);
     std::string uri_str = uri.has_value() ? uri->str() : file_path;
 
-    // The streak this request inherited. Crashes recorded past this point
-    // (a PCH build inside ensure_deps, a concurrent completion build) are
-    // fresh evidence about the current content: a successful landing clears
-    // only the inherited history, never them — or a preamble that reliably
-    // kills the PCH builder while the no-PCH fallback compile succeeds
-    // would burn one stateless worker per edit without ever quarantining.
-    auto entry_streak = session->compile_crash_streak;
+    // The evidence this request inherited: a successful landing clears no
+    // more (see Quarantine::land), so crashes recorded past this point — a
+    // PCH build inside ensure_deps, a concurrent completion build — keep
+    // accumulating toward quarantine even when the compile itself lands.
+    auto flight = session->quarantine.begin_flight();
 
     // At most two rounds: a header with unknown self-containment compiles
     // without a prefix first; if the diagnostics indicate missing includer
@@ -816,19 +871,10 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // to one more worker; the crash also spends any armed probe, since
         // this WAS the probe's attempt. A probe whose PCH build survived
         // (streak unchanged) continues to the compile.
-        if(session->compile_crash_streak > entry_streak &&
-           session->compile_crash_streak >= Session::quarantine_threshold) {
+        if(session->quarantine.active() && session->quarantine.grew(flight)) {
             LOG_WARN("ensure_compiled: {} quarantined during dependency prep", uri_str);
-            session->quarantine_probe = false;
-            session->quarantine_announced = true;
-            session->output = CompileOutput{
-                .version = std::nullopt,
-                .source = source,
-                .diagnostics = quarantine_diagnostics(session->compile_crash_streak),
-                .line_limit = suffix_line_limit,
-                .inactive_regions = std::nullopt,
-            };
-            on_output.emit(session);
+            session->quarantine.spend_probe();
+            publish_quarantined(session, source, suffix_line_limit);
             finish_compile();
             co_return;
         }
@@ -852,8 +898,8 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
 
         // A quarantined document's probe is a known risk: tell the pool so
         // the crash, if it comes, does not spend the slot's budget.
-        bool suspect = session->compile_crash_streak >= Session::quarantine_threshold;
-        session->quarantine_probe = false;
+        bool suspect = session->quarantine.active();
+        session->quarantine.spend_probe();
         auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
         // Crash accounting runs even for superseded compiles: the crash came
@@ -863,11 +909,11 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // restarting-window fast-fail never reached a worker.
         if(!result.has_value()) {
             if(result.error().code == worker::dispatch_errc::worker_crashed) {
-                session->compile_crash_streak += 1;
+                session->quarantine.on_crash();
             } else if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
                 // The probe never ran: keep it armed so a later request
                 // retries once an expendable worker frees up.
-                session->quarantine_probe = true;
+                session->quarantine.re_arm_probe();
             }
         }
 
@@ -892,20 +938,21 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                             uri_str,
                             result.error().message);
             }
-            bool quarantined = session->compile_crash_streak >= Session::quarantine_threshold;
-            session->quarantine_announced = quarantined;
-            // Clear path: empty diagnostics without a version, and no
-            // inactive-regions update. A quarantined document announces
-            // itself instead of hiding behind the empty list.
-            session->output = CompileOutput{
-                .version = std::nullopt,
-                .source = source,
-                .diagnostics = quarantined ? quarantine_diagnostics(session->compile_crash_streak)
-                                           : kota::codec::RawValue{},
-                .line_limit = suffix_line_limit,
-                .inactive_regions = std::nullopt,
-            };
-            on_output.emit(session);
+            // A quarantined document announces itself instead of hiding
+            // behind the empty list; the clear path publishes empty
+            // diagnostics without a version and no inactive regions.
+            if(session->quarantine.active()) {
+                publish_quarantined(session, source, suffix_line_limit);
+            } else {
+                session->output = CompileOutput{
+                    .version = std::nullopt,
+                    .source = source,
+                    .diagnostics = kota::codec::RawValue{},
+                    .line_limit = suffix_line_limit,
+                    .inactive_regions = std::nullopt,
+                };
+                on_output.emit(session);
+            }
             finish_compile();
             co_return;
         }
@@ -953,10 +1000,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // a stale world — record it, publish it (bounded staleness), but do
         // not declare it fresh; the next request recompiles.
         session->settle_compile(epoch);
-        // Success clears the inherited streak but keeps crashes recorded
-        // during this request (see entry_streak above): they will recur on
-        // the next request and must keep accumulating toward quarantine.
-        session->compile_crash_streak -= std::min(entry_streak, session->compile_crash_streak);
+        session->quarantine.land(flight);
         pc->succeeded = true;
         record_deps(*session, result.value().deps, result.value().build_at);
 
@@ -984,7 +1028,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         inactive.insert(inactive.end(),
                         result.value().inactive_regions.begin(),
                         result.value().inactive_regions.end());
-        session->quarantine_announced = false;
         session->output = CompileOutput{
             .version = version,
             .source = source,
@@ -1037,26 +1080,16 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
     // The crash budget lives on pool slots, the poison lives in documents:
     // a document that keeps killing workers is quarantined instead of
     // burning slot after slot. A content change grants one probe attempt.
-    if(session->compile_crash_streak >= Session::quarantine_threshold &&
-       !session->quarantine_probe) {
+    if(session->quarantine.blocked()) {
         LOG_WARN("ensure_compiled: {} quarantined after {} worker crashes",
                  workspace.path_pool.resolve(path_id),
-                 session->compile_crash_streak);
+                 session->quarantine.crashes());
         // A quarantine reached outside the compile-failure landing (a
         // completion or PCH build tipped the streak, or the crash landed on
         // a superseded generation) never materialized its diagnostic;
         // announce it once here instead of leaving the file silently dead.
-        if(!session->quarantine_announced) {
-            session->quarantine_announced = true;
-            session->output = CompileOutput{
-                .version = std::nullopt,
-                .source =
-                    session->output.has_value() ? session->output->source : CommandSource::CDBExact,
-                .diagnostics = quarantine_diagnostics(session->compile_crash_streak),
-                .line_limit = std::nullopt,
-                .inactive_regions = std::nullopt,
-            };
-            on_output.emit(session);
+        if(session->quarantine.needs_announcement()) {
+            publish_quarantined(session, std::nullopt, std::nullopt);
         }
         co_return false;
     }
@@ -1226,7 +1259,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     // quarantined document gets no stateless builds either, or completion
     // requests would keep killing workers the compile path is protecting.
     // Recovery stays with the compile path's probe.
-    if(session->compile_crash_streak >= Session::quarantine_threshold) {
+    if(session->quarantine.active()) {
         LOG_WARN("forward_build: {} is quarantined, refusing build", path);
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
@@ -1255,7 +1288,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     // A PCH crash inside ensure_deps may have tipped the document into
     // quarantine after the entry gate: stop before dispatching the same
     // content again.
-    if(session->compile_crash_streak >= Session::quarantine_threshold) {
+    if(session->quarantine.active()) {
         LOG_WARN("forward_build: {} quarantined during dependency prep", path);
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
@@ -1269,13 +1302,8 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     lsp::LineMap map(wp.text);
     wp.offset = clamped_offset(map, position);
 
-    auto result = co_await send_stateless_retrying(pool, wp);
+    auto result = co_await build_for(pool, *session, wp);
     if(!result.has_value()) {
-        // Same content, same quarantine: a completion build that kills its
-        // worker counts like a compile crash.
-        if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->compile_crash_streak += 1;
-        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "build (kind={}) failed for {}: {}",
@@ -1294,6 +1322,15 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
 
+    // Formatting runs no sema, but it is still this document's content on
+    // a worker: a quarantined document waits for its probe to land instead
+    // of keeping a side channel that can kill workers.
+    if(session->quarantine.active()) {
+        LOG_WARN("forward_format: {} is quarantined, refusing format", path);
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
+    }
+
     worker::BuildParams wp;
     wp.priority = worker::Priority::High;
     wp.kind = worker::BuildKind::Format;
@@ -1311,7 +1348,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
-    auto result = co_await send_stateless_retrying(pool, wp);
+    auto result = co_await build_for(pool, *session, wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -818,21 +818,17 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         session->quarantine_probe = false;
         auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
-        // Crash accounting runs even for superseded compiles: the crash was
-        // caused by content this document dispatched, and skipping it would
-        // let a poison file dodge quarantine by being edited between the
-        // dispatch and the crash response. The budget the pool keeps is per
-        // slot; the poison is in the document — a document that keeps
-        // killing workers is quarantined instead of burning slots. Only a
-        // real mid-request death counts: a restarting-window fast-fail
-        // (worker_restarting) never reached a worker.
+        // Crash accounting runs even for superseded compiles: the crash came
+        // from content this document dispatched, and skipping it would let a
+        // poison file dodge quarantine by being edited between dispatch and
+        // the crash response. Only a real mid-request death counts — a
+        // restarting-window fast-fail never reached a worker.
         if(!result.has_value()) {
             if(result.error().code == worker::dispatch_errc::worker_crashed) {
                 session->compile_crash_streak += 1;
-            }
-            // No expendable worker right now: the probe never ran — keep
-            // it armed so a later request retries once one frees up.
-            if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
+            } else if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
+                // The probe never ran: keep it armed so a later request
+                // retries once an expendable worker frees up.
                 session->quarantine_probe = true;
             }
         }
@@ -1166,6 +1162,17 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
     auto gen = session->generation;
+
+    // This build compiles the same content the quarantine watches; a
+    // quarantined document gets no stateless builds either, or completion
+    // requests would keep killing workers the compile path is protecting.
+    // Recovery stays with the compile path's probe.
+    if(session->compile_crash_streak >= Session::quarantine_threshold) {
+        LOG_WARN("forward_build: {} is quarantined, refusing build", path);
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
+    }
+
     // Takeoff snapshot for the pch_key write license (see
     // may_write_pch_key): this request runs concurrently with compiles and
     // holds no compiling token, so it is the easiest continuation to come
@@ -1197,6 +1204,11 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
 
     auto result = co_await send_stateless_retrying(pool, wp);
     if(!result.has_value()) {
+        // Same content, same quarantine: a completion build that kills its
+        // worker counts like a compile crash.
+        if(result.error().code == worker::dispatch_errc::worker_crashed) {
+            session->compile_crash_streak += 1;
+        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "build (kind={}) failed for {}: {}",

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1361,13 +1361,17 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     auto path = std::string(workspace.path_pool.resolve(path_id));
     auto gen = session->generation;
 
-    // This build compiles the same content the quarantine watches; a
-    // blocked document gets no stateless builds either, or completion
-    // requests would keep killing workers the compile path is protecting.
-    // A probe-armed document passes: when this kind holds the strikes,
-    // this dispatch IS the recovery attempt.
-    if(session->quarantine.blocked()) {
+    // This build compiles the same content the quarantine watches: while
+    // the document is quarantined, only the recovery dispatch — the kind
+    // holding the strikes, with the probe armed — may run. Anything else
+    // is arbitrary work on proven-poisonous content. A refusal announces
+    // the quarantine, or a completion-only client would never see it.
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
+    if(session->quarantine.active() && (session->quarantine.blocked() || !recovery)) {
         LOG_WARN("forward_build: {} is quarantined, refusing build", path);
+        if(session->quarantine.needs_announcement()) {
+            publish_quarantined(session, std::nullopt, std::nullopt);
+        }
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
@@ -1401,6 +1405,9 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     if(session->quarantine.active() && session->quarantine.grew(flight)) {
         session->quarantine.spend_probe();
         LOG_WARN("forward_build: {} quarantined during dependency prep", path);
+        if(session->quarantine.needs_announcement()) {
+            publish_quarantined(session, std::nullopt, std::nullopt);
+        }
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
@@ -1414,15 +1421,17 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     wp.offset = clamped_offset(map, position);
 
     // When this kind holds the strikes, this dispatch is the recovery
-    // attempt the edit licensed: spend the probe, hand it back only if the
-    // build provably never dispatched.
-    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
+    // attempt the edit licensed: spend the probe, hand it back only if no
+    // attempt dispatched at all — an unavailable retry after a crashed
+    // first attempt already spent the license on that crash.
     if(recovery) {
         session->quarantine.spend_probe();
     }
+    auto strikes_before = session->quarantine.crashes();
     auto result = co_await build_for(pool, *session, evidence_kind(kind), wp);
     if(!result.has_value()) {
-        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable) {
+        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable &&
+           session->quarantine.crashes() == strikes_before) {
             session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
@@ -1450,10 +1459,14 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     auto gen = session->generation;
 
     // Formatting runs no sema, but it is still this document's content on
-    // a worker: a blocked document is refused. A probe-armed one passes —
-    // when format holds the strikes, this dispatch is the recovery.
-    if(session->quarantine.blocked()) {
+    // a worker: while quarantined, only format-as-recovery may run, and a
+    // refusal announces the quarantine.
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(worker::BuildKind::Format));
+    if(session->quarantine.active() && (session->quarantine.blocked() || !recovery)) {
         LOG_WARN("forward_format: {} is quarantined, refusing format", path);
+        if(session->quarantine.needs_announcement()) {
+            publish_quarantined(session, std::nullopt, std::nullopt);
+        }
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
@@ -1475,13 +1488,14 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
-    bool recovery = session->quarantine.recovery_kind(evidence_kind(worker::BuildKind::Format));
     if(recovery) {
         session->quarantine.spend_probe();
     }
+    auto strikes_before = session->quarantine.crashes();
     auto result = co_await build_for(pool, *session, evidence_kind(worker::BuildKind::Format), wp);
     if(!result.has_value()) {
-        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable) {
+        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable &&
+           session->quarantine.crashes() == strikes_before) {
             session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -771,6 +771,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                            header_context->preamble_path.empty() &&
                            contexts.header_mode(file_path, pid) == HeaderMode::Unknown;
 
+        auto entry_streak = session->compile_crash_streak;
         bool deps_ok = co_await ensure_deps(*session,
                                             gen,
                                             epoch,
@@ -791,6 +792,28 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                      session->generation,
                      gen,
                      uri_str);
+            finish_compile();
+            co_return;
+        }
+
+        // A PCH crash inside ensure_deps may have tipped the document into
+        // quarantine — the entry gate ran before the streak grew. Stop
+        // before the stateful dispatch instead of feeding the same content
+        // to one more worker; the crash also spends any armed probe, since
+        // this WAS the probe's attempt. A probe whose PCH build survived
+        // (streak unchanged) continues to the compile.
+        if(session->compile_crash_streak > entry_streak &&
+           session->compile_crash_streak >= Session::quarantine_threshold) {
+            LOG_WARN("ensure_compiled: {} quarantined during dependency prep", uri_str);
+            session->quarantine_probe = false;
+            session->output = CompileOutput{
+                .version = std::nullopt,
+                .source = source,
+                .diagnostics = quarantine_diagnostics(session->compile_crash_streak),
+                .line_limit = suffix_line_limit,
+                .inactive_regions = std::nullopt,
+            };
+            on_output.emit(session);
             finish_compile();
             co_return;
         }
@@ -1192,6 +1215,14 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     if(!co_await ensure_deps(*session, gen, epoch, wp.directory, wp.arguments, wp.pch, wp.pcms)) {
         LOG_WARN("forward_build: dependency preparation failed for {}", path);
         co_return kota::outcome_error(kota::ipc::Error{"Dependency preparation failed"});
+    }
+    // A PCH crash inside ensure_deps may have tipped the document into
+    // quarantine after the entry gate: stop before dispatching the same
+    // content again.
+    if(session->compile_crash_streak >= Session::quarantine_threshold) {
+        LOG_WARN("forward_build: {} quarantined during dependency prep", path);
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
     auto wait_ms = timer.ms();
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -124,6 +124,17 @@ void Compiler::publish_quarantined(const std::shared_ptr<Session>& session,
     on_output.emit(session);
 }
 
+void Compiler::publish_recovered(const std::shared_ptr<Session>& session) {
+    session->output = CompileOutput{
+        .version = std::nullopt,
+        .source = session->output.has_value() ? session->output->source : CommandSource::CDBExact,
+        .diagnostics = kota::codec::RawValue{},
+        .line_limit = std::nullopt,
+        .inactive_regions = std::nullopt,
+    };
+    on_output.emit(session);
+}
+
 /// Send a stateless request, resending once if the worker died mid-request.
 /// The pool does not retry on its own — it marks the dead slot and surfaces
 /// worker_crashed, so the resend lands on a healthy worker. Build tasks are
@@ -1255,29 +1266,33 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
     }
 
+    // This kind holding strikes without a probe is neither licensed
+    // recovery nor safe ordinary work.
+    if(session->quarantine.kind_blocked(evidence_kind(kind))) {
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
+    }
+
     // A recovery query — this kind holds the strikes — is still
     // distrusted: it needs the owner (the AST lives there), but its crash
     // spends no slot budget and new documents avoid the worker while it
-    // flies. It also spends the probe the edit licensed (a harmless kind
-    // must not: hover would strand a semantic-tokens quarantine), handing
-    // it back only when the query provably never dispatched.
+    // flies. The guard spends the probe the edit licensed (a harmless kind
+    // must not: hover would strand a semantic-tokens quarantine) and hands
+    // it back unless the attempt recorded a strike.
     bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
     auto suspect = recovery ? Suspect::InPlace : Suspect::No;
+    std::optional<Quarantine::ProbeGuard> probe_guard;
     if(recovery) {
-        session->quarantine.spend_probe();
+        probe_guard.emplace(session->quarantine);
     }
     auto result = co_await pool.send_stateful(path_id, wp, {}, suspect);
     if(!result.has_value()) {
         // A query that kills the worker is this document's doing even
         // though its compile landed: per-kind ledger, since only this query
         // kind answering disproves it (see Quarantine::on_kind_crash).
-        auto code = result.error().code;
-        if(code == worker::dispatch_errc::worker_crashed) {
+        if(result.error().code == worker::dispatch_errc::worker_crashed) {
             session->quarantine.on_kind_crash(evidence_kind(kind),
                                               worker::death_of(result.error()));
-        } else if(recovery && (code == worker::dispatch_errc::worker_unavailable ||
-                               code == worker::dispatch_errc::worker_restarting)) {
-            session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1292,7 +1307,11 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
     // that landed mid-flight must not launder the new content's ledger —
     // crashes count regardless of staleness, successes only when fresh.
     if(session->generation == gen) {
+        bool was_active = session->quarantine.active();
         session->quarantine.on_kind_land(evidence_kind(kind));
+        if(was_active && !session->quarantine.active()) {
+            publish_recovered(session);
+        }
     }
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value());
@@ -1313,21 +1332,23 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     }
     auto wait_ms = timer.ms();
 
+    if(session->quarantine.kind_blocked(document_link_evidence)) {
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
+    }
+
     bool recovery = session->quarantine.recovery_kind(document_link_evidence);
     auto suspect = recovery ? Suspect::InPlace : Suspect::No;
+    std::optional<Quarantine::ProbeGuard> probe_guard;
     if(recovery) {
-        session->quarantine.spend_probe();
+        probe_guard.emplace(session->quarantine);
     }
     auto result =
         co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path}, {}, suspect);
     if(!result.has_value()) {
-        auto code = result.error().code;
-        if(code == worker::dispatch_errc::worker_crashed) {
+        if(result.error().code == worker::dispatch_errc::worker_crashed) {
             session->quarantine.on_kind_crash(document_link_evidence,
                                               worker::death_of(result.error()));
-        } else if(recovery && (code == worker::dispatch_errc::worker_unavailable ||
-                               code == worker::dispatch_errc::worker_restarting)) {
-            session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1345,7 +1366,11 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     if(session->generation != gen) {
         co_return std::vector<feature::DocumentLink>{};
     }
+    bool was_active = session->quarantine.active();
     session->quarantine.on_kind_land(document_link_evidence);
+    if(was_active && !session->quarantine.active()) {
+        publish_recovered(session);
+    }
     LOG_PERF("request",
              "kind=DocumentLink file={} wait_ms={} total_ms={}",
              path,
@@ -1366,8 +1391,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     // holding the strikes, with the probe armed — may run. Anything else
     // is arbitrary work on proven-poisonous content. A refusal announces
     // the quarantine, or a completion-only client would never see it.
-    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
-    if(session->quarantine.active() && (session->quarantine.blocked() || !recovery)) {
+    if(session->quarantine.active() && !session->quarantine.recovery_kind(evidence_kind(kind))) {
         LOG_WARN("forward_build: {} is quarantined, refusing build", path);
         if(session->quarantine.needs_announcement()) {
             publish_quarantined(session, std::nullopt, std::nullopt);
@@ -1420,20 +1444,23 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     lsp::LineMap map(wp.text);
     wp.offset = clamped_offset(map, position);
 
-    // When this kind holds the strikes, this dispatch is the recovery
-    // attempt the edit licensed: spend the probe, hand it back only if no
-    // attempt dispatched at all — an unavailable retry after a crashed
-    // first attempt already spent the license on that crash.
-    if(recovery) {
-        session->quarantine.spend_probe();
+    // The recovery license is re-taken here: the gate's answer may have
+    // been spent by a concurrent recovery during the deps await. The guard
+    // holds the spent probe across the dispatch and hands it back if the
+    // coroutine unwinds (cancellation) or fails before any attempt ran —
+    // an unavailable retry after a crashed first attempt keeps it spent,
+    // the crash was the licensed attempt.
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
+    if(session->quarantine.active() && !recovery) {
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
-    auto strikes_before = session->quarantine.crashes();
+    std::optional<Quarantine::ProbeGuard> probe_guard;
+    if(recovery) {
+        probe_guard.emplace(session->quarantine);
+    }
     auto result = co_await build_for(pool, *session, evidence_kind(kind), wp);
     if(!result.has_value()) {
-        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable &&
-           session->quarantine.crashes() == strikes_before) {
-            session->quarantine.re_arm_probe();
-        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "build (kind={}) failed for {}: {}",
@@ -1445,8 +1472,14 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     }
     // The reply proves this kind on the DISPATCHED content answers; a
     // stale success must not launder evidence the new content recorded.
+    // Leaving quarantine here clears the published diagnostic — no compile
+    // runs to overwrite it.
     if(session->generation == gen) {
+        bool was_active = session->quarantine.active();
         session->quarantine.on_kind_land(evidence_kind(kind));
+        if(was_active && !session->quarantine.active()) {
+            publish_recovered(session);
+        }
     }
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value().result_json);
@@ -1462,7 +1495,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     // a worker: while quarantined, only format-as-recovery may run, and a
     // refusal announces the quarantine.
     bool recovery = session->quarantine.recovery_kind(evidence_kind(worker::BuildKind::Format));
-    if(session->quarantine.active() && (session->quarantine.blocked() || !recovery)) {
+    if(session->quarantine.active() && !recovery) {
         LOG_WARN("forward_format: {} is quarantined, refusing format", path);
         if(session->quarantine.needs_announcement()) {
             publish_quarantined(session, std::nullopt, std::nullopt);
@@ -1488,16 +1521,12 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
+    std::optional<Quarantine::ProbeGuard> probe_guard;
     if(recovery) {
-        session->quarantine.spend_probe();
+        probe_guard.emplace(session->quarantine);
     }
-    auto strikes_before = session->quarantine.crashes();
     auto result = co_await build_for(pool, *session, evidence_kind(worker::BuildKind::Format), wp);
     if(!result.has_value()) {
-        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable &&
-           session->quarantine.crashes() == strikes_before) {
-            session->quarantine.re_arm_probe();
-        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "format failed for {}: {}",
@@ -1507,7 +1536,11 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
         co_return kota::outcome_error(std::move(result.error()));
     }
     if(session->generation == gen) {
+        bool was_active = session->quarantine.active();
         session->quarantine.on_kind_land(evidence_kind(worker::BuildKind::Format));
+        if(was_active && !session->quarantine.active()) {
+            publish_recovered(session);
+        }
     }
     LOG_PERF("request", "kind=Format file={} total_ms={}", path, timer.ms());
     co_return std::move(result.value().result_json);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -129,35 +129,39 @@ void Compiler::publish_quarantined(const std::shared_ptr<Session>& session,
 /// worker_crashed, so the resend lands on a healthy worker. Build tasks are
 /// idempotent; one retry suffices, since a request that kills two workers in
 /// a row is a poison workload that a third attempt would not survive either.
-template <typename Params>
-static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool, Params params) {
+///
+/// `on_crash` fires once per attempt that killed a worker — evidence is
+/// counted per death, not per request, so a poison build that burns two
+/// workers spends two strikes. Callers must count ONLY through it: the
+/// returned error is the retry's status, which may not be a crash.
+template <typename Params, typename OnCrash>
+static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool,
+                                                                Params params,
+                                                                OnCrash on_crash) {
     auto result = co_await pool.send_stateless(params);
     if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-        auto retry = co_await pool.send_stateless(params);
-        // A failed retry must not launder the crash: the first attempt
-        // killed a worker, and callers count that evidence toward the
-        // document's quarantine no matter how the retry failed.
-        if(retry.has_value()) {
-            co_return std::move(retry);
+        on_crash(result.error());
+        result = co_await pool.send_stateless(params);
+        if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
+            on_crash(result.error());
         }
-        co_return std::move(result);
     }
     co_return std::move(result);
 }
 
 /// Every stateless build carrying an open document's content goes through
-/// here: a dispatch that killed a worker is blamed on the session before
-/// the caller sees the result, so no site can forget the accounting.
-/// Grep for build_for to enumerate every such site.
+/// here: each worker kill is blamed on the session before the caller sees
+/// the result, so no site can forget the accounting. Grep for build_for to
+/// enumerate every such site.
 template <typename Params>
 static kota::ipc::RequestResult<Params> build_for(WorkerPool& pool,
                                                   Session& session,
                                                   Params params) {
-    auto result = co_await send_stateless_retrying(pool, std::move(params));
-    if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-        session.quarantine.on_crash(worker::death_of(result.error()));
-    }
-    co_return std::move(result);
+    return send_stateless_retrying(pool,
+                                   std::move(params),
+                                   [&session](const kota::ipc::protocol::Error& error) {
+                                       session.quarantine.on_crash(worker::death_of(error));
+                                   });
 }
 
 /// Clamp a client-supplied position to the document, following LSP
@@ -314,13 +318,14 @@ void Compiler::init_compile_graph() {
         // in pcm_paths from a previous (now-invalidated) build.
         workspace.fill_pcm_deps(bp.pcms, path_id);
 
-        auto result = co_await send_stateless_retrying(pool, bp);
+        auto result = co_await send_stateless_retrying(
+            pool,
+            bp,
+            [this, &budget_key](const kota::ipc::protocol::Error&) {
+                workspace.build_crashes.on_crash(budget_key);
+            });
         if(!result.has_value() || !result.value().success) {
             workspace.store->abort(pending);
-            if(!result.has_value() &&
-               result.error().code == worker::dispatch_errc::worker_crashed) {
-                workspace.build_crashes.on_crash(budget_key);
-            }
             if(expected_build_failure(result)) {
                 LOG_WARN("BuildPCM failed for module {}: {}",
                          module_name,
@@ -342,6 +347,7 @@ void Compiler::init_compile_graph() {
             co_return false;
         }
 
+        workspace.build_crashes.on_land(budget_key);
         auto pcm_path = std::move(committed.value().value());
         workspace.pcm_paths[path_id] = pcm_path;
         workspace.pcm_cache[path_id] = {pcm_path,
@@ -542,17 +548,20 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     LOG_DEBUG("Building PCH for {}, bound={}, key={}", path, bound, pch_key);
 
-    auto result = co_await build_for(pool, session, bp);
+    // Each worker kill lands in two ledgers by design: the session's (the
+    // preamble is this document's content) and the shared key's (other
+    // sessions with the same preamble must stop re-triggering the build).
+    auto result = co_await send_stateless_retrying(
+        pool,
+        bp,
+        [this, &session, &pch_key](const kota::ipc::protocol::Error& error) {
+            session.quarantine.on_crash(worker::death_of(error));
+            workspace.build_crashes.on_crash(pch_key);
+        });
 
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
         workspace.store->abort(pending_idx);
-        // The preamble is this document's content too — build_for blamed
-        // the session. The shared-key budget additionally stops other
-        // sessions with the same preamble from re-triggering the build.
-        if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-            workspace.build_crashes.on_crash(pch_key);
-        }
         if(expected_build_failure(result)) {
             LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
         } else {
@@ -610,6 +619,9 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         workspace.pch_cache.erase(pch_key);
         co_return false;
     }
+
+    // The key built: its strikes were transient, not poison.
+    workspace.build_crashes.on_land(pch_key);
 
     auto& st = workspace.pch_cache[pch_key];
     st.path = *committed.value().pch_path;
@@ -1114,7 +1126,9 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
         on_stale(path_id);
     }
 
-    // If an up-to-date compile is already in flight, wait for it.
+    // If an up-to-date compile is already in flight, wait for it. The wait
+    // may watch that compile spend the streak's last budget: re-check the
+    // gate afterwards (below) before launching a replacement.
     // This co_await may be cancelled by LSP $/cancelRequest — that's fine,
     // it just means this particular feature request is abandoned.  The
     // detached compile task keeps running independently.
@@ -1137,6 +1151,17 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
     // If we fell through (not superseding) and the generation changed while
     // we were waiting, the session was closed or replaced — don't compile.
     if(!session->compiling && session->generation != gen) {
+        co_return false;
+    }
+
+    // The compile just waited out may have spent the streak's last budget
+    // (its crash, or its PCH build's): the entry gate ran before that
+    // evidence existed, so a waiter must not launch a replacement for
+    // content that is now quarantined. The crash's own error path already
+    // announced it.
+    if(session->quarantine.blocked()) {
+        LOG_WARN("ensure_compiled: {} quarantined while waiting for a compile",
+                 workspace.path_pool.resolve(path_id));
         co_return false;
     }
 

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -150,19 +150,38 @@ static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool
 }
 
 /// Every stateless build carrying an open document's content goes through
-/// here: each worker kill is blamed on the session before the caller sees
-/// the result, so no site can forget the accounting. Grep for build_for to
+/// here: each worker kill is blamed on the session's ledger for `kind`
+/// before the caller sees the result, so no site can forget the
+/// accounting, and a build that answers clears its own kind — a compile
+/// landing disproves none of this evidence. Grep for build_for to
 /// enumerate every such site.
 template <typename Params>
-static kota::ipc::RequestResult<Params> build_for(WorkerPool& pool,
-                                                  Session& session,
-                                                  Params params) {
-    return send_stateless_retrying(pool,
-                                   std::move(params),
-                                   [&session](const kota::ipc::protocol::Error& error) {
-                                       session.quarantine.on_crash(worker::death_of(error));
-                                   });
+static kota::ipc::RequestResult<Params>
+    build_for(WorkerPool& pool, Session& session, std::uint8_t kind, Params params) {
+    auto result = co_await send_stateless_retrying(
+        pool,
+        std::move(params),
+        [&session, kind](const kota::ipc::protocol::Error& error) {
+            session.quarantine.on_kind_crash(kind, worker::death_of(error));
+        });
+    if(result.has_value()) {
+        session.quarantine.on_kind_land(kind);
+    }
+    co_return std::move(result);
 }
+
+/// Evidence-kind discriminators for Quarantine's per-kind ledgers. Queries
+/// and stateless builds share one space, offset so they cannot collide;
+/// document links have no QueryKind and get their own slot.
+constexpr std::uint8_t evidence_kind(worker::QueryKind kind) {
+    return static_cast<std::uint8_t>(kind);
+}
+
+constexpr std::uint8_t evidence_kind(worker::BuildKind kind) {
+    return 0x40 + static_cast<std::uint8_t>(kind);
+}
+
+constexpr inline std::uint8_t document_link_evidence = 0x20;
 
 /// Clamp a client-supplied position to the document, following LSP
 /// semantics: a character beyond the line length defaults to the line end,
@@ -555,7 +574,8 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         pool,
         bp,
         [this, &session, &pch_key](const kota::ipc::protocol::Error& error) {
-            session.quarantine.on_crash(worker::death_of(error));
+            session.quarantine.on_kind_crash(evidence_kind(worker::BuildKind::BuildPCH),
+                                             worker::death_of(error));
             workspace.build_crashes.on_crash(pch_key);
         });
 
@@ -622,6 +642,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     // The key built: its strikes were transient, not poison.
     workspace.build_crashes.on_land(pch_key);
+    session.quarantine.on_kind_land(evidence_kind(worker::BuildKind::BuildPCH));
 
     auto& st = workspace.pch_cache[pch_key];
     st.path = *committed.value().pch_path;
@@ -1226,15 +1247,28 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 
     // A recovery query after a query-crash quarantine is still distrusted:
     // it needs the owner (the AST lives there), but its crash spends no
-    // slot budget and new documents avoid the worker while it flies.
+    // slot budget and new documents avoid the worker while it flies. It is
+    // also the attempt the edit's probe licensed — spend the probe here
+    // (idempotent when the compile already spent it; this covers the
+    // clean-AST fast path) and hand it back only when the query provably
+    // never dispatched.
     auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
+    if(suspect == Suspect::InPlace) {
+        session->quarantine.spend_probe();
+    }
     auto result = co_await pool.send_stateful(path_id, wp, {}, suspect);
     if(!result.has_value()) {
         // A query that kills the worker is this document's doing even
-        // though its compile landed: separate ledger, since only a query
-        // that answers disproves it (see Quarantine::on_query_crash).
-        if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->quarantine.on_query_crash(worker::death_of(result.error()));
+        // though its compile landed: per-kind ledger, since only this query
+        // kind answering disproves it (see Quarantine::on_kind_crash).
+        auto code = result.error().code;
+        if(code == worker::dispatch_errc::worker_crashed) {
+            session->quarantine.on_kind_crash(evidence_kind(kind),
+                                              worker::death_of(result.error()));
+        } else if(suspect == Suspect::InPlace &&
+                  (code == worker::dispatch_errc::worker_unavailable ||
+                   code == worker::dispatch_errc::worker_restarting)) {
+            session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1249,7 +1283,7 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
     // that landed mid-flight must not launder the new content's ledger —
     // crashes count regardless of staleness, successes only when fresh.
     if(session->generation == gen) {
-        session->quarantine.on_query_land();
+        session->quarantine.on_kind_land(evidence_kind(kind));
     }
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value());
@@ -1271,11 +1305,20 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     auto wait_ms = timer.ms();
 
     auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
+    if(suspect == Suspect::InPlace) {
+        session->quarantine.spend_probe();
+    }
     auto result =
         co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path}, {}, suspect);
     if(!result.has_value()) {
-        if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->quarantine.on_query_crash(worker::death_of(result.error()));
+        auto code = result.error().code;
+        if(code == worker::dispatch_errc::worker_crashed) {
+            session->quarantine.on_kind_crash(document_link_evidence,
+                                              worker::death_of(result.error()));
+        } else if(suspect == Suspect::InPlace &&
+                  (code == worker::dispatch_errc::worker_unavailable ||
+                   code == worker::dispatch_errc::worker_restarting)) {
+            session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1293,7 +1336,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     if(session->generation != gen) {
         co_return std::vector<feature::DocumentLink>{};
     }
-    session->quarantine.on_query_land();
+    session->quarantine.on_kind_land(document_link_evidence);
     LOG_PERF("request",
              "kind=DocumentLink file={} wait_ms={} total_ms={}",
              path,
@@ -1356,7 +1399,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     lsp::LineMap map(wp.text);
     wp.offset = clamped_offset(map, position);
 
-    auto result = co_await build_for(pool, *session, wp);
+    auto result = co_await build_for(pool, *session, evidence_kind(kind), wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1402,7 +1445,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
-    auto result = co_await build_for(pool, *session, wp);
+    auto result = co_await build_for(pool, *session, evidence_kind(worker::BuildKind::Format), wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -87,6 +87,20 @@ const static std::string& build_failure_message(const auto& result) {
     return result.has_value() ? result.value().error : result.error().message;
 }
 
+/// Send a stateless request, resending once if the worker died mid-request.
+/// The pool does not retry on its own — it marks the dead slot and surfaces
+/// worker_crashed, so the resend lands on a healthy worker. Build tasks are
+/// idempotent; one retry suffices, since a request that kills two workers in
+/// a row is a poison workload that a third attempt would not survive either.
+template <typename Params>
+static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool, Params params) {
+    auto result = co_await pool.send_stateless(params);
+    if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
+        result = co_await pool.send_stateless(params);
+    }
+    co_return std::move(result);
+}
+
 /// Clamp a client-supplied position to the document, following LSP
 /// semantics: a character beyond the line length defaults to the line end,
 /// a line beyond the document defaults to the end of the content.
@@ -226,7 +240,7 @@ void Compiler::init_compile_graph() {
         // in pcm_paths from a previous (now-invalidated) build.
         workspace.fill_pcm_deps(bp.pcms, path_id);
 
-        auto result = co_await pool.send_stateless(bp);
+        auto result = co_await send_stateless_retrying(pool, bp);
         if(!result.has_value() || !result.value().success) {
             workspace.store->abort(pending);
             if(expected_build_failure(result)) {
@@ -440,7 +454,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
 
     LOG_DEBUG("Building PCH for {}, bound={}, key={}", path, bound, pch_key);
 
-    auto result = co_await pool.send_stateless(bp);
+    auto result = co_await send_stateless_retrying(pool, bp);
 
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
@@ -1118,7 +1132,7 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     lsp::LineMap map(wp.text);
     wp.offset = clamped_offset(map, position);
 
-    auto result = co_await pool.send_stateless(wp);
+    auto result = co_await send_stateless_retrying(pool, wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1155,7 +1169,7 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
-    auto result = co_await pool.send_stateless(wp);
+    auto result = co_await send_stateless_retrying(pool, wp);
     if(!result.has_value()) {
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -87,6 +87,24 @@ const static std::string& build_failure_message(const auto& result) {
     return result.has_value() ? result.value().error : result.error().message;
 }
 
+/// A quarantined document must not hide behind empty diagnostics: publish
+/// one that says why every semantic feature went quiet, and how to lift it.
+static kota::codec::RawValue quarantine_diagnostics(unsigned crashes) {
+    std::vector<protocol::Diagnostic> diagnostics(1);
+    auto& diagnostic = diagnostics[0];
+    diagnostic.range = protocol::Range{
+        .start = protocol::Position{.line = 0, .character = 0},
+        .end = protocol::Position{.line = 0, .character = 0},
+    };
+    diagnostic.severity = protocol::DiagnosticSeverity::Error;
+    diagnostic.source = "clice";
+    diagnostic.message = std::format(
+        "compiling this file crashed the language server worker {} times; " "the file is quarantined until it is edited",
+        crashes);
+    auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(diagnostics);
+    return kota::codec::RawValue{json ? std::move(*json) : "[]"};
+}
+
 /// Send a stateless request, resending once if the worker died mid-request.
 /// The pool does not retry on its own — it marks the dead slot and surfaces
 /// worker_crashed, so the resend lands on a healthy worker. Build tasks are
@@ -787,7 +805,11 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             params.open_conditionals.assign(conditionals.begin(), conditionals.end());
         }
 
-        auto result = co_await pool.send_stateful(pid, params);
+        // A quarantined document's probe is a known risk: tell the pool so
+        // the crash, if it comes, does not spend the slot's budget.
+        bool suspect = session->compile_crash_streak >= Session::quarantine_threshold;
+        session->quarantine_probe = false;
+        auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
         if(session->generation != gen) {
             LOG_INFO("ensure_compiled: generation mismatch ({} vs {}) for {}",
@@ -810,12 +832,26 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                             uri_str,
                             result.error().message);
             }
+            // The budget the pool keeps is per slot; the poison is in the
+            // document. Count the crash here so a document that keeps
+            // killing workers is quarantined instead of burning slots.
+            if(result.error().code == worker::dispatch_errc::worker_crashed) {
+                session->compile_crash_streak += 1;
+            }
+            // No expendable worker right now: the probe never ran — keep
+            // it armed so a later request retries once one frees up.
+            if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
+                session->quarantine_probe = true;
+            }
+            bool quarantined = session->compile_crash_streak >= Session::quarantine_threshold;
             // Clear path: empty diagnostics without a version, and no
-            // inactive-regions update.
+            // inactive-regions update. A quarantined document announces
+            // itself instead of hiding behind the empty list.
             session->output = CompileOutput{
                 .version = std::nullopt,
                 .source = source,
-                .diagnostics = {},
+                .diagnostics = quarantined ? quarantine_diagnostics(session->compile_crash_streak)
+                                           : kota::codec::RawValue{},
                 .line_limit = suffix_line_limit,
                 .inactive_regions = std::nullopt,
             };
@@ -867,6 +903,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // a stale world — record it, publish it (bounded staleness), but do
         // not declare it fresh; the next request recompiles.
         session->settle_compile(epoch);
+        session->compile_crash_streak = 0;
         pc->succeeded = true;
         record_deps(*session, result.value().deps, result.value().build_at);
 
@@ -942,6 +979,17 @@ kota::task<bool> Compiler::ensure_compiled(std::shared_ptr<Session> session) {
               session->version,
               gen,
               session->ast_dirty);
+
+    // The crash budget lives on pool slots, the poison lives in documents:
+    // a document that keeps killing workers is quarantined instead of
+    // burning slot after slot. A content change grants one probe attempt.
+    if(session->compile_crash_streak >= Session::quarantine_threshold &&
+       !session->quarantine_probe) {
+        LOG_WARN("ensure_compiled: {} quarantined after {} worker crashes",
+                 workspace.path_pool.resolve(path_id),
+                 session->compile_crash_streak);
+        co_return false;
+    }
 
     if(!session->ast_dirty) {
         if(!is_stale(*session)) {

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -154,7 +154,7 @@ static kota::ipc::RequestResult<Params> build_for(WorkerPool& pool,
                                                   Params params) {
     auto result = co_await send_stateless_retrying(pool, std::move(params));
     if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
-        session.quarantine.on_crash();
+        session.quarantine.on_crash(worker::death_of(result.error()));
     }
     co_return std::move(result);
 }
@@ -909,7 +909,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // restarting-window fast-fail never reached a worker.
         if(!result.has_value()) {
             if(result.error().code == worker::dispatch_errc::worker_crashed) {
-                session->quarantine.on_crash();
+                session->quarantine.on_crash(worker::death_of(result.error()));
             } else if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
                 // The probe never ran: keep it armed so a later request
                 // retries once an expendable worker frees up.
@@ -1199,7 +1199,7 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         // though its compile landed: separate ledger, since only a query
         // that answers disproves it (see Quarantine::on_query_crash).
         if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->quarantine.on_query_crash();
+            session->quarantine.on_query_crash(worker::death_of(result.error()));
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
@@ -1233,7 +1233,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     auto result = co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path});
     if(!result.has_value()) {
         if(result.error().code == worker::dispatch_errc::worker_crashed) {
-            session->quarantine.on_query_crash();
+            session->quarantine.on_query_crash(worker::death_of(result.error()));
         }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -152,22 +152,19 @@ static kota::ipc::RequestResult<Params> send_stateless_retrying(WorkerPool& pool
 /// Every stateless build carrying an open document's content goes through
 /// here: each worker kill is blamed on the session's ledger for `kind`
 /// before the caller sees the result, so no site can forget the
-/// accounting, and a build that answers clears its own kind — a compile
-/// landing disproves none of this evidence. Grep for build_for to
-/// enumerate every such site.
+/// accounting. Clearing the kind on success stays with the caller — it
+/// must be guarded by the launch generation, or a stale reply would
+/// launder evidence the new content recorded meanwhile. Grep for
+/// build_for to enumerate every such site.
 template <typename Params>
 static kota::ipc::RequestResult<Params>
     build_for(WorkerPool& pool, Session& session, std::uint8_t kind, Params params) {
-    auto result = co_await send_stateless_retrying(
-        pool,
-        std::move(params),
-        [&session, kind](const kota::ipc::protocol::Error& error) {
-            session.quarantine.on_kind_crash(kind, worker::death_of(error));
-        });
-    if(result.has_value()) {
-        session.quarantine.on_kind_land(kind);
-    }
-    co_return std::move(result);
+    return send_stateless_retrying(pool,
+                                   std::move(params),
+                                   [&session, kind](const kota::ipc::protocol::Error& error) {
+                                       session.quarantine.on_kind_crash(kind,
+                                                                        worker::death_of(error));
+                                   });
 }
 
 /// Evidence-kind discriminators for Quarantine's per-kind ledgers. Queries
@@ -486,6 +483,9 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
             pch_miss = "deps_changed";
         } else {
             session.pch_key = pch_key;
+            // Adopting a proven-good artifact disproves the session's PCH
+            // strikes as surely as building one.
+            session.quarantine.on_kind_land(evidence_kind(worker::BuildKind::BuildPCH));
             LOG_PERF("cache", "ns=pch event=hit key={} file={}", pch_key, path);
             co_return true;
         }
@@ -522,6 +522,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         if(auto it2 = workspace.pch_cache.find(pch_key);
            it2 != workspace.pch_cache.end() && !it2->second.path.empty()) {
             session.pch_key = pch_key;
+            session.quarantine.on_kind_land(evidence_kind(worker::BuildKind::BuildPCH));
             co_return true;
         }
         co_return false;
@@ -640,9 +641,13 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         co_return false;
     }
 
-    // The key built: its strikes were transient, not poison.
+    // The key built: its strikes were transient, not poison. The session
+    // ledger clears only when this build's launch is still current — a
+    // stale build must not launder strikes the new content recorded.
     workspace.build_crashes.on_land(pch_key);
-    session.quarantine.on_kind_land(evidence_kind(worker::BuildKind::BuildPCH));
+    if(session.generation == launch_generation) {
+        session.quarantine.on_kind_land(evidence_kind(worker::BuildKind::BuildPCH));
+    }
 
     auto& st = workspace.pch_cache[pch_key];
     st.path = *committed.value().pch_path;
@@ -934,10 +939,15 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             params.open_conditionals.assign(conditionals.begin(), conditionals.end());
         }
 
-        // A quarantined document's probe is a known risk: tell the pool so
-        // the crash, if it comes, does not spend the slot's budget.
-        auto suspect = session->quarantine.active() ? Suspect::Isolated : Suspect::No;
-        session->quarantine.spend_probe();
+        // The probe rides the dispatch that can disprove its evidence: a
+        // compile spends it only when compiles are the crashers. A
+        // kind-quarantined document's compile is ordinary work, and the
+        // probe must survive it for the crashing kind's own retry.
+        bool recovery = session->quarantine.recovery_compile();
+        auto suspect = recovery ? Suspect::Isolated : Suspect::No;
+        if(recovery) {
+            session->quarantine.spend_probe();
+        }
         auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
         // Crash accounting runs even for superseded compiles: the crash came
@@ -1245,15 +1255,15 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
     }
 
-    // A recovery query after a query-crash quarantine is still distrusted:
-    // it needs the owner (the AST lives there), but its crash spends no
-    // slot budget and new documents avoid the worker while it flies. It is
-    // also the attempt the edit's probe licensed — spend the probe here
-    // (idempotent when the compile already spent it; this covers the
-    // clean-AST fast path) and hand it back only when the query provably
-    // never dispatched.
-    auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
-    if(suspect == Suspect::InPlace) {
+    // A recovery query — this kind holds the strikes — is still
+    // distrusted: it needs the owner (the AST lives there), but its crash
+    // spends no slot budget and new documents avoid the worker while it
+    // flies. It also spends the probe the edit licensed (a harmless kind
+    // must not: hover would strand a semantic-tokens quarantine), handing
+    // it back only when the query provably never dispatched.
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
+    auto suspect = recovery ? Suspect::InPlace : Suspect::No;
+    if(recovery) {
         session->quarantine.spend_probe();
     }
     auto result = co_await pool.send_stateful(path_id, wp, {}, suspect);
@@ -1265,9 +1275,8 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         if(code == worker::dispatch_errc::worker_crashed) {
             session->quarantine.on_kind_crash(evidence_kind(kind),
                                               worker::death_of(result.error()));
-        } else if(suspect == Suspect::InPlace &&
-                  (code == worker::dispatch_errc::worker_unavailable ||
-                   code == worker::dispatch_errc::worker_restarting)) {
+        } else if(recovery && (code == worker::dispatch_errc::worker_unavailable ||
+                               code == worker::dispatch_errc::worker_restarting)) {
             session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
@@ -1304,8 +1313,9 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
     }
     auto wait_ms = timer.ms();
 
-    auto suspect = session->quarantine.active() ? Suspect::InPlace : Suspect::No;
-    if(suspect == Suspect::InPlace) {
+    bool recovery = session->quarantine.recovery_kind(document_link_evidence);
+    auto suspect = recovery ? Suspect::InPlace : Suspect::No;
+    if(recovery) {
         session->quarantine.spend_probe();
     }
     auto result =
@@ -1315,9 +1325,8 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
         if(code == worker::dispatch_errc::worker_crashed) {
             session->quarantine.on_kind_crash(document_link_evidence,
                                               worker::death_of(result.error()));
-        } else if(suspect == Suspect::InPlace &&
-                  (code == worker::dispatch_errc::worker_unavailable ||
-                   code == worker::dispatch_errc::worker_restarting)) {
+        } else if(recovery && (code == worker::dispatch_errc::worker_unavailable ||
+                               code == worker::dispatch_errc::worker_restarting)) {
             session->quarantine.re_arm_probe();
         }
         if(!worker::is_operational_error(result.error())) {
@@ -1353,14 +1362,16 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     auto gen = session->generation;
 
     // This build compiles the same content the quarantine watches; a
-    // quarantined document gets no stateless builds either, or completion
+    // blocked document gets no stateless builds either, or completion
     // requests would keep killing workers the compile path is protecting.
-    // Recovery stays with the compile path's probe.
-    if(session->quarantine.active()) {
+    // A probe-armed document passes: when this kind holds the strikes,
+    // this dispatch IS the recovery attempt.
+    if(session->quarantine.blocked()) {
         LOG_WARN("forward_build: {} is quarantined, refusing build", path);
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
     }
+    auto flight = session->quarantine.begin_flight();
 
     // Takeoff snapshot for the pch_key write license (see
     // may_write_pch_key): this request runs concurrently with compiles and
@@ -1384,8 +1395,11 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     }
     // A PCH crash inside ensure_deps may have tipped the document into
     // quarantine after the entry gate: stop before dispatching the same
-    // content again.
-    if(session->quarantine.active()) {
+    // content again — that crash also spent any armed probe (it WAS the
+    // attempt). A probe that predates this request's own evidence does not
+    // excuse dispatching content that just proved poisonous.
+    if(session->quarantine.active() && session->quarantine.grew(flight)) {
+        session->quarantine.spend_probe();
         LOG_WARN("forward_build: {} quarantined during dependency prep", path);
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
@@ -1399,8 +1413,18 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
     lsp::LineMap map(wp.text);
     wp.offset = clamped_offset(map, position);
 
+    // When this kind holds the strikes, this dispatch is the recovery
+    // attempt the edit licensed: spend the probe, hand it back only if the
+    // build provably never dispatched.
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(kind));
+    if(recovery) {
+        session->quarantine.spend_probe();
+    }
     auto result = co_await build_for(pool, *session, evidence_kind(kind), wp);
     if(!result.has_value()) {
+        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable) {
+            session->quarantine.re_arm_probe();
+        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "build (kind={}) failed for {}: {}",
@@ -1410,6 +1434,11 @@ Compiler::RawResult Compiler::forward_build(worker::BuildKind kind,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    // The reply proves this kind on the DISPATCHED content answers; a
+    // stale success must not launder evidence the new content recorded.
+    if(session->generation == gen) {
+        session->quarantine.on_kind_land(evidence_kind(kind));
+    }
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value().result_json);
 }
@@ -1418,11 +1447,12 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
                                              std::optional<protocol::Range> range) {
     auto path_id = session->path_id;
     auto path = std::string(workspace.path_pool.resolve(path_id));
+    auto gen = session->generation;
 
     // Formatting runs no sema, but it is still this document's content on
-    // a worker: a quarantined document waits for its probe to land instead
-    // of keeping a side channel that can kill workers.
-    if(session->quarantine.active()) {
+    // a worker: a blocked document is refused. A probe-armed one passes —
+    // when format holds the strikes, this dispatch is the recovery.
+    if(session->quarantine.blocked()) {
         LOG_WARN("forward_format: {} is quarantined, refusing format", path);
         co_return kota::outcome_error(
             kota::ipc::Error{worker::dispatch_errc::worker_unavailable, "Document is quarantined"});
@@ -1445,8 +1475,15 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
     }
 
     ScopedTimer timer;
+    bool recovery = session->quarantine.recovery_kind(evidence_kind(worker::BuildKind::Format));
+    if(recovery) {
+        session->quarantine.spend_probe();
+    }
     auto result = co_await build_for(pool, *session, evidence_kind(worker::BuildKind::Format), wp);
     if(!result.has_value()) {
+        if(recovery && result.error().code == worker::dispatch_errc::worker_unavailable) {
+            session->quarantine.re_arm_probe();
+        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "format failed for {}: {}",
@@ -1454,6 +1491,9 @@ Compiler::RawResult Compiler::forward_format(std::shared_ptr<Session> session,
                         result.error().message);
         }
         co_return kota::outcome_error(std::move(result.error()));
+    }
+    if(session->generation == gen) {
+        session->quarantine.on_kind_land(evidence_kind(worker::BuildKind::Format));
     }
     LOG_PERF("request", "kind=Format file={} total_ms={}", path, timer.ms());
     co_return std::move(result.value().result_json);

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -1195,6 +1195,12 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
 
     auto result = co_await pool.send_stateful(path_id, wp);
     if(!result.has_value()) {
+        // A query that kills the worker is this document's doing even
+        // though its compile landed: separate ledger, since only a query
+        // that answers disproves it (see Quarantine::on_query_crash).
+        if(result.error().code == worker::dispatch_errc::worker_crashed) {
+            session->quarantine.on_query_crash();
+        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "query (kind={}) failed for {}: {}",
@@ -1204,6 +1210,7 @@ Compiler::RawResult Compiler::forward_query(worker::QueryKind kind,
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    session->quarantine.on_query_land();
     LOG_PERF("request", "kind={} file={} wait_ms={} total_ms={}", kind, path, wait_ms, timer.ms());
     co_return std::move(result.value());
 }
@@ -1225,6 +1232,9 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
 
     auto result = co_await pool.send_stateful(path_id, worker::DocumentLinkParams{path});
     if(!result.has_value()) {
+        if(result.error().code == worker::dispatch_errc::worker_crashed) {
+            session->quarantine.on_query_crash();
+        }
         if(!worker::is_operational_error(result.error())) {
             LOG_ANOMALY(WorkerRequestFail,
                         "documentLink failed for {}: {}",
@@ -1233,6 +1243,7 @@ kota::task<std::vector<feature::DocumentLink>, kota::ipc::Error>
         }
         co_return kota::outcome_error(std::move(result.error()));
     }
+    session->quarantine.on_query_land();
     // The result carries byte offsets against the compiled buffer; a
     // didChange that landed during the await makes them describe text the
     // session no longer holds — the reply edge would map them onto the

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -477,6 +477,13 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
     if(!result.has_value() || !result.value().success) {
         workspace.store->abort(pending);
         workspace.store->abort(pending_idx);
+        // The preamble is this document's content too: a PCH build that
+        // crashes workers counts toward the same quarantine streak as the
+        // stateful compile, or a poison preamble would keep killing two
+        // stateless slots per feature request without ever quarantining.
+        if(!result.has_value() && result.error().code == worker::dispatch_errc::worker_crashed) {
+            session.compile_crash_streak += 1;
+        }
         if(expected_build_failure(result)) {
             LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
         } else {
@@ -811,6 +818,25 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         session->quarantine_probe = false;
         auto result = co_await pool.send_stateful(pid, params, {}, suspect);
 
+        // Crash accounting runs even for superseded compiles: the crash was
+        // caused by content this document dispatched, and skipping it would
+        // let a poison file dodge quarantine by being edited between the
+        // dispatch and the crash response. The budget the pool keeps is per
+        // slot; the poison is in the document — a document that keeps
+        // killing workers is quarantined instead of burning slots. Only a
+        // real mid-request death counts: a restarting-window fast-fail
+        // (worker_restarting) never reached a worker.
+        if(!result.has_value()) {
+            if(result.error().code == worker::dispatch_errc::worker_crashed) {
+                session->compile_crash_streak += 1;
+            }
+            // No expendable worker right now: the probe never ran — keep
+            // it armed so a later request retries once one frees up.
+            if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
+                session->quarantine_probe = true;
+            }
+        }
+
         if(session->generation != gen) {
             LOG_INFO("ensure_compiled: generation mismatch ({} vs {}) for {}",
                      session->generation,
@@ -831,17 +857,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                             "Compile failed for {}: {}",
                             uri_str,
                             result.error().message);
-            }
-            // The budget the pool keeps is per slot; the poison is in the
-            // document. Count the crash here so a document that keeps
-            // killing workers is quarantined instead of burning slots.
-            if(result.error().code == worker::dispatch_errc::worker_crashed) {
-                session->compile_crash_streak += 1;
-            }
-            // No expendable worker right now: the probe never ran — keep
-            // it armed so a later request retries once one frees up.
-            if(suspect && result.error().code == worker::dispatch_errc::worker_unavailable) {
-                session->quarantine_probe = true;
             }
             bool quarantined = session->compile_crash_streak >= Session::quarantine_threshold;
             // Clear path: empty diagnostics without a version, and no

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -125,6 +125,11 @@ private:
                              std::optional<CommandSource> source,
                              std::optional<std::uint32_t> line_limit);
 
+    /// Clear the published quarantine diagnostic after a stateless or
+    /// query recovery lifted the quarantine: no compile ran to overwrite
+    /// the output, and the stale "file is quarantined" must not linger.
+    void publish_recovered(const std::shared_ptr<Session>& session);
+
     /// @param launch_generation, launch_epoch  The caller's staleness-token
     ///               snapshots from the moment its round took off, NOT ones
     ///               taken on entry: a round invalidated during the

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -117,6 +117,14 @@ public:
 private:
     kota::task<> run_compile(std::shared_ptr<Session> session);
 
+    /// Publish the quarantine diagnostic as the session's current output
+    /// and mark the spell announced. `source` falls back to the previous
+    /// output's command source when the announcement has no compile of its
+    /// own (the ensure_compiled entry gate).
+    void publish_quarantined(const std::shared_ptr<Session>& session,
+                             std::optional<CommandSource> source,
+                             std::optional<std::uint32_t> line_limit);
+
     /// @param launch_generation, launch_epoch  The caller's staleness-token
     ///               snapshots from the moment its round took off, NOT ones
     ///               taken on entry: a round invalidated during the

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -533,9 +533,16 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
         // a verdict, and each retry round waits out the idle timer rather
         // than spinning. Without revival a requeue could never succeed.
         bool crashed = result.error().code == worker::dispatch_errc::worker_crashed;
-        switch(note_dispatch_failure(server_path_id, crashed)) {
+        switch(note_dispatch_failure(server_path_id, ticket, crashed)) {
             case RequeueVerdict::Dropped: {
                 LOG_INFO("[{}/{}] Index dropped for removed file {}", index, total, file_path);
+                break;
+            }
+            case RequeueVerdict::Superseded: {
+                LOG_INFO("[{}/{}] Index failure for superseded content of {}",
+                         index,
+                         total,
+                         file_path);
                 break;
             }
             case RequeueVerdict::GaveUp: {
@@ -565,12 +572,22 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
     }
 }
 
-auto Indexer::note_dispatch_failure(std::uint32_t server_path_id, bool crashed) -> RequeueVerdict {
+auto Indexer::note_dispatch_failure(std::uint32_t server_path_id,
+                                    std::uint64_t ticket,
+                                    bool crashed) -> RequeueVerdict {
     // Only while the pending entry survives: a file removed from disk
     // mid-flight was cleared and has nothing to redo.
     auto it = reindex_reasons.find(server_path_id);
     if(it == reindex_reasons.end()) {
         return RequeueVerdict::Dropped;
+    }
+
+    // The failed dispatch carried bytes a ContentChanged enqueue has since
+    // replaced: its crash says nothing about the fixed content, so it
+    // neither spends the fresh budget nor requeues — the newer content's
+    // own slot redoes the work.
+    if(it->second.content_ticket > ticket) {
+        return RequeueVerdict::Superseded;
     }
 
     // The budget both counts and gates crashes only: a preemption under

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -600,13 +600,20 @@ auto Indexer::note_dispatch_failure(std::uint32_t server_path_id,
         }
         it->second.requeue_attempts += 1;
     }
+    // Requeue with the debt class this dispatch carried, not the entry's
+    // current one: a deps-only enqueue that landed mid-flight downgraded
+    // the reason betting on this content pass to land — a failed pass
+    // leaves the edit uncovered, and only a ContentChanged pending entry
+    // keeps suppressing the stale shard.
+    auto reason =
+        it->second.content_ticket == ticket ? ReindexReason::ContentChanged : it->second.reason;
     // The enqueue bumps the entry's ticket, which shields it from the
     // in-flight task's pending-state clear. It also resets the poison
     // budget on ContentChanged — right for a user edit, wrong for this
     // requeue of the same bytes — so restore the ledger afterwards
     // (try_emplace on the existing key keeps `it` valid).
     auto attempts = it->second.requeue_attempts;
-    enqueue(server_path_id, it->second.reason);
+    enqueue(server_path_id, reason);
     it->second.requeue_attempts = attempts;
     return RequeueVerdict::Requeued;
 }

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -601,6 +601,12 @@ auto Indexer::note_dispatch_failure(std::uint32_t server_path_id,
     // clear the pending state and serve the stale shard as fresh.
     if(crashed) {
         if(it->second.requeue_attempts >= max_requeue_attempts) {
+            // Giving up accepts the staleness, so clear the pending slot
+            // here rather than relying on run_index_task's ticket-guarded
+            // clear: a deps-only enqueue that landed mid-flight bumped the
+            // ticket, and the guard would leave that downgraded entry
+            // queued — a doomed retry that spends one more worker.
+            clear_pending(server_path_id);
             return RequeueVerdict::GaveUp;
         }
         it->second.requeue_attempts += 1;

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -546,12 +546,17 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
                 break;
             }
             case RequeueVerdict::GaveUp: {
-                LOG_WARN("[{}/{}] Index giving up on {} after {} requeues: {}",
-                         index,
-                         total,
-                         file_path,
-                         max_requeue_attempts,
-                         result.error().message);
+                // Log-only by design: the file is usually not open (open
+                // documents are served by their session, not the shard),
+                // so there is no diagnostic surface. Cross-file references
+                // into this file stay stale until its content changes.
+                LOG_WARN(
+                    "[{}/{}] Index giving up on {} after {} crash requeues; " "its cross-file data stays stale until it is edited: {}",
+                    index,
+                    total,
+                    file_path,
+                    max_requeue_attempts,
+                    result.error().message);
                 break;
             }
             case RequeueVerdict::Requeued: {

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -569,11 +569,14 @@ auto Indexer::note_dispatch_failure(std::uint32_t server_path_id, bool crashed) 
         return RequeueVerdict::Dropped;
     }
 
-    if(it->second.requeue_attempts >= max_requeue_attempts) {
-        return RequeueVerdict::GaveUp;
-    }
-
+    // The budget both counts and gates crashes only: a preemption under
+    // memory pressure says nothing about the file, so it requeues even
+    // when the crash budget is already spent — giving up on it would
+    // clear the pending state and serve the stale shard as fresh.
     if(crashed) {
+        if(it->second.requeue_attempts >= max_requeue_attempts) {
+            return RequeueVerdict::GaveUp;
+        }
         it->second.requeue_attempts += 1;
     }
     // The enqueue bumps the entry's ticket, which shields it from the

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -522,12 +522,16 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
     } else if(result.has_value() && result.value().tu_index_data.empty()) {
         LOG_WARN("[{}/{}] Index returned empty TUIndex for {}", index, total, file_path);
     } else if(result.error().code == worker::dispatch_errc::cancelled ||
-              result.error().code == worker::dispatch_errc::worker_crashed) {
+              result.error().code == worker::dispatch_errc::worker_crashed ||
+              (result.error().code == worker::dispatch_errc::worker_unavailable &&
+               pool.revives_slots())) {
         // Preempted under memory pressure or lost to a worker crash: the
         // work itself is fine — requeue the file with its original reason so
         // the next round redoes it instead of silently dropping coverage.
-        // Not on worker_unavailable: with no future capacity a requeue would
-        // spin forever.
+        // worker_unavailable requeues (budget-free, like a preemption) only
+        // when the pool revives dead slots: the outage is then a window, not
+        // a verdict, and each retry round waits out the idle timer rather
+        // than spinning. Without revival a requeue could never succeed.
         bool crashed = result.error().code == worker::dispatch_errc::worker_crashed;
         switch(note_dispatch_failure(server_path_id, crashed)) {
             case RequeueVerdict::Dropped: {

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -517,6 +517,36 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
         LOG_WARN("[{}/{}] Index failed for {}: {}", index, total, file_path, result.value().error);
     } else if(result.has_value() && result.value().tu_index_data.empty()) {
         LOG_WARN("[{}/{}] Index returned empty TUIndex for {}", index, total, file_path);
+    } else if(result.error().code == worker::dispatch_errc::cancelled ||
+              result.error().code == worker::dispatch_errc::worker_crashed) {
+        // Preempted under memory pressure or lost to a worker crash: the
+        // work itself is fine — requeue the file with its original reason so
+        // the next round redoes it instead of silently dropping coverage.
+        // Not on worker_unavailable: with no future capacity a requeue would
+        // spin forever. Only while the pending entry survives (a file removed
+        // from disk mid-flight was cleared and has nothing to redo), and only
+        // a bounded number of times — a poison file that crashes every worker
+        // it lands on must not grind the pool's crash budget down.
+        constexpr unsigned max_requeue_attempts = 3;
+        auto it = reindex_reasons.find(server_path_id);
+        if(it == reindex_reasons.end()) {
+            LOG_INFO("[{}/{}] Index dropped for removed file {}", index, total, file_path);
+        } else if(it->second.requeue_attempts >= max_requeue_attempts) {
+            LOG_WARN("[{}/{}] Index giving up on {} after {} requeues: {}",
+                     index,
+                     total,
+                     file_path,
+                     it->second.requeue_attempts,
+                     result.error().message);
+        } else {
+            it->second.requeue_attempts += 1;
+            enqueue(server_path_id, it->second.reason);
+            LOG_INFO("[{}/{}] Index requeued for {}: {}",
+                     index,
+                     total,
+                     file_path,
+                     result.error().message);
+        }
     } else {
         LOG_WARN("[{}/{}] Index IPC error for {}: {}",
                  index,

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -393,6 +393,10 @@ void Indexer::enqueue(std::uint32_t server_path_id, ReindexReason reason) {
         if(reason == ReindexReason::ContentChanged) {
             it->second.reason = ReindexReason::ContentChanged;
             it->second.content_ticket = reindex_ticket;
+            // New content starts a fresh poison budget: the crashes the
+            // old bytes caused say nothing about the fixed ones, and a
+            // stale ledger would abandon the file on its first hiccup.
+            it->second.requeue_attempts = 0;
         } else if(fresh_slot) {
             it->second.reason = ReindexReason::DepsOnly;
         }
@@ -573,8 +577,13 @@ auto Indexer::note_dispatch_failure(std::uint32_t server_path_id, bool crashed) 
         it->second.requeue_attempts += 1;
     }
     // The enqueue bumps the entry's ticket, which shields it from the
-    // in-flight task's pending-state clear.
+    // in-flight task's pending-state clear. It also resets the poison
+    // budget on ContentChanged — right for a user edit, wrong for this
+    // requeue of the same bytes — so restore the ledger afterwards
+    // (try_emplace on the existing key keeps `it` valid).
+    auto attempts = it->second.requeue_attempts;
     enqueue(server_path_id, it->second.reason);
+    it->second.requeue_attempts = attempts;
     return RequeueVerdict::Requeued;
 }
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -523,29 +523,30 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
         // work itself is fine — requeue the file with its original reason so
         // the next round redoes it instead of silently dropping coverage.
         // Not on worker_unavailable: with no future capacity a requeue would
-        // spin forever. Only while the pending entry survives (a file removed
-        // from disk mid-flight was cleared and has nothing to redo), and only
-        // a bounded number of times — a poison file that crashes every worker
-        // it lands on must not grind the pool's crash budget down.
-        constexpr unsigned max_requeue_attempts = 3;
-        auto it = reindex_reasons.find(server_path_id);
-        if(it == reindex_reasons.end()) {
-            LOG_INFO("[{}/{}] Index dropped for removed file {}", index, total, file_path);
-        } else if(it->second.requeue_attempts >= max_requeue_attempts) {
-            LOG_WARN("[{}/{}] Index giving up on {} after {} requeues: {}",
-                     index,
-                     total,
-                     file_path,
-                     it->second.requeue_attempts,
-                     result.error().message);
-        } else {
-            it->second.requeue_attempts += 1;
-            enqueue(server_path_id, it->second.reason);
-            LOG_INFO("[{}/{}] Index requeued for {}: {}",
-                     index,
-                     total,
-                     file_path,
-                     result.error().message);
+        // spin forever.
+        bool crashed = result.error().code == worker::dispatch_errc::worker_crashed;
+        switch(note_dispatch_failure(server_path_id, crashed)) {
+            case RequeueVerdict::Dropped: {
+                LOG_INFO("[{}/{}] Index dropped for removed file {}", index, total, file_path);
+                break;
+            }
+            case RequeueVerdict::GaveUp: {
+                LOG_WARN("[{}/{}] Index giving up on {} after {} requeues: {}",
+                         index,
+                         total,
+                         file_path,
+                         max_requeue_attempts,
+                         result.error().message);
+                break;
+            }
+            case RequeueVerdict::Requeued: {
+                LOG_INFO("[{}/{}] Index requeued for {}: {}",
+                         index,
+                         total,
+                         file_path,
+                         result.error().message);
+                break;
+            }
         }
     } else {
         LOG_WARN("[{}/{}] Index IPC error for {}: {}",
@@ -554,6 +555,27 @@ kota::task<> Indexer::index_one(std::uint32_t server_path_id,
                  file_path,
                  result.error().message);
     }
+}
+
+auto Indexer::note_dispatch_failure(std::uint32_t server_path_id, bool crashed) -> RequeueVerdict {
+    // Only while the pending entry survives: a file removed from disk
+    // mid-flight was cleared and has nothing to redo.
+    auto it = reindex_reasons.find(server_path_id);
+    if(it == reindex_reasons.end()) {
+        return RequeueVerdict::Dropped;
+    }
+
+    if(it->second.requeue_attempts >= max_requeue_attempts) {
+        return RequeueVerdict::GaveUp;
+    }
+
+    if(crashed) {
+        it->second.requeue_attempts += 1;
+    }
+    // The enqueue bumps the entry's ticket, which shields it from the
+    // in-flight task's pending-state clear.
+    enqueue(server_path_id, it->second.reason);
+    return RequeueVerdict::Requeued;
 }
 
 kota::task<> Indexer::run_index_task(std::uint32_t server_path_id,

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -235,6 +235,12 @@ private:
         /// not discard an in-flight content pass — its rows are positionally
         /// right and the follow-up slot redoes the semantic drift anyway.
         std::uint64_t content_ticket;
+
+        /// Crash/preemption requeues of this entry. Bounds the damage of a
+        /// poison file that reliably crashes workers: without a cap, every
+        /// requeue would burn another worker's crash budget until the whole
+        /// pool is dead.
+        unsigned requeue_attempts = 0;
     };
 
     llvm::DenseMap<std::uint32_t, PendingReindex> reindex_reasons;

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -254,6 +254,9 @@ private:
     enum class RequeueVerdict : std::uint8_t {
         /// No pending entry survived (file removed mid-flight).
         Dropped,
+        /// The failed dispatch carried bytes older than the pending
+        /// content; the newer content's own queued slot redoes the work.
+        Superseded,
         /// The crash budget is spent; the file is abandoned.
         GaveUp,
         /// Re-enqueued for the next round.
@@ -263,11 +266,16 @@ private:
     constexpr static unsigned max_requeue_attempts = 3;
 
     /// Requeue a file whose index dispatch failed with a crash or a
-    /// memory-pressure preemption. Only crashes spend the bounded budget:
-    /// a preemption says nothing about the file, and capping it would
-    /// silently drop coverage — the pending reason is erased after the
-    /// attempt, so the stale shard would be served as fresh.
-    RequeueVerdict note_dispatch_failure(std::uint32_t server_path_id, bool crashed);
+    /// memory-pressure preemption. `ticket` is the failed dispatch's launch
+    /// ticket: a crash of superseded bytes says nothing about the current
+    /// content and must not spend its budget. Only crashes spend the
+    /// bounded budget: a preemption says nothing about the file, and
+    /// capping it would silently drop coverage — the pending reason is
+    /// erased after the attempt, so the stale shard would be served as
+    /// fresh.
+    RequeueVerdict note_dispatch_failure(std::uint32_t server_path_id,
+                                         std::uint64_t ticket,
+                                         bool crashed);
 
     friend struct testing::IndexerFixture;
 

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -20,6 +20,12 @@ class ContextResolver;
 struct SessionStore;
 class WorkerPool;
 
+namespace testing {
+
+struct IndexerFixture;
+
+}
+
 /// Why a file awaits re-indexing. The invalidation engine knows the cause
 /// at enqueue time, so queries can decide in O(1) whether a pending file's
 /// existing index rows are still trustworthy (see IndexQuery's freshness
@@ -236,12 +242,34 @@ private:
         /// right and the follow-up slot redoes the semantic drift anyway.
         std::uint64_t content_ticket;
 
-        /// Crash/preemption requeues of this entry. Bounds the damage of a
-        /// poison file that reliably crashes workers: without a cap, every
-        /// requeue would burn another worker's crash budget until the whole
-        /// pool is dead.
+        /// Crash requeues of this entry. Bounds the damage of a poison
+        /// file that reliably crashes workers: without a cap, every
+        /// requeue would burn another worker's crash budget until the
+        /// whole pool is dead. Preemption requeues do not count — they
+        /// say nothing about the file.
         unsigned requeue_attempts = 0;
     };
+
+    /// What a failed index dispatch did to the file's pending state.
+    enum class RequeueVerdict : std::uint8_t {
+        /// No pending entry survived (file removed mid-flight).
+        Dropped,
+        /// The crash budget is spent; the file is abandoned.
+        GaveUp,
+        /// Re-enqueued for the next round.
+        Requeued,
+    };
+
+    constexpr static unsigned max_requeue_attempts = 3;
+
+    /// Requeue a file whose index dispatch failed with a crash or a
+    /// memory-pressure preemption. Only crashes spend the bounded budget:
+    /// a preemption says nothing about the file, and capping it would
+    /// silently drop coverage — the pending reason is erased after the
+    /// attempt, so the stale shard would be served as fresh.
+    RequeueVerdict note_dispatch_failure(std::uint32_t server_path_id, bool crashed);
+
+    friend struct testing::IndexerFixture;
 
     llvm::DenseMap<std::uint32_t, PendingReindex> reindex_reasons;
     std::uint64_t reindex_ticket = 0;

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -38,6 +38,11 @@ constexpr inline protocol::integer worker_unavailable = -33000;
 /// e.g. the indexer prefers to requeue the file instead.
 constexpr inline protocol::integer worker_crashed = -33001;
 
+/// The assigned worker is mid-restart after a crash: the request was never
+/// dispatched. Distinct from worker_crashed so crash accounting (document
+/// quarantine) does not blame a document for a window it merely hit.
+constexpr inline protocol::integer worker_restarting = -33002;
+
 }  // namespace dispatch_errc
 
 /// True when a dispatch failure is an expected operational condition rather
@@ -45,7 +50,8 @@ constexpr inline protocol::integer worker_crashed = -33001;
 inline bool is_operational_error(const protocol::Error& error) {
     return error.code == dispatch_errc::cancelled ||
            error.code == dispatch_errc::worker_unavailable ||
-           error.code == dispatch_errc::worker_crashed;
+           error.code == dispatch_errc::worker_crashed ||
+           error.code == dispatch_errc::worker_restarting;
 }
 
 /// True for errors produced by the IPC transport itself (broken pipe, closed

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <format>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -52,6 +53,25 @@ inline bool is_operational_error(const protocol::Error& error) {
            error.code == dispatch_errc::worker_unavailable ||
            error.code == dispatch_errc::worker_crashed ||
            error.code == dispatch_errc::worker_restarting;
+}
+
+/// Identity of the worker incarnation a crashed request died with, carried
+/// in Error::data. One process death fails every request in flight on it;
+/// per-content blame (Quarantine) dedups by this identity so a single death
+/// is counted at most once per document.
+inline protocol::Value death_identity(std::size_t index, unsigned generation, bool stateful) {
+    return std::format("{}:{}:{}", stateful ? "sf" : "sl", index, generation);
+}
+
+/// The death identity attached to a worker_crashed error; empty when the
+/// error carries none (locally synthesized failures).
+inline std::string_view death_of(const protocol::Error& error) {
+    if(error.data.has_value()) {
+        if(auto* id = std::get_if<std::string>(&*error.data)) {
+            return *id;
+        }
+    }
+    return {};
 }
 
 /// True for errors produced by the IPC transport itself (broken pipe, closed

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -32,13 +32,28 @@ constexpr inline protocol::integer cancelled =
 /// No live worker could take the request (crash/restart window or pool stop).
 constexpr inline protocol::integer worker_unavailable = -33000;
 
+/// The worker process died while serving the request. The pool does not
+/// retry: it marks the slot dead and surfaces this code so the caller can
+/// decide — stateless build tasks are idempotent and safe to resend, while
+/// e.g. the indexer prefers to requeue the file instead.
+constexpr inline protocol::integer worker_crashed = -33001;
+
 }  // namespace dispatch_errc
 
 /// True when a dispatch failure is an expected operational condition rather
 /// than clice infrastructure breakage.
 inline bool is_operational_error(const protocol::Error& error) {
     return error.code == dispatch_errc::cancelled ||
-           error.code == dispatch_errc::worker_unavailable;
+           error.code == dispatch_errc::worker_unavailable ||
+           error.code == dispatch_errc::worker_crashed;
+}
+
+/// True for errors produced by the IPC transport itself (broken pipe, closed
+/// peer) as opposed to errors returned by the remote handler. kota surfaces
+/// transport failures with the default RequestFailed code; clice worker
+/// handlers never return that code, so it identifies a dead worker link.
+inline bool is_transport_error(const protocol::Error& error) {
+    return error.code == static_cast<protocol::integer>(protocol::ErrorCode::RequestFailed);
 }
 
 /// Kind of AST query dispatched to a stateful worker.

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <string>
 
 #include "llvm/ADT/StringMap.h"
@@ -199,21 +200,47 @@ class CrashBudget {
 public:
     constexpr static unsigned threshold = Quarantine::threshold;
 
+    /// A block must never be final: the poison may live in content the key
+    /// cannot see (a header included by the preamble text the pch_key
+    /// hashes), so editing it cannot unlock the key. After the cooldown the
+    /// key earns a fresh budget — the retry either succeeds or re-blocks
+    /// after `threshold` more crashes. Mirrors slot revival: bounded burn,
+    /// never a permanent verdict.
+    explicit CrashBudget(std::chrono::steady_clock::duration retry_after =
+                             std::chrono::minutes(5)) : retry_after(retry_after) {}
+
     /// The artifact with this key has spent its budget: refuse to build it.
-    bool blocked(llvm::StringRef key) const {
+    bool blocked(llvm::StringRef key) {
         auto it = crashes.find(key);
-        return it != crashes.end() && it->second >= threshold;
+        if(it == crashes.end() || it->second.count < threshold) {
+            return false;
+        }
+        if(std::chrono::steady_clock::now() - it->second.last_crash < retry_after) {
+            return true;
+        }
+        // Cooldown over: a fresh budget, not a pardon (cf. revive_slot).
+        crashes.erase(it);
+        return false;
     }
 
     /// Building the artifact with this key killed a worker.
     void on_crash(llvm::StringRef key) {
-        crashes[key] += 1;
+        auto& entry = crashes[key];
+        entry.count += 1;
+        entry.last_crash = std::chrono::steady_clock::now();
     }
 
 private:
-    /// Grows by one entry per crashing artifact key — bounded by edits of
-    /// poison content, so no eviction is needed.
-    llvm::StringMap<unsigned> crashes;
+    struct Entry {
+        unsigned count = 0;
+        std::chrono::steady_clock::time_point last_crash;
+    };
+
+    std::chrono::steady_clock::duration retry_after;
+
+    /// Grows by one entry per crashing artifact key and shrinks as
+    /// cooldowns expire — bounded by edits of poison content.
+    llvm::StringMap<Entry> crashes;
 };
 
 }  // namespace clice

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <string>
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -61,8 +62,13 @@ public:
     }
 
     /// A dispatch carrying this document's content killed a worker.
-    void on_crash() {
-        streak += 1;
+    /// `death` is the worker incarnation's identity (worker::death_of):
+    /// one process death fails every request in flight on it, and a death
+    /// already counted — by either ledger — is not counted again.
+    void on_crash(llvm::StringRef death = {}) {
+        if(!counted(death)) {
+            streak += 1;
+        }
     }
 
     /// Snapshot the inherited evidence at compile takeoff.
@@ -98,8 +104,10 @@ public:
     /// that answers (on_query_land) clears it. Without the split, the
     /// crash-triggered recompile would land, launder the evidence, and the
     /// next query would kill a worker again, forever.
-    void on_query_crash() {
-        query_streak += 1;
+    void on_query_crash(llvm::StringRef death = {}) {
+        if(!counted(death)) {
+            query_streak += 1;
+        }
     }
 
     /// A query answered: queries on the current content provably do not
@@ -153,13 +161,30 @@ public:
         query_streak = 0;
         probe = false;
         announced_spell = false;
+        last_death.clear();
     }
 
 private:
+    /// Whether this death was already counted. Remembering only the most
+    /// recent identity suffices: a peer teardown fails all of a death's
+    /// in-flight requests in the same loop turn, so their errors arrive
+    /// adjacently. Anonymous evidence (no identity) always counts.
+    bool counted(llvm::StringRef death) {
+        if(death.empty()) {
+            return false;
+        }
+        if(death == last_death) {
+            return true;
+        }
+        last_death = death.str();
+        return false;
+    }
+
     unsigned streak = 0;
     unsigned query_streak = 0;
     bool probe = false;
     bool announced_spell = false;
+    std::string last_death;
 };
 
 /// Content-keyed crash budget for shared build artifacts (PCH, PCM).

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <string>
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -48,7 +50,11 @@ public:
 
     /// Crashes currently blamed on this document's content.
     unsigned crashes() const {
-        return streak + query_streak;
+        unsigned total = streak;
+        for(auto& [kind, count]: kind_streaks) {
+            total += count;
+        }
+        return total;
     }
 
     /// The document has spent its crash budget: compile and query evidence
@@ -90,8 +96,8 @@ public:
 
     /// A full compile of the current content landed: the inherited compile
     /// evidence is disproved, but crashes recorded during the flight will
-    /// recur on the next request, and query evidence is untouched — the
-    /// compile succeeding says nothing about the queries that follow it.
+    /// recur on the next request, and per-kind evidence is untouched — the
+    /// compile succeeding says nothing about the dispatches it never ran.
     void land(Flight flight) {
         streak -= std::min(flight.inherited, streak);
         if(!active()) {
@@ -99,22 +105,24 @@ public:
         }
     }
 
-    /// A query on this document's settled AST killed a worker. A separate
-    /// ledger from compile crashes: a successful compile does not disprove
-    /// it — the same AST crashes the same query again — so only a query
-    /// that answers (on_query_land) clears it. Without the split, the
-    /// crash-triggered recompile would land, launder the evidence, and the
-    /// next query would kill a worker again, forever.
-    void on_query_crash(llvm::StringRef death = {}) {
+    /// A dispatch of `kind` — a query against the settled AST, a stateless
+    /// build such as completion or format — killed a worker. Per-kind
+    /// ledgers, separate from the compile streak: a compile landing
+    /// disproves none of this (the same AST crashes the same query again,
+    /// clang-format never ran the compile's code), and one kind's success
+    /// says nothing about another's — a harmless hover must not launder
+    /// semantic-tokens evidence. Kind values are caller-defined
+    /// discriminators; each kind clears only via its own on_kind_land.
+    void on_kind_crash(std::uint8_t kind, llvm::StringRef death = {}) {
         if(!counted(death)) {
-            query_streak += 1;
+            kind_streaks[kind] += 1;
         }
     }
 
-    /// A query answered: queries on the current content provably do not
-    /// kill workers.
-    void on_query_land() {
-        query_streak = 0;
+    /// A dispatch of `kind` answered: this kind on the current content
+    /// provably does not kill workers.
+    void on_kind_land(std::uint8_t kind) {
+        kind_streaks.erase(kind);
         if(!active()) {
             announced_spell = false;
         }
@@ -159,7 +167,7 @@ public:
     /// The document was (re)opened: fresh content, fresh record.
     void reset() {
         streak = 0;
-        query_streak = 0;
+        kind_streaks.clear();
         probe = false;
         announced_spell = false;
         last_death.clear();
@@ -182,7 +190,7 @@ private:
     }
 
     unsigned streak = 0;
-    unsigned query_streak = 0;
+    llvm::SmallDenseMap<std::uint8_t, unsigned, 4> kind_streaks;
     bool probe = false;
     bool announced_spell = false;
     std::string last_death;

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <algorithm>
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clice {
+
+/// Per-document crash containment: the state machine behind quarantining a
+/// document whose content keeps killing workers.
+///
+/// The pool's crash budget lives on slots; the poison lives in content. This
+/// type owns the document half of that split, and every transition goes
+/// through a method — the fields are private precisely so the invariants
+/// cannot be broken from a call site:
+///
+///  1. Blame conservation — on_crash() is the only way evidence accrues, and
+///     nothing but land() (inherited evidence only) or reset() removes it.
+///     A crash recorded mid-request survives that request's success.
+///  2. Bounded blast radius — blocked() flips at `threshold` crashes and
+///     stays until a probe is armed; each real content change arms at most
+///     one probe (on_edit), consumed by exactly one attempt (spend_probe),
+///     returned only when the attempt provably never ran (re_arm_probe).
+///  3. Visibility — a quarantine spell asks to be announced exactly once
+///     (needs_announcement / mark_announced); leaving quarantine re-arms
+///     the announcement for the next spell.
+///
+/// The Flight token pins invariant 1 structurally: a compile snapshots the
+/// evidence it inherited at takeoff and can only clear that much on landing,
+/// so a success cannot launder crashes that happened while it flew.
+class Quarantine {
+public:
+    /// Consecutive worker kills a document gets before it is refused
+    /// further dispatches. Two: one crash can be an unlucky coincidence
+    /// (OOM racing the accounting), two in a row for the same content is
+    /// a pattern.
+    constexpr static unsigned threshold = 2;
+
+    /// The evidence a compile inherited at takeoff; land() clears no more.
+    class Flight {
+        friend class Quarantine;
+        unsigned inherited = 0;
+    };
+
+    /// Crashes currently blamed on this document's content.
+    unsigned crashes() const {
+        return streak;
+    }
+
+    /// The document has spent its crash budget.
+    bool active() const {
+        return streak >= threshold;
+    }
+
+    /// Quarantined with no probe attempt armed: refuse dispatches.
+    bool blocked() const {
+        return active() && !probe;
+    }
+
+    /// A dispatch carrying this document's content killed a worker.
+    void on_crash() {
+        streak += 1;
+    }
+
+    /// Snapshot the inherited evidence at compile takeoff.
+    Flight begin_flight() const {
+        Flight flight;
+        flight.inherited = streak;
+        return flight;
+    }
+
+    /// Evidence accrued since this flight took off (a PCH build inside its
+    /// own dependency prep, a concurrent completion build of the same
+    /// content). Used with active() to stop a request whose dependency
+    /// phase already tipped the document into quarantine.
+    bool grew(Flight flight) const {
+        return streak > flight.inherited;
+    }
+
+    /// A full compile of the current content landed: the inherited evidence
+    /// is disproved, but crashes recorded during the flight will recur on
+    /// the next request and must keep accumulating toward quarantine.
+    void land(Flight flight) {
+        streak -= std::min(flight.inherited, streak);
+        if(!active()) {
+            announced_spell = false;
+        }
+    }
+
+    /// A content change grants a quarantined document one probe attempt.
+    /// It deliberately does NOT reset the streak: only a compile that
+    /// succeeds proves the document healthy — resetting on edits would let
+    /// a poison file under active editing crash a worker per keystroke and
+    /// never reach quarantine. Dropped and no-op edits (`changed == false`)
+    /// grant nothing: the poison bytes are unchanged.
+    void on_edit(bool changed) {
+        if(changed && active()) {
+            probe = true;
+        }
+    }
+
+    /// The probe attempt is being spent: at dispatch, or when the attempt's
+    /// own dependency phase crashed (that WAS the attempt).
+    void spend_probe() {
+        probe = false;
+    }
+
+    /// The attempt provably never ran (no expendable worker to host it):
+    /// keep the license so a later request retries.
+    void re_arm_probe() {
+        if(active()) {
+            probe = true;
+        }
+    }
+
+    /// True until the current quarantine spell has been announced to the
+    /// client; a document must never go silently dead.
+    bool needs_announcement() const {
+        return active() && !announced_spell;
+    }
+
+    void mark_announced() {
+        announced_spell = true;
+    }
+
+    /// The document was (re)opened: fresh content, fresh record.
+    void reset() {
+        streak = 0;
+        probe = false;
+        announced_spell = false;
+    }
+
+private:
+    unsigned streak = 0;
+    bool probe = false;
+    bool announced_spell = false;
+};
+
+/// Content-keyed crash budget for shared build artifacts (PCH, PCM).
+///
+/// A document quarantine cannot contain a poison preamble or module
+/// interface: the artifact is shared, so every dependent (or every session
+/// with the same preamble) would re-trigger the build and kill workers of
+/// its own. The budget is keyed by the artifact's content-derived cache key,
+/// which makes recovery structural: editing the poison content changes the
+/// key, and the fresh key starts with a fresh budget.
+class CrashBudget {
+public:
+    constexpr static unsigned threshold = Quarantine::threshold;
+
+    /// The artifact with this key has spent its budget: refuse to build it.
+    bool blocked(llvm::StringRef key) const {
+        auto it = crashes.find(key);
+        return it != crashes.end() && it->second >= threshold;
+    }
+
+    /// Building the artifact with this key killed a worker.
+    void on_crash(llvm::StringRef key) {
+        crashes[key] += 1;
+    }
+
+private:
+    /// Grows by one entry per crashing artifact key — bounded by edits of
+    /// poison content, so no eviction is needed.
+    llvm::StringMap<unsigned> crashes;
+};
+
+}  // namespace clice

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -41,16 +41,18 @@ public:
     class Flight {
         friend class Quarantine;
         unsigned inherited = 0;
+        unsigned inherited_total = 0;
     };
 
     /// Crashes currently blamed on this document's content.
     unsigned crashes() const {
-        return streak;
+        return streak + query_streak;
     }
 
-    /// The document has spent its crash budget.
+    /// The document has spent its crash budget: compile and query evidence
+    /// pool into one budget — both are this content killing workers.
     bool active() const {
-        return streak >= threshold;
+        return crashes() >= threshold;
     }
 
     /// Quarantined with no probe attempt armed: refuse dispatches.
@@ -67,6 +69,7 @@ public:
     Flight begin_flight() const {
         Flight flight;
         flight.inherited = streak;
+        flight.inherited_total = crashes();
         return flight;
     }
 
@@ -75,14 +78,34 @@ public:
     /// content). Used with active() to stop a request whose dependency
     /// phase already tipped the document into quarantine.
     bool grew(Flight flight) const {
-        return streak > flight.inherited;
+        return crashes() > flight.inherited_total;
     }
 
-    /// A full compile of the current content landed: the inherited evidence
-    /// is disproved, but crashes recorded during the flight will recur on
-    /// the next request and must keep accumulating toward quarantine.
+    /// A full compile of the current content landed: the inherited compile
+    /// evidence is disproved, but crashes recorded during the flight will
+    /// recur on the next request, and query evidence is untouched — the
+    /// compile succeeding says nothing about the queries that follow it.
     void land(Flight flight) {
         streak -= std::min(flight.inherited, streak);
+        if(!active()) {
+            announced_spell = false;
+        }
+    }
+
+    /// A query on this document's settled AST killed a worker. A separate
+    /// ledger from compile crashes: a successful compile does not disprove
+    /// it — the same AST crashes the same query again — so only a query
+    /// that answers (on_query_land) clears it. Without the split, the
+    /// crash-triggered recompile would land, launder the evidence, and the
+    /// next query would kill a worker again, forever.
+    void on_query_crash() {
+        query_streak += 1;
+    }
+
+    /// A query answered: queries on the current content provably do not
+    /// kill workers.
+    void on_query_land() {
+        query_streak = 0;
         if(!active()) {
             announced_spell = false;
         }
@@ -127,12 +150,14 @@ public:
     /// The document was (re)opened: fresh content, fresh record.
     void reset() {
         streak = 0;
+        query_streak = 0;
         probe = false;
         announced_spell = false;
     }
 
 private:
     unsigned streak = 0;
+    unsigned query_streak = 0;
     bool probe = false;
     bool announced_spell = false;
 };

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -116,9 +116,7 @@ public:
     /// compile succeeding says nothing about the dispatches it never ran.
     void land(Flight flight) {
         streak -= std::min(flight.inherited, streak);
-        if(!active()) {
-            announced_spell = false;
-        }
+        settle();
     }
 
     /// A dispatch of `kind` — a query against the settled AST, a stateless
@@ -139,9 +137,7 @@ public:
     /// provably does not kill workers.
     void on_kind_land(std::uint8_t kind) {
         kind_streaks.erase(kind);
-        if(!active()) {
-            announced_spell = false;
-        }
+        settle();
     }
 
     /// A content change grants a quarantined document one probe attempt.
@@ -190,6 +186,17 @@ public:
     }
 
 private:
+    /// Leaving quarantine retires the spell's state: the armed probe is a
+    /// license for a quarantine that no longer exists — left set, the next
+    /// spell would start with a free crashing dispatch and no edit — and
+    /// the announcement re-arms for the next spell.
+    void settle() {
+        if(!active()) {
+            probe = false;
+            announced_spell = false;
+        }
+    }
+
     /// Whether this death was already counted. Remembering only the most
     /// recent identity suffices: a peer teardown fails all of a death's
     /// in-flight requests in the same loop turn, so their errors arrive

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -71,18 +71,57 @@ public:
     /// Whether a compile is this quarantine's recovery attempt: the probe
     /// rides the dispatch that can disprove the evidence, and a compile
     /// disproves only compile strikes — a kind-quarantined document's
-    /// compile is ordinary work and must not spend the probe.
+    /// compile is ordinary work and must not spend the probe. Requires the
+    /// armed probe: a concurrent request that lost the race to spend it
+    /// holds no license.
     bool recovery_compile() const {
-        return active() && streak > 0;
+        return active() && streak > 0 && probe;
     }
 
     /// Whether a dispatch of `kind` is this quarantine's recovery attempt:
-    /// only a kind holding strikes can disprove them. A harmless hover on
-    /// a semantic-tokens-quarantined document must leave the probe for the
+    /// only a kind holding strikes can disprove them, and only while the
+    /// edit-granted probe is armed. A harmless hover on a
+    /// semantic-tokens-quarantined document must leave the probe for the
     /// semantic-tokens retry.
     bool recovery_kind(std::uint8_t kind) const {
-        return active() && kind_streaks.contains(kind);
+        return active() && kind_streaks.contains(kind) && probe;
     }
+
+    /// This kind holds strikes and no probe is armed: its dispatch is
+    /// neither licensed recovery nor safe ordinary work — refuse it.
+    bool kind_blocked(std::uint8_t kind) const {
+        return active() && kind_streaks.contains(kind) && !probe;
+    }
+
+    /// Holds a spent probe across a recovery dispatch: if the coroutine
+    /// unwinds (an LSP cancellation) before any attempt dispatched — no
+    /// new strikes recorded — the license is handed back, so a cancelled
+    /// recovery does not strand the document until another edit. Call
+    /// settle() once the outcome is known and owned by the call site.
+    class [[nodiscard]] ProbeGuard {
+    public:
+        explicit ProbeGuard(Quarantine& quarantine) :
+            quarantine(&quarantine), strikes(quarantine.crashes()) {
+            quarantine.spend_probe();
+        }
+
+        ProbeGuard(const ProbeGuard&) = delete;
+        ProbeGuard& operator=(const ProbeGuard&) = delete;
+
+        ~ProbeGuard() {
+            if(quarantine && quarantine->crashes() == strikes) {
+                quarantine->re_arm_probe();
+            }
+        }
+
+        void settle() {
+            quarantine = nullptr;
+        }
+
+    private:
+        Quarantine* quarantine;
+        unsigned strikes;
+    };
 
     /// A dispatch carrying this document's content killed a worker.
     /// `death` is the worker incarnation's identity (worker::death_of):

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -230,6 +230,13 @@ public:
         entry.last_crash = std::chrono::steady_clock::now();
     }
 
+    /// The artifact built: the key's strikes were transient, not poison —
+    /// without this, two unrelated hiccups far apart would block a key
+    /// that rebuilds fine in between.
+    void on_land(llvm::StringRef key) {
+        crashes.erase(key);
+    }
+
 private:
     struct Entry {
         unsigned count = 0;

--- a/src/server/state/quarantine.h
+++ b/src/server/state/quarantine.h
@@ -68,6 +68,22 @@ public:
         return active() && !probe;
     }
 
+    /// Whether a compile is this quarantine's recovery attempt: the probe
+    /// rides the dispatch that can disprove the evidence, and a compile
+    /// disproves only compile strikes — a kind-quarantined document's
+    /// compile is ordinary work and must not spend the probe.
+    bool recovery_compile() const {
+        return active() && streak > 0;
+    }
+
+    /// Whether a dispatch of `kind` is this quarantine's recovery attempt:
+    /// only a kind holding strikes can disprove them. A harmless hover on
+    /// a semantic-tokens-quarantined document must leave the probe for the
+    /// semantic-tokens retry.
+    bool recovery_kind(std::uint8_t kind) const {
+        return active() && kind_streaks.contains(kind);
+    }
+
     /// A dispatch carrying this document's content killed a worker.
     /// `death` is the worker incarnation's identity (worker::death_of):
     /// one process death fails every request in flight on it, and a death

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -78,6 +78,22 @@ struct Session {
     /// Used to detect stale compilation results (ABA prevention).
     std::uint64_t generation = 0;
 
+    /// A document whose compiles keep crashing workers is quarantined at
+    /// this many consecutive crashes: the crash budget lives on pool slots
+    /// but the poison lives in documents, and without the cut one document
+    /// burns slot after slot until the whole pool is dead.
+    constexpr static unsigned quarantine_threshold = 2;
+
+    /// Consecutive compiles of this document that crashed a worker. A
+    /// successful compile clears it; a content change below the threshold
+    /// restarts it (the new bytes owe nothing to the old ones).
+    unsigned compile_crash_streak = 0;
+
+    /// One compile attempt granted to a quarantined document by a content
+    /// change, consumed at dispatch. A crashing probe returns straight to
+    /// quarantine; a successful one clears the streak.
+    bool quarantine_probe = false;
+
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;
 

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -95,6 +95,13 @@ struct Session {
     /// quarantine; a successful one clears the streak.
     bool quarantine_probe = false;
 
+    /// Whether the quarantine diagnostic has been published for the current
+    /// quarantine spell. A quarantine reached outside the compile-failure
+    /// landing (a completion or PCH build) has no output of its own; the
+    /// next ensure_compiled announces it once instead of going silently
+    /// dead. Cleared when real output lands.
+    bool quarantine_announced = false;
+
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;
 

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "index/tu_index.h"
+#include "server/state/quarantine.h"
 #include "server/state/workspace.h"
 
 #include "kota/async/async.h"
@@ -78,29 +79,11 @@ struct Session {
     /// Used to detect stale compilation results (ABA prevention).
     std::uint64_t generation = 0;
 
-    /// A document whose compiles keep crashing workers is quarantined at
-    /// this many consecutive crashes: the crash budget lives on pool slots
-    /// but the poison lives in documents, and without the cut one document
-    /// burns slot after slot until the whole pool is dead.
-    constexpr static unsigned quarantine_threshold = 2;
-
-    /// Consecutive compiles of this document that crashed a worker. Only
-    /// a successful compile clears it — edits never do, or a poison file
-    /// under active editing would crash one worker per keystroke without
-    /// ever reaching quarantine. New content gets its say via the probe.
-    unsigned compile_crash_streak = 0;
-
-    /// One compile attempt granted to a quarantined document by a content
-    /// change, consumed at dispatch. A crashing probe returns straight to
-    /// quarantine; a successful one clears the streak.
-    bool quarantine_probe = false;
-
-    /// Whether the quarantine diagnostic has been published for the current
-    /// quarantine spell. A quarantine reached outside the compile-failure
-    /// landing (a completion or PCH build) has no output of its own; the
-    /// next ensure_compiled announces it once instead of going silently
-    /// dead. Cleared when real output lands.
-    bool quarantine_announced = false;
+    /// Crash containment for this document's content: the crash budget
+    /// lives on pool slots, but the poison lives in documents — without
+    /// the cut one document burns slot after slot until the whole pool is
+    /// dead. All transitions go through the type; see quarantine.h.
+    Quarantine quarantine;
 
     /// Whether the AST needs to be rebuilt before serving queries.
     bool ast_dirty = true;

--- a/src/server/state/session.h
+++ b/src/server/state/session.h
@@ -84,9 +84,10 @@ struct Session {
     /// burns slot after slot until the whole pool is dead.
     constexpr static unsigned quarantine_threshold = 2;
 
-    /// Consecutive compiles of this document that crashed a worker. A
-    /// successful compile clears it; a content change below the threshold
-    /// restarts it (the new bytes owe nothing to the old ones).
+    /// Consecutive compiles of this document that crashed a worker. Only
+    /// a successful compile clears it — edits never do, or a poison file
+    /// under active editing would crash one worker per keystroke without
+    /// ever reaching quarantine. New content gets its say via the probe.
     unsigned compile_crash_streak = 0;
 
     /// One compile attempt granted to a quarantined document by a content

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -59,28 +59,26 @@ void SessionStore::apply_change(Session& session,
                                 int version) {
     session.version = version;
 
-    // A content change re-arms a quarantined document with one probe
-    // attempt. It deliberately does NOT reset the streak: only a compile
-    // that succeeds proves the document healthy — resetting on edits
-    // would let a poison file under active editing crash a worker per
-    // keystroke and never reach quarantine.
-    if(session.compile_crash_streak >= Session::quarantine_threshold) {
-        session.quarantine_probe = true;
-    }
-
+    bool applied = false;
     for(auto& change: changes) {
         std::visit(
             [&](auto& c) {
                 using T = std::remove_cvref_t<decltype(c)>;
                 if constexpr(std::is_same_v<T, protocol::TextDocumentContentChangeWholeDocument>) {
-                    session.text = c.text;
+                    if(session.text != c.text) {
+                        session.text = c.text;
+                        applied = true;
+                    }
                 } else {
                     auto& range = c.range;
                     auto map = session.line_map();
                     auto start = map.to_offset(range.start);
                     auto end = map.to_offset(range.end);
                     if(start && end && *start <= *end) {
-                        session.text.replace(*start, *end - *start, c.text);
+                        if(llvm::StringRef(session.text).substr(*start, *end - *start) != c.text) {
+                            session.text.replace(*start, *end - *start, c.text);
+                            applied = true;
+                        }
                     } else {
                         // The client's view has drifted from ours (or the
                         // client is buggy). Drop the edit but keep serving:
@@ -98,6 +96,16 @@ void SessionStore::apply_change(Session& session,
                 session.line_starts = lsp::build_line_starts(session.text);
             },
             change);
+    }
+
+    // A real content change re-arms a quarantined document with one probe
+    // attempt — dropped or no-op edits grant none, or the unchanged poison
+    // bytes would be compiled again. It deliberately does NOT reset the
+    // streak: only a compile that succeeds proves the document healthy;
+    // resetting on edits would let a poison file under active editing
+    // crash a worker per keystroke and never reach quarantine.
+    if(applied && session.compile_crash_streak >= Session::quarantine_threshold) {
+        session.quarantine_probe = true;
     }
 
     session.generation++;

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -60,12 +60,12 @@ void SessionStore::apply_change(Session& session,
     session.version = version;
 
     // A content change re-arms a quarantined document with one probe
-    // attempt; below the threshold the streak simply restarts — the new
-    // bytes owe nothing to the old ones.
+    // attempt. It deliberately does NOT reset the streak: only a compile
+    // that succeeds proves the document healthy — resetting on edits
+    // would let a poison file under active editing crash a worker per
+    // keystroke and never reach quarantine.
     if(session.compile_crash_streak >= Session::quarantine_threshold) {
         session.quarantine_probe = true;
-    } else {
-        session.compile_crash_streak = 0;
     }
 
     for(auto& change: changes) {

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -50,9 +50,7 @@ void SessionStore::apply_open(Session& session, std::string text, int version) {
     session.text = std::move(text);
     session.line_starts = lsp::build_line_starts(session.text);
     session.generation++;
-    session.compile_crash_streak = 0;
-    session.quarantine_probe = false;
-    session.quarantine_announced = false;
+    session.quarantine.reset();
 }
 
 void SessionStore::apply_change(Session& session,
@@ -100,14 +98,8 @@ void SessionStore::apply_change(Session& session,
     }
 
     // A real content change re-arms a quarantined document with one probe
-    // attempt — dropped or no-op edits grant none, or the unchanged poison
-    // bytes would be compiled again. It deliberately does NOT reset the
-    // streak: only a compile that succeeds proves the document healthy;
-    // resetting on edits would let a poison file under active editing
-    // crash a worker per keystroke and never reach quarantine.
-    if(applied && session.compile_crash_streak >= Session::quarantine_threshold) {
-        session.quarantine_probe = true;
-    }
+    // attempt; dropped or no-op edits grant none (see Quarantine::on_edit).
+    session.quarantine.on_edit(applied);
 
     session.generation++;
     session.ast_dirty = true;

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -50,12 +50,23 @@ void SessionStore::apply_open(Session& session, std::string text, int version) {
     session.text = std::move(text);
     session.line_starts = lsp::build_line_starts(session.text);
     session.generation++;
+    session.compile_crash_streak = 0;
+    session.quarantine_probe = false;
 }
 
 void SessionStore::apply_change(Session& session,
                                 llvm::ArrayRef<protocol::TextDocumentContentChangeEvent> changes,
                                 int version) {
     session.version = version;
+
+    // A content change re-arms a quarantined document with one probe
+    // attempt; below the threshold the streak simply restarts — the new
+    // bytes owe nothing to the old ones.
+    if(session.compile_crash_streak >= Session::quarantine_threshold) {
+        session.quarantine_probe = true;
+    } else {
+        session.compile_crash_streak = 0;
+    }
 
     for(auto& change: changes) {
         std::visit(

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -52,6 +52,7 @@ void SessionStore::apply_open(Session& session, std::string text, int version) {
     session.generation++;
     session.compile_crash_streak = 0;
     session.quarantine_probe = false;
+    session.quarantine_announced = false;
 }
 
 void SessionStore::apply_change(Session& session,

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -18,6 +18,7 @@
 #include "semantic/relation_kind.h"
 #include "server/compiler/compile_graph.h"
 #include "server/state/config.h"
+#include "server/state/quarantine.h"
 #include "support/cache_store.h"
 #include "support/path_pool.h"
 #include "syntax/dependency_graph.h"
@@ -225,6 +226,13 @@ struct Workspace {
     /// so files with identical preambles share one PCH.  Hot-path mirror
     /// of CacheStore state; blob paths come from the store.
     llvm::StringMap<PCHState> pch_cache;
+
+    /// Crash budget for shared build artifacts (PCH/PCM), keyed by the
+    /// same content-derived cache keys: an artifact that keeps killing
+    /// workers is refused until its content — and therefore its key —
+    /// changes. Document quarantine cannot contain these: the artifact is
+    /// shared, so every dependent would burn workers of its own.
+    CrashBudget build_crashes;
 
     /// PCM cache, keyed by module source path_id.
     llvm::DenseMap<std::uint32_t, PCMState> pcm_cache;

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -169,7 +169,7 @@ void MasterServer::wire() {
         dispatch(FileEvent::worker_crashed(info.lost_documents));
     };
 
-    pool.on_evicted = [this](const std::string& path) {
+    pool.on_evicted = [this](const std::string& path, std::size_t worker_index) {
         auto it = workspace.path_pool.cache.find(path);
         if(it == workspace.path_pool.cache.end()) {
             LOG_WARN("Evicted path not in pool: {}", path);
@@ -178,8 +178,14 @@ void MasterServer::wire() {
         // Owner-table upkeep is pool-domain state and stays here; the
         // session-side consequence (the worker's AST is gone, same as a
         // crash) goes through the event pipeline like any invalidation.
-        pool.remove_owner(it->second);
-        dispatch(FileEvent::document_evicted(it->second));
+        // Only the current owner's eviction counts: a stale copy left
+        // behind by a probe reassignment says nothing about the document
+        // the new owner still holds.
+        if(pool.remove_owner_from(it->second, worker_index)) {
+            dispatch(FileEvent::document_evicted(it->second));
+        } else {
+            LOG_INFO("Ignoring eviction of {} from non-owner worker {}", path, worker_index);
+        }
     };
 
     compiler.on_indexing_needed = [this]() {

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -160,7 +160,8 @@ kota::task<> MasterServer::workspace_poll_task() {
 void MasterServer::wire() {
     pool.on_crash = [this](const WorkerCrashInfo& info) {
         // A stateless crash loses only in-flight requests, which fail back
-        // to their callers (send_stateless already retries once). No state
+        // to their callers with dispatch_errc::worker_crashed — the compiler
+        // resends idempotent builds, the indexer requeues the file. No state
         // outlives the request, so there is nothing to invalidate and no
         // event to dispatch.
         if(!info.stateful)

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -140,11 +140,18 @@ std::optional<WorkerPool::SpawnedProcess> WorkerPool::spawn_process(const std::s
 }
 
 void WorkerPool::install_evict_handler(WorkerProcess& worker, std::size_t index) {
-    worker.peer->on_notification([this, index](const worker::EvictedParams& params) {
-        if(on_evicted) {
-            on_evicted(params.path, index);
-        }
-    });
+    worker.peer->on_notification(
+        [this, index, gen = worker.generation](const worker::EvictedParams& params) {
+            // A buffered eviction from a dead peer can drain after the slot
+            // respawned and reacquired the same path; matching by slot index
+            // alone would unseat the new owner.
+            if(stateful_workers[index].generation != gen) {
+                return;
+            }
+            if(on_evicted) {
+                on_evicted(params.path, index);
+            }
+        });
 }
 
 bool WorkerPool::spawn_worker(bool stateful) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -87,6 +87,12 @@ std::size_t WorkerPool::stateless_capacity() const {
     });
 }
 
+std::size_t WorkerPool::stateless_footprint() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state != SlotState::Dead && w.state != SlotState::Retired;
+    });
+}
+
 std::optional<WorkerPool::SpawnedProcess> WorkerPool::spawn_process(const std::string& name,
                                                                     bool stateful) {
     kota::process::options opts;
@@ -869,10 +875,7 @@ bool WorkerPool::scale_up_worker() {
     // worker still holds its process until the monitor reaps it, and a
     // replacement spawned beside it would push the pool past max_stateless
     // during exactly the memory pressure that triggered the retirement.
-    auto footprint = std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
-        return w.state != SlotState::Dead && w.state != SlotState::Retired;
-    });
-    if(static_cast<std::size_t>(footprint) >= options.max_stateless)
+    if(stateless_footprint() >= options.max_stateless)
         return false;
 
     // A Dead slot is capacity already allocated, just waiting out its

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -63,6 +63,12 @@ std::size_t WorkerPool::alive_stateless() const {
     });
 }
 
+std::size_t WorkerPool::schedulable_stateless() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state == SlotState::Alive && !w.retiring;
+    });
+}
+
 std::size_t WorkerPool::busy_stateless() const {
     return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
         return w.state == SlotState::Alive && w.busy;

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -393,6 +393,14 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     }
 }
 
+void WorkerPool::reset_streak_if_healthy(WorkerProcess& w) {
+    auto now = std::chrono::steady_clock::now();
+    if(w.spawn_time != std::chrono::steady_clock::time_point{} &&
+       now - w.spawn_time >= options.healthy_uptime) {
+        w.crash_streak = 0;
+    }
+}
+
 bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal) {
     auto& workers = stateful ? stateful_workers : stateless_workers;
     auto& w = workers[index];
@@ -451,13 +459,7 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
         }
     }
 
-    // A worker that ran healthily for a while starts a fresh streak: the
-    // budget bounds crash loops, not lifetime bad luck.
-    auto now = std::chrono::steady_clock::now();
-    if(w.spawn_time != std::chrono::steady_clock::time_point{} &&
-       now - w.spawn_time >= options.healthy_uptime) {
-        w.crash_streak = 0;
-    }
+    reset_streak_if_healthy(w);
     w.crash_streak += 1;
 
     WorkerCrashInfo info;
@@ -841,6 +843,10 @@ void WorkerPool::preempt_low_priority(std::size_t count) {
         // keeps the classification correct without depending on that.
         auto source = w.preempt_source;
         w.preempted = true;
+        // The preempt respawn skips crash accounting, so credit a healthy
+        // run here the same way a crash would — the slot must not carry a
+        // stale streak past the healthy interval that already cleared it.
+        reset_streak_if_healthy(w);
         if(source)
             source->cancel();
         mark_worker_dead(i, false, true);

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -834,11 +834,16 @@ void WorkerPool::preempt_low_priority(std::size_t count) {
 
         // Signal the sender first, then take the slot out of rotation and
         // kill the process — the kill is what actually frees the memory.
+        // The kill fails the in-flight request, and the sender classifies
+        // that failure as preemption by consulting the source. Today the
+        // runtime only queues waiters on cancel/close (never resumes them
+        // inline), so either order behaves the same; cancelling first
+        // keeps the classification correct without depending on that.
         auto source = w.preempt_source;
         w.preempted = true;
-        mark_worker_dead(i, false, true);
         if(source)
             source->cancel();
+        mark_worker_dead(i, false, true);
         ++preempted;
     }
     if(preempted > 0) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -307,14 +307,24 @@ std::size_t WorkerPool::assign_expendable(std::uint32_t path_id) {
         return it->second;
     }
 
-    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
-        if(!expendable(i)) {
-            continue;
-        }
+    auto take = [&](std::size_t i) {
         remove_owner(path_id);
         owner[path_id] = i;
         stateful_workers[i].owned_documents += 1;
         return i;
+    };
+
+    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
+        if(expendable(i)) {
+            return take(i);
+        }
+    }
+
+    // A single-worker pool has nothing to preserve by refusing: run the
+    // probe there — the occasional respawn beats quarantining the document
+    // until the session reopens.
+    if(stateful_workers.size() == 1 && stateful_workers[0].state == SlotState::Alive) {
+        return take(0);
     }
     return SIZE_MAX;
 }

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -220,10 +220,13 @@ bool WorkerPool::start(const WorkerPoolOptions& opts) {
     // Resolve auto max_stateless (0 = CPU cores).
     if(options.max_stateless == 0)
         options.max_stateless = kota::sys::parallelism();
+    options.max_stateless = std::max(options.max_stateless, options.stateless_count);
     if(options.min_stateless == 0)
         options.min_stateless = 1;
-    options.min_stateless = std::min(options.min_stateless, options.stateless_count);
-    options.max_stateless = std::max(options.max_stateless, options.stateless_count);
+    // The configured floor is honored even above the startup count: idle
+    // scale-down must not shrink a scaled-up pool below it. Only the
+    // ceiling bounds it.
+    options.min_stateless = std::min(options.min_stateless, options.max_stateless);
 
     low_limit = max_low_limit();
 

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -602,7 +602,7 @@ void WorkerPool::give_up_slot(std::size_t index, bool stateful) {
     // Revival is a running-pool concern: unit fixtures drive slot state
     // without an event loop, and a coroutine queued on a never-run loop
     // outlives the pool.
-    if(started && options.revive_after.count() > 0) {
+    if(revives_slots()) {
         worker_tasks.spawn(revive_slot(index, stateful));
     }
 }
@@ -868,9 +868,34 @@ bool WorkerPool::scale_up_worker() {
     if(stateless_capacity() >= options.max_stateless)
         return false;
 
-    if(!spawn_worker(false)) {
-        LOG_WARN("scale_up: spawn_worker failed");
-        return false;
+    // A Dead slot is capacity already allocated, just waiting out its
+    // revival cooldown; under scale-up pressure revive it now instead of
+    // appending a fresh slot beside it — the cooldown revival would later
+    // fire too and grow the pool past what saturation asked for. The
+    // pending revive_slot task no-ops once the state is no longer Dead.
+    auto dead = std::ranges::find(stateless_workers, SlotState::Dead, &WorkerProcess::state);
+    if(dead != stateless_workers.end()) {
+        auto index = static_cast<std::size_t>(dead - stateless_workers.begin());
+        dead->crash_streak = 0;
+        dead->state = SlotState::Respawning;
+        if(!respawn_worker(index, false)) {
+            // Back to Dead with a fresh cooldown revival armed, so a failed
+            // early revive does not orphan the slot.
+            give_up_slot(index, false);
+            LOG_WARN("scale_up: revive of {} failed", stateless_workers[index].name);
+            return false;
+        }
+        LOG_INFO("Scaled up: revived {} (alive={})",
+                 stateless_workers[index].name,
+                 alive_stateless());
+    } else {
+        if(!spawn_worker(false)) {
+            LOG_WARN("scale_up: spawn_worker failed");
+            return false;
+        }
+        LOG_INFO("Scaled up: spawned {} (alive={})",
+                 stateless_workers.back().name,
+                 alive_stateless());
     }
 
     // The new worker raises the ceiling; grow the low allowance by exactly
@@ -878,8 +903,6 @@ bool WorkerPool::scale_up_worker() {
     // backoff state accumulated.
     low_limit = std::min(low_limit + 1, max_low_limit());
     try_dispatch_pending();
-
-    LOG_INFO("Scaled up: spawned {} (alive={})", stateless_workers.back().name, alive_stateless());
     return true;
 }
 

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -865,7 +865,14 @@ void WorkerPool::apply_crash_backoff() {
 }
 
 bool WorkerPool::scale_up_worker() {
-    if(stateless_capacity() >= options.max_stateless)
+    // The ceiling bounds live processes, not schedulable slots: a retiring
+    // worker still holds its process until the monitor reaps it, and a
+    // replacement spawned beside it would push the pool past max_stateless
+    // during exactly the memory pressure that triggered the retirement.
+    auto footprint = std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state != SlotState::Dead && w.state != SlotState::Retired;
+    });
+    if(static_cast<std::size_t>(footprint) >= options.max_stateless)
         return false;
 
     // A Dead slot is capacity already allocated, just waiting out its

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -876,23 +876,21 @@ bool WorkerPool::scale_up_worker() {
     auto dead = std::ranges::find(stateless_workers, SlotState::Dead, &WorkerProcess::state);
     if(dead != stateless_workers.end()) {
         auto index = static_cast<std::size_t>(dead - stateless_workers.begin());
-        dead->crash_streak = 0;
-        dead->state = SlotState::Respawning;
+        auto& w = *dead;
+        w.crash_streak = 0;
+        w.state = SlotState::Respawning;
         if(!respawn_worker(index, false)) {
             // Back to Dead with a fresh cooldown revival armed, so a failed
             // early revive does not orphan the slot.
             give_up_slot(index, false);
-            LOG_WARN("scale_up: revive of {} failed", stateless_workers[index].name);
+            LOG_WARN("scale_up: revive of {} failed", w.name);
             return false;
         }
-        LOG_INFO("Scaled up: revived {} (alive={})",
-                 stateless_workers[index].name,
-                 alive_stateless());
+        LOG_INFO("Scaled up: revived {} (alive={})", w.name, alive_stateless());
+    } else if(!spawn_worker(false)) {
+        LOG_WARN("scale_up: spawn_worker failed");
+        return false;
     } else {
-        if(!spawn_worker(false)) {
-            LOG_WARN("scale_up: spawn_worker failed");
-            return false;
-        }
         LOG_INFO("Scaled up: spawned {} (alive={})",
                  stateless_workers.back().name,
                  alive_stateless());

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -139,10 +139,10 @@ std::optional<WorkerPool::SpawnedProcess> WorkerPool::spawn_process(const std::s
     return SpawnedProcess{std::move(spawn.proc), std::move(peer)};
 }
 
-void WorkerPool::install_evict_handler(WorkerProcess& worker) {
-    worker.peer->on_notification([this](const worker::EvictedParams& params) {
+void WorkerPool::install_evict_handler(WorkerProcess& worker, std::size_t index) {
+    worker.peer->on_notification([this, index](const worker::EvictedParams& params) {
         if(on_evicted) {
-            on_evicted(params.path);
+            on_evicted(params.path, index);
         }
     });
 }
@@ -165,7 +165,7 @@ bool WorkerPool::spawn_worker(bool stateful) {
     });
 
     if(stateful)
-        install_evict_handler(workers[index]);
+        install_evict_handler(workers[index], index);
     worker_tasks.spawn(monitor_worker(index, stateful));
     return true;
 }
@@ -192,7 +192,7 @@ bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
     // until a healthy uptime resets it.
 
     if(stateful)
-        install_evict_handler(w);
+        install_evict_handler(w, index);
     worker_tasks.spawn(monitor_worker(index, stateful));
 
     if(!stateful)
@@ -336,16 +336,26 @@ std::size_t WorkerPool::assign_expendable(std::uint32_t path_id) {
 }
 
 std::size_t WorkerPool::pick_least_loaded() {
-    std::size_t best = SIZE_MAX;
-    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
-        if(stateful_workers[i].state != SlotState::Alive)
-            continue;
-        if(best == SIZE_MAX ||
-           stateful_workers[i].owned_documents < stateful_workers[best].owned_documents) {
-            best = i;
+    // Two passes: a worker hosting an in-flight quarantine probe is a
+    // known crash risk, so new documents are pinned elsewhere while any
+    // other live worker exists — a probe crash must not take a freshly
+    // opened healthy document with it.
+    for(bool allow_suspect: {false, true}) {
+        std::size_t best = SIZE_MAX;
+        for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
+            auto& w = stateful_workers[i];
+            if(w.state != SlotState::Alive)
+                continue;
+            if(!allow_suspect && w.suspect_inflight > 0)
+                continue;
+            if(best == SIZE_MAX || w.owned_documents < stateful_workers[best].owned_documents) {
+                best = i;
+            }
         }
+        if(best != SIZE_MAX)
+            return best;
     }
-    return best;
+    return SIZE_MAX;
 }
 
 void WorkerPool::remove_owner(std::uint32_t path_id) {
@@ -356,6 +366,16 @@ void WorkerPool::remove_owner(std::uint32_t path_id) {
     auto worker_idx = it->second;
     stateful_workers[worker_idx].owned_documents -= 1;
     owner.erase(it);
+}
+
+bool WorkerPool::remove_owner_from(std::uint32_t path_id, std::size_t worker_index) {
+    auto it = owner.find(path_id);
+    if(it == owner.end() || it->second != worker_index)
+        return false;
+
+    stateful_workers[worker_index].owned_documents -= 1;
+    owner.erase(it);
+    return true;
 }
 
 void WorkerPool::clear_owner(std::size_t worker_index) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -144,7 +144,12 @@ void WorkerPool::install_evict_handler(WorkerProcess& worker, std::size_t index)
         [this, index, gen = worker.generation](const worker::EvictedParams& params) {
             // A buffered eviction from a dead peer can drain after the slot
             // respawned and reacquired the same path; matching by slot index
-            // alone would unseat the new owner.
+            // alone would unseat the new owner. A same-generation ABA (a
+            // live worker's stale-copy eviction draining after a probe
+            // reassigned the path back to it) is accepted: the notification
+            // carries no ownership epoch, the window is one notification
+            // drain, and the cost is one spurious invalidation-recompile —
+            // not corrupted state.
             if(stateful_workers[index].generation != gen) {
                 return;
             }

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -223,6 +223,7 @@ bool WorkerPool::start(const WorkerPoolOptions& opts) {
 
     worker_tasks.spawn(kota::with_token(monitor_loop(), stop_scope.token()));
 
+    started = true;
     LOG_INFO("WorkerPool started: {} stateless, {} stateful workers",
              stateless_workers.size(),
              stateful_workers.size());
@@ -286,6 +287,36 @@ std::size_t WorkerPool::assign_worker(std::uint32_t path_id) {
     owner[path_id] = selected;
     stateful_workers[selected].owned_documents += 1;
     return selected;
+}
+
+std::size_t WorkerPool::assign_expendable(std::uint32_t path_id) {
+    auto expendable = [&](std::size_t i) {
+        if(stateful_workers[i].state != SlotState::Alive) {
+            return false;
+        }
+        for(auto& [pid, widx]: owner) {
+            if(widx == i && pid != path_id) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Keep the current owner when sacrificing it risks nothing.
+    if(auto it = owner.find(path_id); it != owner.end() && expendable(it->second)) {
+        return it->second;
+    }
+
+    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
+        if(!expendable(i)) {
+            continue;
+        }
+        remove_owner(path_id);
+        owner[path_id] = i;
+        stateful_workers[i].owned_documents += 1;
+        return i;
+    }
+    return SIZE_MAX;
 }
 
 std::size_t WorkerPool::pick_least_loaded() {
@@ -466,7 +497,14 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     }
 
     reset_streak_if_healthy(w);
-    w.crash_streak += 1;
+    // A crash while a suspect request (a quarantined document's probe) was
+    // in flight says something about the document, not the slot: respawn
+    // with the streak untouched, like a preemption.
+    bool suspect = w.suspect_inflight > 0;
+    w.suspect_inflight = 0;
+    if(!suspect) {
+        w.crash_streak += 1;
+    }
 
     WorkerCrashInfo info;
     info.worker_index = index;
@@ -551,6 +589,30 @@ void WorkerPool::give_up_slot(std::size_t index, bool stateful) {
         // can return an error instead of hanging.
         try_dispatch_pending();
     }
+    // Revival is a running-pool concern: unit fixtures drive slot state
+    // without an event loop, and a coroutine queued on a never-run loop
+    // outlives the pool.
+    if(started && options.revive_after.count() > 0) {
+        worker_tasks.spawn(revive_slot(index, stateful));
+    }
+}
+
+kota::task<> WorkerPool::revive_slot(std::size_t index, bool stateful) {
+    co_await kota::with_token(kota::sleep(options.revive_after, loop), stop_scope.token());
+    if(stop_scope.cancelled()) {
+        co_return;
+    }
+    auto& w = stateful ? stateful_workers[index] : stateless_workers[index];
+    if(w.state != SlotState::Dead) {
+        co_return;
+    }
+    // A fresh budget, not a pardon: if the workload that killed the slot is
+    // still around, the budget bounds the damage again and the next revival
+    // is one cooldown away.
+    LOG_INFO("Worker {} reviving after cooldown", w.name);
+    w.crash_streak = 0;
+    w.state = SlotState::Respawning;
+    worker_tasks.spawn(respawn_after(index, stateful, std::chrono::milliseconds(0)));
 }
 
 std::size_t WorkerPool::claim_stateless(std::size_t index, worker::Priority priority) {

--- a/src/server/worker/worker_pool.cpp
+++ b/src/server/worker/worker_pool.cpp
@@ -49,27 +49,50 @@ kota::task<> drain_stderr(kota::pipe stderr_pipe, std::string prefix) {
     }
 }
 
+/// IO pump wrapper owning a peer reference, so the peer object outlives its
+/// own run() coroutine no matter when the slot drops its copy.
+kota::task<> run_peer(std::shared_ptr<kota::ipc::BincodePeer> peer) {
+    co_await peer->run();
+}
+
 }  // namespace
 
-bool WorkerPool::spawn_worker(const std::string& self_path,
-                              bool stateful,
-                              std::uint64_t memory_limit) {
-    auto& workers = stateful ? stateful_workers : stateless_workers;
-    auto worker_index = workers.size();
-    std::string worker_name = std::string(stateful ? "SF-" : "SL-") + std::to_string(worker_index);
+std::size_t WorkerPool::alive_stateless() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state == SlotState::Alive;
+    });
+}
 
+std::size_t WorkerPool::busy_stateless() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state == SlotState::Alive && w.busy;
+    });
+}
+
+std::size_t WorkerPool::low_busy_count() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state == SlotState::Alive && w.busy && w.low_priority;
+    });
+}
+
+std::size_t WorkerPool::stateless_capacity() const {
+    return std::ranges::count_if(stateless_workers, [](const WorkerProcess& w) {
+        return w.state != SlotState::Dead && w.state != SlotState::Retired && !w.retiring;
+    });
+}
+
+std::optional<WorkerPool::SpawnedProcess> WorkerPool::spawn_process(const std::string& name,
+                                                                    bool stateful) {
     kota::process::options opts;
-    opts.file = self_path;
-    opts.args = {self_path, "worker"};
+    opts.file = options.self_path;
+    opts.args = {options.self_path, "worker"};
     if(stateful) {
         opts.args.push_back("--stateful");
         opts.args.push_back("--memory-limit");
-        opts.args.push_back(std::to_string(memory_limit));
+        opts.args.push_back(std::to_string(options.worker_memory_limit));
     }
-
     opts.args.push_back("--worker-name");
-    opts.args.push_back(worker_name);
-
+    opts.args.push_back(name);
     if(!log_dir.empty()) {
         opts.args.push_back("--log-dir");
         opts.args.push_back(log_dir);
@@ -84,36 +107,86 @@ bool WorkerPool::spawn_worker(const std::string& self_path,
     auto result = kota::process::spawn(opts, loop);
     if(!result) {
         LOG_ANOMALY(WorkerSpawnFail,
-                    "Failed to spawn {} worker: {}",
-                    stateful ? "stateful" : "stateless",
+                    "Failed to spawn worker {}: {}",
+                    name,
                     result.error().message());
-        return false;
+        return std::nullopt;
     }
 
     auto& spawn = *result;
 
-    // StreamTransport: input = child's stdout (parent reads), output = child's stdin (parent
-    // writes)
+    // StreamTransport: input = child's stdout (parent reads), output = child's
+    // stdin (parent writes).
     auto transport = std::make_unique<kota::ipc::StreamTransport>(std::move(spawn.stdout_pipe),
                                                                   std::move(spawn.stdin_pipe));
-    auto peer = std::make_unique<kota::ipc::BincodePeer>(loop, std::move(transport));
+    auto peer = std::make_shared<kota::ipc::BincodePeer>(loop, std::move(transport));
 
-    std::string prefix = "[" + worker_name + "]";
-    worker_tasks.spawn(drain_stderr(std::move(spawn.stderr_pipe), prefix));
+    worker_tasks.spawn(drain_stderr(std::move(spawn.stderr_pipe), "[" + name + "]"));
+    worker_tasks.spawn(run_peer(peer));
+
+    return SpawnedProcess{std::move(spawn.proc), std::move(peer)};
+}
+
+void WorkerPool::install_evict_handler(WorkerProcess& worker) {
+    worker.peer->on_notification([this](const worker::EvictedParams& params) {
+        if(on_evicted) {
+            on_evicted(params.path);
+        }
+    });
+}
+
+bool WorkerPool::spawn_worker(bool stateful) {
+    auto& workers = stateful ? stateful_workers : stateless_workers;
+    auto index = workers.size();
+    auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
+
+    auto spawned = spawn_process(name, stateful);
+    if(!spawned)
+        return false;
 
     workers.push_back(WorkerProcess{
-        .proc = std::move(spawn.proc),
-        .peer = std::move(peer),
-        .name = worker_name,
-        .owned_documents = 0,
+        .proc = std::move(spawned->proc),
+        .peer = std::move(spawned->peer),
+        .name = name,
+        .state = SlotState::Alive,
+        .spawn_time = std::chrono::steady_clock::now(),
     });
 
-    auto& w = workers.back();
-    w.alive = true;
-    if(!stateful)
-        alive_stateless_count += 1;
-    worker_tasks.spawn(w.peer->run());
+    if(stateful)
+        install_evict_handler(workers[index]);
+    worker_tasks.spawn(monitor_worker(index, stateful));
+    return true;
+}
 
+bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
+    auto& workers = stateful ? stateful_workers : stateless_workers;
+    auto name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
+
+    auto spawned = spawn_process(name, stateful);
+    if(!spawned)
+        return false;
+
+    auto& w = workers[index];
+    w.proc = std::move(spawned->proc);
+    w.peer = std::move(spawned->peer);
+    w.state = SlotState::Alive;
+    w.owned_documents = 0;
+    w.busy = false;
+    w.low_priority = false;
+    w.retiring = false;
+    w.preempted = false;
+    w.spawn_time = std::chrono::steady_clock::now();
+    // generation was bumped at death; crash_streak carries across restarts
+    // until a healthy uptime resets it.
+
+    if(stateful)
+        install_evict_handler(w);
+    worker_tasks.spawn(monitor_worker(index, stateful));
+
+    if(!stateful)
+        try_dispatch_pending();
+
+    LOG_INFO("Worker {} restarted (crash streak {})", w.name, w.crash_streak);
     return true;
 }
 
@@ -121,30 +194,15 @@ bool WorkerPool::start(const WorkerPoolOptions& opts) {
     options = opts;
     log_dir = opts.log_dir;
 
-    stateless_workers.reserve(options.stateless_count);
-    stateful_workers.reserve(options.stateful_count);
-
     for(std::uint32_t i = 0; i < options.stateless_count; ++i) {
-        if(!spawn_worker(options.self_path, false, 0)) {
+        if(!spawn_worker(false)) {
             return false;
         }
-        worker_tasks.spawn(monitor_worker(stateless_workers.size() - 1, false));
     }
-
     for(std::uint32_t i = 0; i < options.stateful_count; ++i) {
-        if(!spawn_worker(options.self_path, true, options.worker_memory_limit)) {
+        if(!spawn_worker(true)) {
             return false;
         }
-        worker_tasks.spawn(monitor_worker(stateful_workers.size() - 1, true));
-    }
-
-    // Register evicted notification handler for each stateful worker
-    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
-        stateful_workers[i].peer->on_notification([this](const worker::EvictedParams& params) {
-            if(on_evicted) {
-                on_evicted(params.path);
-            }
-        });
     }
 
     // Resolve auto max_stateless (0 = CPU cores).
@@ -155,15 +213,9 @@ bool WorkerPool::start(const WorkerPoolOptions& opts) {
     options.min_stateless = std::min(options.min_stateless, options.stateless_count);
     options.max_stateless = std::max(options.max_stateless, options.stateless_count);
 
-    // Reserve one worker for high-priority requests by capping low-priority
-    // concurrency to N-1. With a single worker this collapses to 1: both
-    // priorities share it, and high wins only via queue ordering.
-    max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
-    low_limit = max_low_limit;
+    low_limit = max_low_limit();
 
-    slot_cancel_sources.resize(stateless_workers.size());
-
-    worker_tasks.spawn(kota::with_token(monitor_memory(), stop_scope.token()));
+    worker_tasks.spawn(kota::with_token(monitor_loop(), stop_scope.token()));
 
     LOG_INFO("WorkerPool started: {} stateless, {} stateful workers",
              stateless_workers.size(),
@@ -176,8 +228,6 @@ kota::task<> WorkerPool::stop() {
     stop_scope.cancel();
     fail_pending_requests();
 
-    // Retired workers (scale-down) have their peer moved to retired_peers
-    // and their process already exited — skip them to avoid null deref / SEGV.
     for(auto& w: stateless_workers)
         if(w.peer)
             w.peer->close_output();
@@ -185,11 +235,12 @@ kota::task<> WorkerPool::stop() {
         if(w.peer)
             w.peer->close_output();
 
+    // Dying slots were already SIGKILLed; vacant slots have no process.
     for(auto& w: stateless_workers)
-        if(w.alive)
+        if(w.state == SlotState::Alive)
             w.proc.kill(SIGTERM);
     for(auto& w: stateful_workers)
-        if(w.alive)
+        if(w.state == SlotState::Alive)
             w.proc.kill(SIGTERM);
 
     // A wedged worker that ignores SIGTERM would otherwise block the join
@@ -209,10 +260,10 @@ kota::task<> WorkerPool::kill_stragglers() {
     LOG_WARN("Workers still alive 5s after SIGTERM; escalating to SIGKILL");
     // 9 == SIGKILL by value; Windows' <csignal> does not define the macro.
     for(auto& w: stateless_workers)
-        if(w.alive)
+        if(w.state == SlotState::Alive)
             w.proc.kill(9);
     for(auto& w: stateful_workers)
-        if(w.alive)
+        if(w.state == SlotState::Alive)
             w.proc.kill(9);
 }
 
@@ -222,19 +273,21 @@ std::size_t WorkerPool::assign_worker(std::uint32_t path_id) {
         return it->second;
     }
 
-    // New assignment: pick the least-loaded worker
+    // New assignment: pick the least-loaded live worker.
     auto selected = pick_least_loaded();
+    if(selected == SIZE_MAX)
+        return SIZE_MAX;
     owner[path_id] = selected;
     stateful_workers[selected].owned_documents += 1;
     return selected;
 }
 
 std::size_t WorkerPool::pick_least_loaded() {
-    std::size_t best = 0;
-    for(std::size_t i = 1; i < stateful_workers.size(); ++i) {
-        if(!stateful_workers[i].alive)
+    std::size_t best = SIZE_MAX;
+    for(std::size_t i = 0; i < stateful_workers.size(); ++i) {
+        if(stateful_workers[i].state != SlotState::Alive)
             continue;
-        if(!stateful_workers[best].alive ||
+        if(best == SIZE_MAX ||
            stateful_workers[i].owned_documents < stateful_workers[best].owned_documents) {
             best = i;
         }
@@ -264,6 +317,27 @@ void WorkerPool::clear_owner(std::size_t worker_index) {
     }
 }
 
+void WorkerPool::mark_worker_dead(std::size_t index, bool stateful, bool kill_process) {
+    auto& w = stateful ? stateful_workers[index] : stateless_workers[index];
+    if(w.state != SlotState::Alive)
+        return;
+
+    w.state = SlotState::Dying;
+    w.generation += 1;
+    w.busy = false;
+    w.low_priority = false;
+    w.preempt_source.reset();
+    if(w.peer) {
+        w.peer->close();
+        w.peer.reset();
+    }
+    if(kill_process) {
+        // Make sure the process is really gone so monitor_worker's
+        // proc.wait() is guaranteed to deliver a verdict.
+        w.proc.kill(9);
+    }
+}
+
 kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     auto& workers = stateful ? stateful_workers : stateless_workers;
 
@@ -272,26 +346,20 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
     if(stop_scope.cancelled())
         co_return;
 
-    // Intentional retirement (scale-down): skip crash processing and respawn.
+    // Intentional retirement (scale-down): the slot becomes permanently
+    // vacant without crash processing.
     if(!stateful && workers[index].retiring) {
-        LOG_INFO("Worker {} retired gracefully", workers[index].name);
-        workers[index].alive = false;
-        alive_stateless_count -= 1;
-        if(workers[index].busy) {
-            if(workers[index].low_priority)
-                low_busy_count -= 1;
-            workers[index].busy = false;
-            workers[index].low_priority = false;
-            stateless_busy_count -= 1;
+        auto& w = workers[index];
+        LOG_INFO("Worker {} retired gracefully", w.name);
+        w.state = SlotState::Retired;
+        w.retiring = false;
+        w.generation += 1;
+        w.busy = false;
+        w.low_priority = false;
+        if(w.peer) {
+            w.peer->close();
+            w.peer.reset();
         }
-        if(workers[index].peer) {
-            workers[index].peer->close();
-            retired_peers.push_back(std::move(workers[index].peer));
-        }
-        max_low_limit =
-            alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
-        if(low_limit > max_low_limit)
-            low_limit = max_low_limit;
         co_return;
     }
 
@@ -304,27 +372,31 @@ kota::task<> WorkerPool::monitor_worker(std::size_t index, bool stateful) {
         exit_signal = 9;
     }
 
+    bool preempted = workers[index].preempted;
+    mark_worker_dead(index, stateful, false);
+    workers[index].preempted = false;
+
+    if(preempted) {
+        // The pool killed this worker on purpose to reclaim its memory; the
+        // work it lost was signalled to its sender. Bring the capacity back
+        // immediately, without touching the crash budget.
+        LOG_INFO("Worker {} preempted for memory pressure, respawning", workers[index].name);
+        workers[index].state = SlotState::Respawning;
+        worker_tasks.spawn(respawn_after(index, stateful, std::chrono::milliseconds(0)));
+        co_return;
+    }
+
     if(process_crash(index, stateful, exit_code, exit_signal)) {
-        if(!respawn_worker(index, stateful)) {
-            LOG_ERROR("Worker {} respawn failed", workers[index].name);
-            if(!stateful) {
-                // Slot is effectively permanently dead — shrink ceiling
-                // so monitor_memory() can't raise low_limit above capacity.
-                max_low_limit =
-                    alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
-                if(low_limit > max_low_limit)
-                    low_limit = max_low_limit;
-                if(alive_stateless_count == 0)
-                    fail_pending_requests();
-            }
-        }
+        workers[index].state = SlotState::Respawning;
+        worker_tasks.spawn(
+            respawn_after(index, stateful, backoff_delay(workers[index].crash_streak)));
     }
 }
 
 bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal) {
     auto& workers = stateful ? stateful_workers : stateless_workers;
     auto& w = workers[index];
-    w.alive = false;
+    mark_worker_dead(index, stateful, false);
 
     // POSIX SIGHUP == 1 by value: Windows' <csignal> does not define the
     // macro, and a worker can only receive it on POSIX anyway.
@@ -333,22 +405,22 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
         // Termination requested from outside — e.g. the editor tearing the
         // whole process group down on a hard restart. The worker did not
         // crash; don't alarm the user through the anomaly channel.
-        LOG_WARN("Worker {} terminated by signal {} (restarts: {})",
+        LOG_WARN("Worker {} terminated by signal {} (crash streak: {})",
                  w.name,
                  exit_signal,
-                 w.restart_count);
+                 w.crash_streak);
     } else if(exit_signal != 0) {
         LOG_ANOMALY(WorkerCrash,
-                    "Worker {} killed by signal {} (restarts: {})",
+                    "Worker {} killed by signal {} (crash streak: {})",
                     w.name,
                     exit_signal,
-                    w.restart_count);
+                    w.crash_streak);
     } else {
         LOG_ANOMALY(WorkerCrash,
-                    "Worker {} exited with code {} (restarts: {})",
+                    "Worker {} exited with code {} (crash streak: {})",
                     w.name,
                     exit_code,
-                    w.restart_count);
+                    w.crash_streak);
     }
 
     // Relay the tail of the dead worker's own log into the master log so CI,
@@ -379,17 +451,22 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
         }
     }
 
+    // A worker that ran healthily for a while starts a fresh streak: the
+    // budget bounds crash loops, not lifetime bad luck.
+    auto now = std::chrono::steady_clock::now();
+    if(w.spawn_time != std::chrono::steady_clock::time_point{} &&
+       now - w.spawn_time >= options.healthy_uptime) {
+        w.crash_streak = 0;
+    }
+    w.crash_streak += 1;
+
     WorkerCrashInfo info;
     info.worker_index = index;
     info.stateful = stateful;
     info.exit_code = exit_code;
     info.exit_signal = exit_signal;
-    info.restart_count = w.restart_count;
-    info.will_restart = w.restart_count < options.max_restarts;
-
-    if(!info.will_restart) {
-        LOG_ERROR("Worker {} exceeded max restarts ({}), giving up", w.name, options.max_restarts);
-    }
+    info.crash_streak = w.crash_streak;
+    info.will_restart = w.crash_streak <= options.max_crash_streak;
 
     if(stateful) {
         // Collect documents owned by this worker so the caller (on_crash)
@@ -400,31 +477,18 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
         }
         clear_owner(index);
     } else {
-        alive_stateless_count -= 1;
-        if(w.busy) {
-            if(w.low_priority)
-                low_busy_count -= 1;
-            w.busy = false;
-            w.low_priority = false;
-            stateless_busy_count -= 1;
-        }
         apply_crash_backoff();
+        // The dead worker's claim was released by mark_worker_dead; a queued
+        // low-priority waiter may now fit on another idle worker instead of
+        // stalling until the respawn lands.
+        try_dispatch_pending();
+    }
 
-        // Permanently lost slot: shrink the ceiling so monitor_memory()
-        // can't raise low_limit above the surviving worker count.
-        if(!info.will_restart) {
-            max_low_limit =
-                alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
-            if(low_limit > max_low_limit)
-                low_limit = max_low_limit;
-        }
-
-        // If no workers remain and none will restart, wake all waiters
-        // with SIZE_MAX so they can return an error instead of hanging.
-        if(alive_stateless_count == 0 && !info.will_restart)
-            fail_pending_requests();
-        else
-            try_dispatch_pending();
+    if(!info.will_restart) {
+        LOG_ERROR("Worker {} exceeded crash budget ({} consecutive), giving up",
+                  w.name,
+                  options.max_crash_streak);
+        give_up_slot(index, stateful);
     }
 
     if(on_crash)
@@ -433,215 +497,149 @@ bool WorkerPool::process_crash(std::size_t index, bool stateful, int exit_code, 
     return info.will_restart;
 }
 
-bool WorkerPool::respawn_worker(std::size_t index, bool stateful) {
-    auto& workers = stateful ? stateful_workers : stateless_workers;
-    auto old_restart_count = workers[index].restart_count + 1;
-    auto worker_name = std::string(stateful ? "SF-" : "SL-") + std::to_string(index);
-
-    // Close the old peer and retire it so its coroutines (run/write_loop)
-    // can finish naturally before the object is destroyed.
-    if(workers[index].peer) {
-        workers[index].peer->close();
-        retired_peers.push_back(std::move(workers[index].peer));
-    }
-
-    kota::process::options opts;
-    opts.file = options.self_path;
-    opts.args = {options.self_path, "worker"};
-    if(stateful) {
-        opts.args.push_back("--stateful");
-        opts.args.push_back("--memory-limit");
-        opts.args.push_back(std::to_string(options.worker_memory_limit));
-    }
-    opts.args.push_back("--worker-name");
-    opts.args.push_back(worker_name);
-    if(!log_dir.empty()) {
-        opts.args.push_back("--log-dir");
-        opts.args.push_back(log_dir);
-    }
-    opts.streams = {
-        kota::process::stdio::pipe(true, false),
-        kota::process::stdio::pipe(false, true),
-        kota::process::stdio::pipe(false, true),
-    };
-
-    auto result = kota::process::spawn(opts, loop);
-    if(!result) {
-        LOG_ANOMALY(WorkerSpawnFail,
-                    "Failed to respawn worker {}: {}",
-                    worker_name,
-                    result.error().message());
-        return false;
-    }
-
-    auto& spawn = *result;
-    auto transport = std::make_unique<kota::ipc::StreamTransport>(std::move(spawn.stdout_pipe),
-                                                                  std::move(spawn.stdin_pipe));
-    auto peer = std::make_unique<kota::ipc::BincodePeer>(loop, std::move(transport));
-
-    std::string prefix = "[" + worker_name + "]";
-    worker_tasks.spawn(drain_stderr(std::move(spawn.stderr_pipe), prefix));
-
-    workers[index] = WorkerProcess{
-        .proc = std::move(spawn.proc),
-        .peer = std::move(peer),
-        .name = worker_name,
-        .owned_documents = 0,
-        .alive = true,
-        .busy = false,
-        .low_priority = false,
-        .restart_count = old_restart_count,
-    };
-
-    if(!stateful)
-        alive_stateless_count += 1;
-
-    auto& w = workers[index];
-    worker_tasks.spawn(w.peer->run());
-
-    // Dispatch pending requests now that a fresh worker is available.
-    if(!stateful)
-        try_dispatch_pending();
-
-    if(stateful) {
-        w.peer->on_notification([this](const worker::EvictedParams& params) {
-            if(on_evicted)
-                on_evicted(params.path);
-        });
-    }
-
-    worker_tasks.spawn(monitor_worker(index, stateful));
-
-    LOG_INFO("Worker {} restarted (attempt {})", worker_name, old_restart_count);
-    return true;
+std::chrono::milliseconds WorkerPool::backoff_delay(unsigned crash_streak) const {
+    if(crash_streak <= 1)
+        return std::chrono::milliseconds(0);
+    auto shift = std::min(crash_streak - 2, 4u);
+    return options.respawn_backoff * (1u << shift);
 }
 
-kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority,
-                                                           std::size_t exclude) {
-    using P = worker::Priority;
-    auto can_proceed = [&]() {
-        auto idle = alive_stateless_count - stateless_busy_count;
-        // Don't count the excluded worker (failed peer whose crash
-        // hasn't been processed by monitor_worker yet).
-        if(exclude < stateless_workers.size() && stateless_workers[exclude].alive &&
-           !stateless_workers[exclude].busy)
-            idle -= 1;
-        // Don't count retiring workers — they are alive but won't accept work.
-        for(auto& w: stateless_workers)
-            if(w.retiring && w.alive && !w.busy)
-                idle -= 1;
-        if(idle == 0)
-            return false;
-        if(priority == P::High)
-            return true;
-        return low_busy_count < low_limit;
-    };
-
+kota::task<> WorkerPool::respawn_after(std::size_t index,
+                                       bool stateful,
+                                       std::chrono::milliseconds delay) {
+    auto& workers = stateful ? stateful_workers : stateless_workers;
     while(true) {
-        if(alive_stateless_count == 0)
+        if(delay.count() > 0) {
+            LOG_INFO("Worker {} respawn delayed by {}ms (crash streak {})",
+                     workers[index].name,
+                     delay.count(),
+                     workers[index].crash_streak);
+            co_await kota::with_token(kota::sleep(delay, loop), stop_scope.token());
+        }
+        if(stop_scope.cancelled())
+            co_return;
+
+        if(respawn_worker(index, stateful))
+            co_return;
+
+        // The spawn itself failed (e.g. transient resource exhaustion):
+        // treat it like another crash in the streak and back off harder.
+        auto& w = workers[index];
+        w.crash_streak += 1;
+        if(w.crash_streak > options.max_crash_streak) {
+            LOG_ERROR("Worker {} respawn failed permanently, giving up", w.name);
+            give_up_slot(index, stateful);
+            co_return;
+        }
+        delay = backoff_delay(w.crash_streak);
+    }
+}
+
+void WorkerPool::give_up_slot(std::size_t index, bool stateful) {
+    auto& w = stateful ? stateful_workers[index] : stateless_workers[index];
+    w.state = SlotState::Dead;
+    if(!stateful) {
+        // If this was the last slot with a future, wake all waiters so they
+        // can return an error instead of hanging.
+        try_dispatch_pending();
+    }
+}
+
+std::size_t WorkerPool::claim_stateless(std::size_t index, worker::Priority priority) {
+    auto& w = stateless_workers[index];
+    w.busy = true;
+    w.low_priority = priority == worker::Priority::Low;
+    return index;
+}
+
+kota::task<std::size_t> WorkerPool::acquire_stateless_slot(worker::Priority priority) {
+    using P = worker::Priority;
+    while(true) {
+        if(stop_scope.cancelled() || !has_future_capacity())
             co_return SIZE_MAX;
 
-        if(!can_proceed()) {
-            // Enqueue and suspend until try_dispatch_pending() wakes us.
-            // PendingStateless destructor handles cleanup on cancellation:
-            //   - still queued → removes from queue
-            //   - dispatched but cancelled before StatelessSlot → releases slot
-            PendingStateless pending(priority);
-            pending.pool = this;
-            if(priority == P::High) {
-                high_queue.push_back(&pending);
-                pending.queue = &high_queue;
-            } else {
-                low_queue.push_back(&pending);
-                pending.queue = &low_queue;
-            }
-            co_await pending.ready.wait();
-            pending.pool = nullptr;  // claimed — StatelessSlot will handle release
-
-            if(pending.assigned_worker == SIZE_MAX)
-                co_return SIZE_MAX;
-
-            // If the assigned worker crashed and was respawned between
-            // dispatch and resume, the slot is stale — loop to re-acquire.
-            auto idx = pending.assigned_worker;
-            if(stateless_workers[idx].restart_count != pending.assigned_gen)
-                continue;
-
-            co_return idx;
+        // Claim directly only when no earlier request is queued (FIFO
+        // fairness); high priority never waits behind queued low.
+        bool fifo_clear =
+            priority == P::High ? high_queue.empty() : high_queue.empty() && low_queue.empty();
+        if(fifo_clear && (priority == P::High || low_busy_count() < effective_low_limit())) {
+            if(auto idx = pick_idle_stateless(); idx != SIZE_MAX)
+                co_return claim_stateless(idx, priority);
         }
 
-        auto idx = pick_idle_stateless();
-        stateless_workers[idx].busy = true;
-        stateless_workers[idx].low_priority = (priority == P::Low);
-        stateless_busy_count += 1;
-        if(priority == P::Low)
-            low_busy_count += 1;
+        // Queue up and suspend until try_dispatch_pending() claims a worker
+        // for us or wakes us to observe pool death. The destructor covers
+        // cancellation while queued or between dispatch and resume.
+        PendingStateless pending(*this, priority);
+        auto& queue = priority == P::High ? high_queue : low_queue;
+        queue.push_back(&pending);
+        pending.queue = &queue;
 
+        co_await pending.ready.wait();
+
+        if(pending.assigned_worker == SIZE_MAX)
+            continue;
+
+        auto idx = std::exchange(pending.assigned_worker, SIZE_MAX);
+        // If the claimed worker died between dispatch and resume, the claim
+        // was already cleaned up with the slot — go around again.
+        if(stateless_workers[idx].generation != pending.assigned_gen)
+            continue;
         co_return idx;
     }
 }
 
 void WorkerPool::release_stateless_slot(std::size_t worker_index) {
-    if(worker_index >= stateless_workers.size() || !stateless_workers[worker_index].busy)
+    auto& w = stateless_workers[worker_index];
+    if(!w.busy)
         return;
-    if(worker_index < slot_cancel_sources.size())
-        slot_cancel_sources[worker_index].reset();
-    if(stateless_workers[worker_index].low_priority)
-        low_busy_count -= 1;
-    stateless_workers[worker_index].busy = false;
-    stateless_workers[worker_index].low_priority = false;
-    stateless_busy_count -= 1;
-    LOG_DEBUG("Release {} (busy={}, low_busy={})",
-              stateless_workers[worker_index].name,
-              stateless_busy_count,
-              low_busy_count);
+    w.busy = false;
+    w.low_priority = false;
+    w.preempt_source.reset();
+    LOG_DEBUG("Release {} (busy={}, low_busy={})", w.name, busy_stateless(), low_busy_count());
     try_dispatch_pending();
 }
 
 void WorkerPool::try_dispatch_pending() {
-    // Subtract retiring workers from idle count — they won't accept new work.
-    std::size_t retiring_idle = 0;
-    for(auto& w: stateless_workers)
-        if(w.retiring && w.alive && !w.busy)
-            retiring_idle += 1;
-    auto idle = alive_stateless_count - stateless_busy_count - retiring_idle;
+    if(stop_scope.cancelled() || !has_future_capacity()) {
+        fail_pending_requests();
+        return;
+    }
 
-    auto dispatch = [&](std::deque<PendingStateless*>& queue, bool is_low) {
-        while(!queue.empty() && idle > 0 && (!is_low || low_busy_count < low_limit)) {
+    auto dispatch = [&](std::deque<PendingStateless*>& queue, worker::Priority priority) {
+        while(!queue.empty()) {
+            if(priority == worker::Priority::Low && low_busy_count() >= effective_low_limit())
+                break;
+            auto idx = pick_idle_stateless();
+            if(idx == SIZE_MAX)
+                break;
             auto* next = queue.front();
             queue.pop_front();
             next->queue = nullptr;
-            auto idx = pick_idle_stateless();
-            stateless_workers[idx].busy = true;
-            stateless_workers[idx].low_priority = is_low;
-            stateless_busy_count += 1;
-            if(is_low)
-                low_busy_count += 1;
-            idle -= 1;
+            claim_stateless(idx, priority);
             next->assigned_worker = idx;
-            next->assigned_gen = stateless_workers[idx].restart_count;
-            LOG_DEBUG("Dispatch {} -> {} (busy={}, low_busy={}, idle={})",
-                      is_low ? "low" : "high",
+            next->assigned_gen = stateless_workers[idx].generation;
+            LOG_DEBUG("Dispatch {} -> {} (busy={}, low_busy={})",
+                      priority == worker::Priority::Low ? "low" : "high",
                       stateless_workers[idx].name,
-                      stateless_busy_count,
-                      low_busy_count,
-                      idle);
+                      busy_stateless(),
+                      low_busy_count());
             next->ready.set();
         }
     };
 
-    dispatch(high_queue, false);
-    dispatch(low_queue, true);
+    dispatch(high_queue, worker::Priority::High);
+    dispatch(low_queue, worker::Priority::Low);
 }
 
 void WorkerPool::fail_pending_requests() {
-    // SIZE_MAX signals to send_stateless() that no worker was assigned.
+    // Waiters are woken without a claim (assigned_worker stays SIZE_MAX);
+    // they re-check the pool state and return an error.
     auto drain = [](std::deque<PendingStateless*>& queue) {
         while(!queue.empty()) {
             auto* next = queue.front();
             queue.pop_front();
             next->queue = nullptr;
-            next->assigned_worker = SIZE_MAX;
             next->ready.set();
         }
     };
@@ -649,16 +647,16 @@ void WorkerPool::fail_pending_requests() {
     drain(low_queue);
 }
 
-std::size_t WorkerPool::pick_idle_stateless(std::size_t exclude) {
+std::size_t WorkerPool::pick_idle_stateless() {
     for(std::size_t i = 0; i < stateless_workers.size(); ++i) {
-        if(i != exclude && stateless_workers[i].alive && !stateless_workers[i].busy &&
-           !stateless_workers[i].retiring)
+        auto& w = stateless_workers[i];
+        if(w.state == SlotState::Alive && !w.busy && !w.retiring)
             return i;
     }
-    llvm_unreachable("pick_idle_stateless called with no idle workers");
+    return SIZE_MAX;
 }
 
-kota::task<> WorkerPool::monitor_memory() {
+kota::task<> WorkerPool::monitor_loop() {
     while(true) {
         co_await kota::sleep(std::chrono::milliseconds(3000), loop);
 
@@ -670,63 +668,108 @@ kota::task<> WorkerPool::monitor_memory() {
             (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
         auto ratio = static_cast<double>(mem.available) / static_cast<double>(effective_total);
 
-        LOG_DEBUG(
-            "Memory: {:.0f}% available, low_limit={}/{}, busy={} (low={}), " "queued=hi:{}/lo:{}, alive={}, sat={}/idle={}",
-            ratio * 100,
-            low_limit,
-            max_low_limit,
-            stateless_busy_count,
-            low_busy_count,
-            high_queue.size(),
-            low_queue.size(),
-            alive_stateless_count,
-            saturated_cycles,
-            idle_cycles);
+        tick_memory(ratio);
+        tick_scaling(ratio);
+    }
+}
 
-        // Severe pressure: preempt low-priority in-flight requests.
-        // FIXME: cancelled Index requests are not requeued by the indexer,
-        // so those files will be skipped until the next indexing cycle.
-        if(ratio < 0.10 && low_busy_count > 0) {
-            cancel_low_priority_requests(low_busy_count);
+void WorkerPool::tick_memory(double available_ratio) {
+    LOG_DEBUG(
+        "Memory: {:.0f}% available, low_limit={}/{}, busy={} (low={}), " "queued=hi:{}/lo:{}, alive={}, sat={}/idle={}",
+        available_ratio * 100,
+        low_limit,
+        max_low_limit(),
+        busy_stateless(),
+        low_busy_count(),
+        high_queue.size(),
+        low_queue.size(),
+        alive_stateless(),
+        saturated_cycles,
+        idle_cycles);
+
+    // Severe pressure: drop the low allowance to its floor and preempt all
+    // running low-priority work — killing the workers releases their memory
+    // immediately, and they respawn without crash accounting.
+    if(available_ratio < 0.10) {
+        if(low_limit > 1) {
+            if(w_max == 0 || low_limit > w_max)
+                w_max = low_limit;
+            low_limit = 1;
+            LOG_WARN("low_limit -> 1 (severe memory pressure: {:.0f}% available)",
+                     available_ratio * 100);
         }
-
-        // Inner loop: adjust low_limit with CUBIC-style fast recovery.
-        if(ratio < 0.20 && low_limit > 1) {
-            if(backoff_cooldown > 0) {
-                backoff_cooldown -= 1;
-            } else {
-                if(w_max == 0 || low_limit > w_max)
-                    w_max = low_limit;
-                low_limit -= 1;
-                LOG_INFO("low_limit -> {} (memory pressure: {:.0f}% available)",
-                         low_limit,
-                         ratio * 100);
-            }
-        } else if(ratio > 0.40 && low_limit < max_low_limit) {
-            backoff_cooldown = 0;
-            if(w_max > 0 && low_limit < w_max) {
-                auto gap = w_max - low_limit;
-                auto increment = std::max<std::size_t>(1, gap / 2);
-                low_limit = std::min(low_limit + increment, max_low_limit);
-            } else {
-                low_limit += 1;
-                if(low_limit >= max_low_limit)
-                    w_max = 0;
-            }
-            LOG_DEBUG("low_limit -> {} (memory OK: {:.0f}% available, w_max={})",
-                      low_limit,
-                      ratio * 100,
-                      w_max);
-            try_dispatch_pending();
-        }
-
-        // Outer loop: dynamic scaling.
-        check_scaling();
-
-        // Severe pressure: also scale down immediately.
-        if(ratio < 0.10 && alive_stateless_count > options.min_stateless) {
+        if(auto busy_low = low_busy_count())
+            preempt_low_priority(busy_low);
+        if(alive_stateless() > options.min_stateless)
             retire_idle_worker();
+        return;
+    }
+
+    if(available_ratio < 0.20 && low_limit > 1) {
+        if(backoff_cooldown > 0) {
+            backoff_cooldown -= 1;
+        } else {
+            if(w_max == 0 || low_limit > w_max)
+                w_max = low_limit;
+            low_limit -= 1;
+            LOG_INFO("low_limit -> {} (memory pressure: {:.0f}% available)",
+                     low_limit,
+                     available_ratio * 100);
         }
+    } else if(available_ratio > 0.40 && low_limit < max_low_limit()) {
+        backoff_cooldown = 0;
+        if(w_max > 0 && low_limit < w_max) {
+            // CUBIC-style fast recovery: close half the gap to the last
+            // known-good limit per tick.
+            auto gap = w_max - low_limit;
+            auto increment = std::max<std::size_t>(1, gap / 2);
+            low_limit = std::min(low_limit + increment, max_low_limit());
+        } else {
+            low_limit += 1;
+            if(low_limit >= max_low_limit())
+                w_max = 0;
+        }
+        LOG_DEBUG("low_limit -> {} (memory OK: {:.0f}% available, w_max={})",
+                  low_limit,
+                  available_ratio * 100,
+                  w_max);
+        try_dispatch_pending();
+    }
+}
+
+void WorkerPool::tick_scaling(double available_ratio) {
+    bool has_queued = !high_queue.empty() || !low_queue.empty();
+    auto alive = alive_stateless();
+    auto busy = busy_stateless();
+
+    // The pool is saturated when all workers are busy with queued work, OR
+    // when low-priority slots are at capacity with low-priority work queued.
+    // The second condition handles the case where low_limit reserves a worker
+    // for high-priority requests: the reserved slot stays idle, so busy
+    // never equals alive, but the pool is effectively saturated for
+    // low-priority (indexing) work.
+    bool saturated = (alive > 0 && busy == alive && has_queued) ||
+                     (low_busy_count() >= effective_low_limit() && !low_queue.empty());
+
+    if(saturated) {
+        saturated_cycles += 1;
+        idle_cycles = 0;
+    } else if(busy == 0 && !has_queued) {
+        idle_cycles += 1;
+        saturated_cycles = 0;
+    } else {
+        saturated_cycles = 0;
+        idle_cycles = 0;
+    }
+
+    if(saturated_cycles >= scale_up_ticks && available_ratio > 0.30) {
+        if(scale_up_worker())
+            saturated_cycles = 0;
+    }
+
+    if(idle_cycles >= scale_down_ticks) {
+        retire_idle_worker();
+        idle_cycles = 0;
     }
 }
 
@@ -742,112 +785,68 @@ void WorkerPool::apply_crash_backoff() {
 }
 
 bool WorkerPool::scale_up_worker() {
-    if(alive_stateless_count >= options.max_stateless)
+    if(stateless_capacity() >= options.max_stateless)
         return false;
 
-    auto new_index = stateless_workers.size();
-    if(!spawn_worker(options.self_path, false, 0)) {
+    if(!spawn_worker(false)) {
         LOG_WARN("scale_up: spawn_worker failed");
         return false;
     }
 
-    slot_cancel_sources.push_back(nullptr);
-    worker_tasks.spawn(monitor_worker(new_index, false));
-
-    max_low_limit = alive_stateless_count > 1 ? alive_stateless_count - 1 : alive_stateless_count;
-    low_limit = max_low_limit;
-    w_max = 0;
+    // The new worker raises the ceiling; grow the low allowance by exactly
+    // the added capacity instead of resetting whatever pressure or crash
+    // backoff state accumulated.
+    low_limit = std::min(low_limit + 1, max_low_limit());
     try_dispatch_pending();
 
-    LOG_INFO("Scaled up: spawned {} (alive={})",
-             stateless_workers.back().name,
-             alive_stateless_count);
+    LOG_INFO("Scaled up: spawned {} (alive={})", stateless_workers.back().name, alive_stateless());
     return true;
 }
 
 void WorkerPool::retire_idle_worker() {
-    // Count workers already marked retiring (exit not yet observed by
-    // monitor_worker) to avoid retiring below min_stateless.
+    // Workers already marked retiring are still counted alive until
+    // monitor_worker observes their exit; respect the floor including them.
     std::size_t pending_retires = 0;
     for(auto& w: stateless_workers)
-        if(w.retiring && w.alive)
+        if(w.retiring && w.state == SlotState::Alive)
             pending_retires += 1;
-    if(alive_stateless_count - pending_retires <= options.min_stateless)
+    if(alive_stateless() - pending_retires <= options.min_stateless)
         return;
 
-    std::size_t target = SIZE_MAX;
     for(std::size_t i = stateless_workers.size(); i-- > 0;) {
         auto& w = stateless_workers[i];
-        if(w.alive && !w.busy && !w.retiring) {
-            target = i;
-            break;
+        if(w.state == SlotState::Alive && !w.busy && !w.retiring) {
+            w.retiring = true;
+            w.peer->close_output();
+            w.proc.kill(SIGTERM);
+            LOG_INFO("Retiring worker {} (alive={})", w.name, alive_stateless());
+            return;
         }
-    }
-
-    if(target == SIZE_MAX)
-        return;
-
-    auto& w = stateless_workers[target];
-    w.retiring = true;
-    w.peer->close_output();
-    w.proc.kill(SIGTERM);
-
-    LOG_INFO("Retiring worker {} (alive={})", w.name, alive_stateless_count);
-}
-
-void WorkerPool::check_scaling() {
-    bool has_queued = !high_queue.empty() || !low_queue.empty();
-
-    // The pool is saturated when all workers are busy with queued work, OR
-    // when low-priority slots are at capacity with low-priority work queued.
-    // The second condition handles the case where low_limit reserves a worker
-    // for high-priority requests: the reserved slot stays idle, so busy_count
-    // never equals alive_count, but the pool is effectively saturated for
-    // low-priority (indexing) work.
-    bool saturated = (stateless_busy_count == alive_stateless_count && has_queued) ||
-                     (low_busy_count >= low_limit && !low_queue.empty());
-
-    if(saturated) {
-        saturated_cycles += 1;
-        idle_cycles = 0;
-    } else if(stateless_busy_count == 0 && !has_queued) {
-        idle_cycles += 1;
-        saturated_cycles = 0;
-    } else {
-        saturated_cycles = 0;
-        idle_cycles = 0;
-    }
-
-    if(saturated_cycles >= scale_up_ticks) {
-        auto mem = kota::sys::memory();
-        auto effective =
-            (mem.constrained > 0 && mem.constrained < mem.total) ? mem.constrained : mem.total;
-        auto ratio = effective > 0 ? static_cast<double>(mem.available) / effective : 1.0;
-        if(ratio > 0.30) {
-            if(scale_up_worker())
-                saturated_cycles = 0;
-        }
-    }
-
-    if(idle_cycles >= scale_down_ticks) {
-        retire_idle_worker();
-        idle_cycles = 0;
     }
 }
 
-void WorkerPool::cancel_low_priority_requests(std::size_t count) {
-    std::size_t cancelled = 0;
-    for(std::size_t i = 0; i < stateless_workers.size() && cancelled < count; ++i) {
+void WorkerPool::preempt_low_priority(std::size_t count) {
+    std::size_t preempted = 0;
+    for(std::size_t i = 0; i < stateless_workers.size() && preempted < count; ++i) {
         auto& w = stateless_workers[i];
-        if(w.alive && w.busy && w.low_priority) {
-            if(i < slot_cancel_sources.size() && slot_cancel_sources[i]) {
-                slot_cancel_sources[i]->cancel();
-                ++cancelled;
-            }
-        }
+        if(w.state != SlotState::Alive || !w.busy || !w.low_priority)
+            continue;
+
+        // Signal the sender first, then take the slot out of rotation and
+        // kill the process — the kill is what actually frees the memory.
+        auto source = w.preempt_source;
+        w.preempted = true;
+        mark_worker_dead(i, false, true);
+        if(source)
+            source->cancel();
+        ++preempted;
     }
-    if(cancelled > 0)
-        LOG_WARN("Cancelled {} low-priority requests (memory pressure)", cancelled);
+    if(preempted > 0) {
+        LOG_WARN("Preempted {} low-priority workers (memory pressure)", preempted);
+        // The victims' claims are gone; queued work may fit under the
+        // (reduced) limit on the remaining idle workers.
+        try_dispatch_pending();
+    }
 }
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -285,6 +285,10 @@ private:
     /// Stateless slots that can serve requests now.
     std::size_t alive_stateless() const;
 
+    /// Alive stateless slots that also accept new work: a retiring slot
+    /// stays alive to finish its request but is skipped by dispatch.
+    std::size_t schedulable_stateless() const;
+
     /// Alive stateless slots with a request in flight.
     std::size_t busy_stateless() const;
 
@@ -302,12 +306,12 @@ private:
 
     /// Reserve one worker for high-priority requests by capping low-priority
     /// concurrency at one below the slots that can be scheduled right now.
-    /// A slot dying or awaiting respawn cannot serve; counting it would let
-    /// low-priority work occupy every live worker for the whole respawn
-    /// window. With a single live worker this collapses to 1: both
+    /// A slot dying, awaiting respawn, or retiring cannot take new work;
+    /// counting it would let low-priority requests occupy every schedulable
+    /// worker. With a single schedulable worker this collapses to 1: both
     /// priorities share it, and high wins only via queue ordering.
     std::size_t max_low_limit() const {
-        auto live = alive_stateless();
+        auto live = schedulable_stateless();
         return live > 1 ? live - 1 : live;
     }
 

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -495,7 +495,7 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
 
     auto& assigned = stateful_workers[idx];
     if(assigned.state == SlotState::Dying || assigned.state == SlotState::Respawning) {
-        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_crashed,
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_restarting,
                                                        "Assigned stateful worker is restarting"});
     }
     if(assigned.state != SlotState::Alive) {

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -67,6 +67,12 @@ struct WorkerPoolOptions {
     /// streak resets.
     std::chrono::milliseconds healthy_uptime{30'000};
 
+    /// Cooldown before a slot that gave up is revived with a fresh crash
+    /// budget. The pool must never stay at zero workers forever: document
+    /// quarantine isolates the poison, and this bounds how long a fully
+    /// burnt pool stays dark. 0 disables revival.
+    std::chrono::milliseconds revive_after{30'000};
+
     /// Dynamic scaling bounds for stateless workers.
     /// min_stateless: floor — never retire below this count.
     /// max_stateless: ceiling — never spawn above this count (0 = auto = CPU cores).
@@ -102,10 +108,15 @@ public:
     kota::task<> stop();
 
     /// Send a request to a stateful worker with path_id affinity routing.
+    /// `suspect` marks a workload the caller already distrusts (a
+    /// quarantined document's probe): if it crashes the worker, the crash
+    /// does not spend the slot's budget — the failure says something about
+    /// the document, not the slot.
     template <typename Params>
     RequestResult<Params> send_stateful(std::uint32_t path_id,
                                         const Params& params,
-                                        kota::ipc::request_options opts = {});
+                                        kota::ipc::request_options opts = {},
+                                        bool suspect = false);
 
     /// Send a request to a stateless worker with priority-aware scheduling.
     template <typename Params>
@@ -182,6 +193,11 @@ private:
 
         /// Consecutive fast crashes; resets after healthy uptime.
         unsigned crash_streak = 0;
+
+        /// In-flight requests whose caller flagged them as suspect (a
+        /// quarantined document's probe). While non-zero, a crash does not
+        /// spend the slot's budget — see send_stateful.
+        unsigned suspect_inflight = 0;
 
         std::chrono::steady_clock::time_point spawn_time{};
 
@@ -423,6 +439,10 @@ private:
     /// stacktraces, sanitizer reports) was drained to EOF.
     kota::task_group<> worker_tasks{loop};
     WorkerPoolOptions options;
+
+    /// Set once start() succeeded: gates background concerns (slot
+    /// revival) that need a running event loop.
+    bool started = false;
     std::string log_dir;
 
     struct SpawnedProcess {
@@ -440,6 +460,15 @@ private:
     /// Refill an existing slot with a fresh process.
     bool respawn_worker(std::size_t index, bool stateful);
 
+    /// After `revive_after`, grant a given-up slot a fresh crash budget
+    /// and respawn it: the pool never stays at zero workers forever.
+    kota::task<> revive_slot(std::size_t index, bool stateful);
+
+    /// A stateful worker that may be sacrificed to a suspect compile:
+    /// alive and hosting no document other than `path_id` itself, which is
+    /// reassigned to it. SIZE_MAX when every live worker hosts others.
+    std::size_t assign_expendable(std::uint32_t path_id);
+
     void install_evict_handler(WorkerProcess& worker);
 
     kota::task<> monitor_worker(std::size_t index, bool stateful);
@@ -450,11 +479,18 @@ private:
 template <typename Params>
 RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
                                                 const Params& params,
-                                                kota::ipc::request_options opts) {
-    auto idx = assign_worker(path_id);
+                                                kota::ipc::request_options opts,
+                                                bool suspect) {
+    // A suspect workload only runs on a worker hosting no other document:
+    // its crash must never take healthy sessions with it. With no such
+    // worker available right now, the caller keeps the probe armed and
+    // tries again later instead of risking one.
+    auto idx = suspect ? assign_expendable(path_id) : assign_worker(path_id);
     if(idx == SIZE_MAX) {
-        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
-                                                       "No stateful workers available"});
+        co_return kota::outcome_error(
+            kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
+                             suspect ? "No expendable stateful worker for quarantined probe"
+                                     : "No stateful workers available"});
     }
 
     auto& assigned = stateful_workers[idx];
@@ -471,7 +507,18 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
     // moment the worker dies.
     auto peer = assigned.peer;
     auto gen = assigned.generation;
+    if(suspect) {
+        assigned.suspect_inflight += 1;
+    }
     auto result = co_await peer->send_request(params, opts);
+    // Unwind the counter only when the request did not die on transport:
+    // a crash leaves it for the monitor's accounting to consume, and the
+    // generation guard skips incarnations already torn down elsewhere.
+    bool transport_dead = !result.has_value() && worker::is_transport_error(result.error());
+    if(suspect && !transport_dead && stateful_workers[idx].generation == gen &&
+       stateful_workers[idx].suspect_inflight > 0) {
+        stateful_workers[idx].suspect_inflight -= 1;
+    }
 
     if(result.has_value() || !worker::is_transport_error(result.error()))
         co_return std::move(result);

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -86,8 +86,8 @@ struct WorkerPoolOptions {
 ///     to one worker (path_id affinity), balanced by document count.
 ///
 /// The pool owns process lifecycle only: it respawns crashed workers with
-/// exponential backoff and gives a slot up after `max_crash_streak`
-/// consecutive fast crashes. It never retries requests. A request that was
+/// exponential backoff and gives a slot up once a streak exceeds
+/// `max_crash_streak` consecutive fast crashes. It never retries requests. A request that was
 /// in flight when its worker died fails with dispatch_errc::worker_crashed
 /// (or dispatch_errc::cancelled if the pool itself preempted the worker to
 /// relieve memory pressure); the caller decides whether to resend or requeue.

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -131,6 +131,16 @@ public:
     /// document was evicted).
     void remove_owner(std::uint32_t path_id);
 
+    /// True when a Dead slot is not final: the running pool revives dead
+    /// slots after a cooldown, so "no capacity" is a window, not a verdict.
+    /// Callers (the indexer's requeue) may retry work that failed with
+    /// worker_unavailable instead of dropping it. Unit fixtures drive slot
+    /// state without an event loop and never start the pool, so revival
+    /// stays off for them.
+    bool revives_slots() const {
+        return started && options.revive_after.count() > 0;
+    }
+
     /// Callback invoked when a worker process crashes.
     std::function<void(const WorkerCrashInfo&)> on_crash;
 

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -131,6 +131,12 @@ public:
     /// document was evicted).
     void remove_owner(std::uint32_t path_id);
 
+    /// Remove path_id from ownership only if worker_index is its current
+    /// owner. Returns whether it was removed — false means the eviction
+    /// came from a stale copy on a worker that lost ownership (probe
+    /// reassignment) and the current owner's state is untouched.
+    bool remove_owner_from(std::uint32_t path_id, std::size_t worker_index);
+
     /// True when a Dead slot is not final: the running pool revives dead
     /// slots after a cooldown, so "no capacity" is a window, not a verdict.
     /// Callers (the indexer's requeue) may retry work that failed with
@@ -144,10 +150,13 @@ public:
     /// Callback invoked when a worker process crashes.
     std::function<void(const WorkerCrashInfo&)> on_crash;
 
-    /// Callback invoked when a stateful worker sends an EvictedParams notification.
-    /// The master translates the path to a path_id and calls remove_owner() so the
-    /// owner table shrinks together with the worker's document set.
-    std::function<void(const std::string& path)> on_evicted;
+    /// Callback invoked when a stateful worker sends an EvictedParams
+    /// notification, with the slot index of the evicting worker. The master
+    /// translates the path to a path_id and calls remove_owner_from() so an
+    /// eviction of a stale copy — a quarantine probe moved ownership to
+    /// another worker while the old one kept its document entry — cannot
+    /// unseat the current owner.
+    std::function<void(const std::string& path, std::size_t worker_index)> on_evicted;
 
 private:
     /// Lifecycle of a worker slot. The generation counter is bumped on every
@@ -483,7 +492,7 @@ private:
     /// reassigned to it. SIZE_MAX when every live worker hosts others.
     std::size_t assign_expendable(std::uint32_t path_id);
 
-    void install_evict_handler(WorkerProcess& worker);
+    void install_evict_handler(WorkerProcess& worker, std::size_t index);
 
     kota::task<> monitor_worker(std::size_t index, bool stateful);
 

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
-#include <list>
 #include <memory>
+#include <optional>
 
 #include "server/protocol/worker.h"
 
@@ -34,11 +34,12 @@ struct WorkerCrashInfo {
     /// Non-zero when the worker was killed by a signal (e.g. 9 = SIGKILL).
     int exit_signal = 0;
 
-    /// How many times this slot had restarted before this crash.
-    unsigned restart_count;
+    /// Consecutive fast crashes of this slot, including this one. Resets
+    /// after a healthy uptime, so only genuine crash loops accumulate.
+    unsigned crash_streak = 0;
 
     /// Whether the pool will attempt to respawn this worker.
-    bool will_restart;
+    bool will_restart = false;
 
     /// Stateful only: path_ids of documents owned by the crashed worker.
     /// The on_crash handler should mark these dirty for recompilation.
@@ -52,8 +53,19 @@ struct WorkerPoolOptions {
     std::uint64_t worker_memory_limit = 4ULL * 1024 * 1024 * 1024;  // 4GB default
     std::string log_dir;
 
-    /// Per-worker restart cap before the pool gives up on that slot.
-    unsigned max_restarts = 2;
+    /// A slot is given up once it crashes more than this many times in a
+    /// row. The streak resets after `healthy_uptime` of stable operation,
+    /// so the budget bounds crash loops, not lifetime bad luck.
+    unsigned max_crash_streak = 3;
+
+    /// Base delay for exponential respawn backoff. The first crash of a
+    /// streak respawns immediately; each further one doubles the delay,
+    /// capped at 16x the base.
+    std::chrono::milliseconds respawn_backoff{500};
+
+    /// Uptime after which a worker is considered healthy and its crash
+    /// streak resets.
+    std::chrono::milliseconds healthy_uptime{30'000};
 
     /// Dynamic scaling bounds for stateless workers.
     /// min_stateless: floor — never retire below this count.
@@ -62,6 +74,23 @@ struct WorkerPoolOptions {
     std::uint32_t max_stateless = 0;
 };
 
+/// Multi-process scheduler for clice worker processes.
+///
+/// Two kinds of workers are managed:
+///   - Stateless workers execute independent build tasks (PCH/PCM builds,
+///     indexing, completion, formatting) with two-level priority scheduling:
+///     one worker's worth of capacity is reserved for high-priority requests
+///     by capping low-priority concurrency at capacity - 1, and the cap
+///     shrinks further under memory pressure.
+///   - Stateful workers keep per-document ASTs; each open document is pinned
+///     to one worker (path_id affinity), balanced by document count.
+///
+/// The pool owns process lifecycle only: it respawns crashed workers with
+/// exponential backoff and gives a slot up after `max_crash_streak`
+/// consecutive fast crashes. It never retries requests. A request that was
+/// in flight when its worker died fails with dispatch_errc::worker_crashed
+/// (or dispatch_errc::cancelled if the pool itself preempted the worker to
+/// relieve memory pressure); the caller decides whether to resend or requeue.
 class WorkerPool {
 public:
     WorkerPool(kota::event_loop& loop) : loop(loop) {}
@@ -100,17 +129,42 @@ public:
     std::function<void(const std::string& path)> on_evicted;
 
 private:
+    /// Lifecycle of a worker slot. The generation counter is bumped on every
+    /// transition out of Alive, so stale references (an in-flight request's
+    /// slot guard, a dispatched-but-cancelled waiter) can detect that their
+    /// claim no longer describes the current occupant.
+    enum class SlotState : std::uint8_t {
+        /// Process running and accepting requests.
+        Alive,
+        /// Process declared dead (transport failure, preemption kill, or
+        /// observed exit); monitor_worker has not delivered its verdict yet.
+        Dying,
+        /// A respawn is scheduled, possibly sleeping out a backoff delay.
+        Respawning,
+        /// Intentionally scaled down; the slot stays vacant.
+        Retired,
+        /// Crash budget exhausted; the slot stays vacant.
+        Dead,
+    };
+
     struct WorkerProcess {
         kota::process proc;
-        std::unique_ptr<kota::ipc::BincodePeer> peer;
+
+        /// Shared with every coroutine that awaits on it (request senders,
+        /// the IO pump), so a slot can drop its reference the moment the
+        /// process dies without racing in-flight users.
+        std::shared_ptr<kota::ipc::BincodePeer> peer;
 
         /// Display name for logging, e.g. "SL-0" or "SF-1".
         std::string name;
 
+        SlotState state = SlotState::Alive;
+
+        /// Bumped on every death; see SlotState.
+        unsigned generation = 0;
+
         /// Stateful only: number of documents routed to this worker.
         std::size_t owned_documents = 0;
-
-        bool alive = true;
 
         /// Stateless only: true while a request is in-flight on this worker.
         bool busy = false;
@@ -118,12 +172,22 @@ private:
         /// Stateless only: true if the current in-flight request is low-priority.
         bool low_priority = false;
 
-        /// How many times this slot has been respawned.
-        unsigned restart_count = 0;
-
         /// True when this worker is being intentionally shut down (scale-down),
         /// as opposed to an unexpected crash.
         bool retiring = false;
+
+        /// True when the pool killed this worker on purpose to relieve
+        /// memory pressure: respawn immediately, without crash accounting.
+        bool preempted = false;
+
+        /// Consecutive fast crashes; resets after healthy uptime.
+        unsigned crash_streak = 0;
+
+        std::chrono::steady_clock::time_point spawn_time{};
+
+        /// Stateless only: cancels the in-flight low-priority request so its
+        /// sender observes preemption instead of a bare transport error.
+        std::shared_ptr<kota::cancellation_source> preempt_source;
     };
 
     kota::event_loop& loop;
@@ -133,39 +197,39 @@ private:
     // Stateful routing: each open document (path_id) is pinned to one worker.
     llvm::DenseMap<std::uint32_t, std::size_t> owner;  // path_id -> worker index
 
+    /// Returns the worker owning path_id, assigning the least-loaded live
+    /// worker on first use. SIZE_MAX when no stateful worker is alive.
     std::size_t assign_worker(std::uint32_t path_id);
     void clear_owner(std::size_t worker_index);
     std::size_t pick_least_loaded();
 
-    /// A coroutine waiting for a stateless worker slot.  Lives on the coroutine
-    /// frame of acquire_stateless_slot(); the destructor handles two cancellation
-    /// scenarios:
-    ///   - Still queued (queue != nullptr): removes itself from the queue.
-    ///   - Dispatched but coroutine cancelled before StatelessSlot was created
-    ///     (pool != nullptr): releases the assigned slot to prevent leak.
+    /// A coroutine waiting for a stateless worker slot. Lives on the frame of
+    /// acquire_stateless_slot(). Dispatch claims a worker on the waiter's
+    /// behalf before waking it; the destructor covers cancellation:
+    ///   - Still queued: removes itself from the queue.
+    ///   - Claimed but cancelled before the coroutine consumed the claim:
+    ///     releases the slot (unless the worker died in between — then the
+    ///     generation mismatch shows the claim was already cleaned up).
     struct PendingStateless {
+        WorkerPool& pool;
         worker::Priority priority;
 
-        /// Signalled by try_dispatch_pending() when a worker becomes available.
+        /// Signalled by try_dispatch_pending().
         kota::event ready{};
 
-        /// Set by try_dispatch_pending() before signalling ready.
-        /// SIZE_MAX means the pool is dead and no worker was assigned.
-        std::size_t assigned_worker = 0;
+        /// Set to the claimed worker before signalling ready; stays SIZE_MAX
+        /// when the waiter is woken only to observe pool death or stop.
+        std::size_t assigned_worker = SIZE_MAX;
 
-        /// restart_count of the assigned worker at dispatch time.
+        /// Generation of the claimed worker at dispatch time.
         unsigned assigned_gen = 0;
 
         /// Points to whichever queue (high/low) this entry sits in; nullptr
-        /// once popped or if never enqueued.
+        /// once popped.
         std::deque<PendingStateless*>* queue = nullptr;
 
-        /// Non-null while the slot hasn't been claimed by the coroutine.
-        /// Cleared after co_await returns so the destructor doesn't release
-        /// a slot that StatelessSlot now owns.
-        WorkerPool* pool = nullptr;
-
-        explicit PendingStateless(worker::Priority p) : priority(p) {}
+        PendingStateless(WorkerPool& pool, worker::Priority priority) :
+            pool(pool), priority(priority) {}
 
         PendingStateless(const PendingStateless&) = delete;
         PendingStateless& operator=(const PendingStateless&) = delete;
@@ -173,30 +237,29 @@ private:
         ~PendingStateless() {
             if(queue) {
                 std::erase(*queue, this);
-            } else if(assigned_worker != SIZE_MAX && pool) {
-                // Only release if the slot hasn't been crash-replaced.
-                if(pool->stateless_workers[assigned_worker].restart_count == assigned_gen)
-                    pool->release_stateless_slot(assigned_worker);
+            } else if(assigned_worker != SIZE_MAX &&
+                      pool.stateless_workers[assigned_worker].generation == assigned_gen) {
+                pool.release_stateless_slot(assigned_worker);
             }
         }
     };
 
     /// RAII guard that releases a stateless worker slot on scope exit.
-    /// Captures restart_count at construction so that a crash-and-respawn
-    /// on the same index won't accidentally clear the new occupant's busy flag.
+    /// Captures the generation so a death-and-respawn on the same index
+    /// won't accidentally clear the new occupant's busy flag.
     struct StatelessSlot {
         WorkerPool& pool;
         std::size_t worker_index;
         unsigned gen;
 
         StatelessSlot(WorkerPool& p, std::size_t idx) :
-            pool(p), worker_index(idx), gen(p.stateless_workers[idx].restart_count) {}
+            pool(p), worker_index(idx), gen(p.stateless_workers[idx].generation) {}
 
         StatelessSlot(const StatelessSlot&) = delete;
         StatelessSlot& operator=(const StatelessSlot&) = delete;
 
         ~StatelessSlot() {
-            if(pool.stateless_workers[worker_index].restart_count == gen)
+            if(pool.stateless_workers[worker_index].generation == gen)
                 pool.release_stateless_slot(worker_index);
         }
     };
@@ -206,51 +269,107 @@ private:
     std::deque<PendingStateless*> high_queue;
     std::deque<PendingStateless*> low_queue;
 
-    std::size_t stateless_busy_count = 0;
-    std::size_t low_busy_count = 0;
-    std::size_t alive_stateless_count = 0;
-
-    /// Max concurrent low-priority tasks.  Dynamically adjusted by
-    /// monitor_memory() and apply_crash_backoff().
+    /// Max concurrent low-priority tasks, adjusted by tick_memory() and
+    /// apply_crash_backoff(). Reads go through effective_low_limit(), which
+    /// clamps to the capacity-derived ceiling.
     std::size_t low_limit = 0;
 
-    /// Ceiling for low_limit recovery (set once at start).
-    std::size_t max_low_limit = 0;
-
-    /// Remaining monitor_memory cycles to skip after a crash backoff,
+    /// Remaining tick_memory cycles to skip after a crash backoff,
     /// prevents crash AIMD and memory pressure from compounding.
     unsigned backoff_cooldown = 0;
 
-    /// Wait for an idle stateless worker. Returns SIZE_MAX when the pool
-    /// is dead (all workers down, no restarts left).
-    /// @param exclude  worker index to skip (e.g. a peer that just failed
-    ///                 but whose crash hasn't been processed yet).
-    kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority,
-                                                   std::size_t exclude = SIZE_MAX);
+    // All occupancy numbers are derived from slot state on demand instead of
+    // being maintained as counters — with at most a few dozen slots the scans
+    // are trivial, and there is no incremental bookkeeping to drift.
+
+    /// Stateless slots that can serve requests now.
+    std::size_t alive_stateless() const;
+
+    /// Alive stateless slots with a request in flight.
+    std::size_t busy_stateless() const;
+
+    /// Alive stateless slots busy with low-priority work.
+    std::size_t low_busy_count() const;
+
+    /// Stateless slots that are not permanently vacant (Dead/Retired):
+    /// alive ones plus those dying or awaiting respawn.
+    std::size_t stateless_capacity() const;
+
+    /// True while at least one stateless slot can still (eventually) serve.
+    bool has_future_capacity() const {
+        return stateless_capacity() > 0;
+    }
+
+    /// Reserve one worker for high-priority requests by capping low-priority
+    /// concurrency at capacity - 1. With a single worker this collapses to 1:
+    /// both priorities share it, and high wins only via queue ordering.
+    std::size_t max_low_limit() const {
+        auto capacity = stateless_capacity();
+        return capacity > 1 ? capacity - 1 : capacity;
+    }
+
+    std::size_t effective_low_limit() const {
+        return std::min(low_limit, max_low_limit());
+    }
+
+    /// Wait for an idle stateless worker. Returns SIZE_MAX when no slot can
+    /// serve the request anymore (pool stopped or all slots given up).
+    kota::task<std::size_t> acquire_stateless_slot(worker::Priority priority);
     void release_stateless_slot(std::size_t worker_index);
 
-    /// Wake queued requests when a worker becomes available.
+    /// Mark a claimed worker busy. Returns the index for chaining.
+    std::size_t claim_stateless(std::size_t index, worker::Priority priority);
+
+    /// Wake queued requests when a worker becomes available; drains the
+    /// queues with a failure signal when no capacity remains.
     void try_dispatch_pending();
 
-    /// Wake all queued requests with SIZE_MAX (pool is dead).
+    /// Wake all queued requests without a claim so they observe pool death.
     void fail_pending_requests();
 
-    std::size_t pick_idle_stateless(std::size_t exclude = SIZE_MAX);
+    std::size_t pick_idle_stateless();
 
-    /// Periodically adjusts low_limit based on system memory pressure
-    /// and triggers dynamic scaling checks.
-    kota::task<> monitor_memory();
+    /// Declare a worker's process dead right now: bump the generation, drop
+    /// the busy claim and the peer reference. Idempotent — safe to call from
+    /// a failed send before the monitor observed the exit. `kill_process`
+    /// must be true when death is declared ahead of the verdict (failed
+    /// send, preemption) so monitor_worker's proc.wait() is guaranteed to
+    /// deliver; the monitor itself passes false — its process was already
+    /// reaped, and signalling the freed pid could hit an unrelated process.
+    void mark_worker_dead(std::size_t index, bool stateful, bool kill_process);
+
+    /// Handle a crash verdict: log/relay, update crash accounting, fire
+    /// on_crash. Returns true if the worker should be respawned; on false the
+    /// slot has been given up.
+    bool process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal);
+
+    /// Respawn a slot after `delay`, retrying with growing backoff if the
+    /// spawn itself fails; gives the slot up once the streak is exhausted.
+    kota::task<> respawn_after(std::size_t index, bool stateful, std::chrono::milliseconds delay);
+
+    /// Backoff before the respawn for the given crash streak: immediate for
+    /// the first crash, exponential from the second on.
+    std::chrono::milliseconds backoff_delay(unsigned crash_streak) const;
+
+    /// Permanently vacate a slot and fail waiters if it was the last one.
+    void give_up_slot(std::size_t index, bool stateful);
+
+    /// AIMD multiplicative decrease on stateless concurrency limit.
+    void apply_crash_backoff();
+
+    /// 3s tick driving the two controllers below.
+    kota::task<> monitor_loop();
+
+    /// Adjusts low_limit from memory pressure (AIMD down, CUBIC-style fast
+    /// recovery up) and preempts running low-priority work when severe.
+    void tick_memory(double available_ratio);
+
+    /// Scales the stateless pool up/down from saturation/idle streaks.
+    void tick_scaling(double available_ratio);
 
     /// SIGKILL any worker still alive after the SIGTERM grace period, so a
     /// wedged worker can't block stop()'s join forever.
     kota::task<> kill_stragglers();
-
-    /// Handle worker crash: update state, fire on_crash callback.
-    /// Returns true if the worker should be restarted.
-    bool process_crash(std::size_t index, bool stateful, int exit_code, int exit_signal);
-
-    /// AIMD multiplicative decrease on stateless concurrency limit.
-    void apply_crash_backoff();
 
     // --- Dynamic scaling ---
 
@@ -261,12 +380,10 @@ private:
     /// retiring, and close its output pipe + send SIGTERM.
     void retire_idle_worker();
 
-    /// Evaluate scaling conditions and act (called from monitor_memory).
-    void check_scaling();
-
-    /// Cancel up to `count` in-flight low-priority requests to relieve
-    /// memory pressure.
-    void cancel_low_priority_requests(std::size_t count);
+    /// Kill up to `count` in-flight low-priority workers to relieve memory
+    /// pressure. Their requests fail with dispatch_errc::cancelled and the
+    /// processes respawn immediately without crash accounting.
+    void preempt_low_priority(std::size_t count);
 
     /// CUBIC-style fast recovery target: last low_limit before a reduction.
     std::size_t w_max = 0;
@@ -280,19 +397,14 @@ private:
     constexpr static unsigned scale_up_ticks = 5;
     constexpr static unsigned scale_down_ticks = 10;
 
-    /// Per-slot cancellation source for in-flight low-priority requests.
-    /// Indexed by stateless worker index; null when no low-priority request
-    /// is in flight.
-    llvm::SmallVector<std::shared_ptr<kota::cancellation_source>> slot_cancel_sources;
-
-    /// Cancelled by stop(). Unwinds monitor_memory() at its poll sleep
-    /// instead of waiting out the 3s interval, and lets
-    /// monitor_worker() attribute the SIGTERM-induced exits that follow to
-    /// intentional shutdown (no anomaly, no respawn).
+    /// Cancelled by stop(). Unwinds monitor_loop() and respawn backoff sleeps
+    /// at their poll points, and lets monitor_worker() attribute the
+    /// SIGTERM-induced exits that follow to intentional shutdown (no anomaly,
+    /// no respawn).
     kota::cancellation_source stop_scope;
 
     /// All long-lived pool coroutines: monitor_worker() exit observers, the
-    /// peer->run() / drain_stderr() IO pumps, and the wrapped memory poller.
+    /// peer IO pumps and stderr drains, respawn tasks, and the monitor loop.
     /// Never cancelled as a group — stop() joins it, so shutdown waits until
     /// every worker process actually exited and its final output (crash
     /// stacktraces, sanitizer reports) was drained to EOF.
@@ -300,12 +412,23 @@ private:
     WorkerPoolOptions options;
     std::string log_dir;
 
-    /// Peers moved here during respawn so their coroutines can finish
-    /// before the object is destroyed.
-    llvm::SmallVector<std::unique_ptr<kota::ipc::BincodePeer>> retired_peers;
+    struct SpawnedProcess {
+        kota::process proc;
+        std::shared_ptr<kota::ipc::BincodePeer> peer;
+    };
 
-    bool spawn_worker(const std::string& self_path, bool stateful, std::uint64_t memory_limit);
+    /// Launch a worker process and start its IO pumps. Shared by initial
+    /// spawn, scale-up, and respawn.
+    std::optional<SpawnedProcess> spawn_process(const std::string& name, bool stateful);
+
+    /// Append a new slot (initial start and scale-up).
+    bool spawn_worker(bool stateful);
+
+    /// Refill an existing slot with a fresh process.
     bool respawn_worker(std::size_t index, bool stateful);
+
+    void install_evict_handler(WorkerProcess& worker);
+
     kota::task<> monitor_worker(std::size_t index, bool stateful);
 
     friend struct testing::WorkerPoolFixture;
@@ -315,73 +438,90 @@ template <typename Params>
 RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
                                                 const Params& params,
                                                 kota::ipc::request_options opts) {
-    if(stateful_workers.empty()) {
+    auto idx = assign_worker(path_id);
+    if(idx == SIZE_MAX) {
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
                                                        "No stateful workers available"});
     }
-    auto idx = assign_worker(path_id);
-    if(!stateful_workers[idx].alive) {
+
+    auto& assigned = stateful_workers[idx];
+    if(assigned.state == SlotState::Dying || assigned.state == SlotState::Respawning) {
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_crashed,
+                                                       "Assigned stateful worker is restarting"});
+    }
+    if(assigned.state != SlotState::Alive) {
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
                                                        "Assigned stateful worker is down"});
     }
-    co_return co_await stateful_workers[idx].peer->send_request(params, opts);
+
+    // Own a peer reference across the await: the slot drops its copy the
+    // moment the worker dies.
+    auto peer = assigned.peer;
+    auto gen = assigned.generation;
+    auto result = co_await peer->send_request(params, opts);
+
+    if(result.has_value() || !worker::is_transport_error(result.error()))
+        co_return std::move(result);
+
+    // The worker link broke mid-request. Declare the slot dead now so
+    // follow-up requests fail fast instead of piling onto a corpse;
+    // monitor_worker reconciles with the real exit status.
+    if(stateful_workers[idx].generation == gen)
+        mark_worker_dead(idx, true, true);
+    co_return kota::outcome_error(
+        kota::ipc::Error{worker::dispatch_errc::worker_crashed,
+                         "Stateful worker died during request: " + result.error().message});
 }
 
 template <typename Params>
 RequestResult<Params> WorkerPool::send_stateless(const Params& params,
                                                  kota::ipc::request_options opts) {
-    if(stateless_workers.empty()) {
+    auto idx = co_await acquire_stateless_slot(params.priority);
+    if(idx == SIZE_MAX) {
         co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
                                                        "No stateless workers available"});
     }
 
-    // Retry once on transport error, excluding the failed peer so the
-    // retry doesn't hit the same dead worker before process_crash runs.
-    std::size_t exclude = SIZE_MAX;
-    for(int attempt = 0; attempt < 2; ++attempt) {
-        auto idx = co_await acquire_stateless_slot(params.priority, exclude);
-        if(idx >= stateless_workers.size())
-            co_return kota::outcome_error(
-                kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
-                                 "All stateless workers are down"});
+    StatelessSlot slot(*this, idx);
+    auto peer = stateless_workers[idx].peer;
+    auto gen = stateless_workers[idx].generation;
 
-        StatelessSlot slot(*this, idx);
-
-        if(!stateless_workers[idx].alive)
-            continue;
-
-        // For low-priority requests, install a cancellation source so
-        // monitor_memory() can preempt under severe memory pressure.
-        // FIXME: cancelling only aborts the IPC wait — the worker process
-        // continues compiling until it finishes. The slot is released here
-        // but the worker won't accept new work until the in-flight RPC
-        // completes, so the next request dispatched to it queues at the
-        // IPC layer. Not a correctness bug, but limits preemption efficacy.
-        std::shared_ptr<kota::cancellation_source> preempt_src;
-        if(params.priority == worker::Priority::Low) {
-            preempt_src = std::make_shared<kota::cancellation_source>();
-            if(idx < slot_cancel_sources.size())
-                slot_cancel_sources[idx] = preempt_src;
-            if(!opts.token)
-                opts.token = preempt_src->token();
-        }
-
-        auto result = co_await stateless_workers[idx].peer->send_request(params, opts);
-
-        if(result.has_value())
-            co_return std::move(result);
-
-        // If deliberately cancelled by memory pressure, don't retry.
-        if(preempt_src && preempt_src->cancelled())
-            co_return kota::outcome_error(
-                kota::ipc::Error{worker::dispatch_errc::cancelled,
-                                 "Request cancelled due to memory pressure"});
-
-        // Transport error — retry on a different worker.
-        exclude = idx;
+    // For low-priority requests, install a cancellation source so
+    // preempt_low_priority() can signal the preemption to this sender
+    // before the kill's transport error arrives.
+    std::shared_ptr<kota::cancellation_source> preempt_src;
+    if(params.priority == worker::Priority::Low) {
+        preempt_src = std::make_shared<kota::cancellation_source>();
+        stateless_workers[idx].preempt_source = preempt_src;
+        if(!opts.token)
+            opts.token = preempt_src->token();
     }
-    co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
-                                                   "Stateless request failed after retries"});
+
+    auto result = co_await peer->send_request(params, opts);
+    if(result.has_value())
+        co_return std::move(result);
+
+    if(preempt_src && preempt_src->cancelled())
+        co_return kota::outcome_error(kota::ipc::Error{worker::dispatch_errc::cancelled,
+                                                       "Request preempted under memory pressure"});
+
+    // An error returned by the worker's handler leaves the worker healthy;
+    // pass it through untouched.
+    if(!worker::is_transport_error(result.error()))
+        co_return std::move(result);
+
+    // The worker link broke mid-request: declare the slot dead now so a
+    // caller-side retry cannot land on the same corpse before the monitor
+    // observed the exit.
+    if(stateless_workers[idx].generation == gen) {
+        mark_worker_dead(idx, false, true);
+        // The dead worker's claim is gone; a queued low-priority waiter may
+        // now fit under the limit on another idle worker.
+        try_dispatch_pending();
+    }
+    co_return kota::outcome_error(
+        kota::ipc::Error{worker::dispatch_errc::worker_crashed,
+                         "Stateless worker died during request: " + result.error().message});
 }
 
 template <typename Params>
@@ -389,9 +529,10 @@ void WorkerPool::notify_stateful(std::uint32_t path_id, const Params& params) {
     auto it = owner.find(path_id);
     if(it == owner.end())
         return;
-    if(!stateful_workers[it->second].alive)
+    auto& assigned = stateful_workers[it->second];
+    if(assigned.state != SlotState::Alive)
         return;
-    stateful_workers[it->second].peer->send_notification(params);
+    assigned.peer->send_notification(params);
 }
 
 }  // namespace clice

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -325,6 +325,10 @@ private:
     /// alive ones plus those dying or awaiting respawn.
     std::size_t stateless_capacity() const;
 
+    /// Stateless slots still holding a process: stateless_capacity() plus
+    /// retiring workers, which keep theirs until the monitor reaps them.
+    std::size_t stateless_footprint() const;
+
     /// True while at least one stateless slot can still (eventually) serve.
     bool has_future_capacity() const {
         return stateless_capacity() > 0;

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -80,6 +80,21 @@ struct WorkerPoolOptions {
     std::uint32_t max_stateless = 0;
 };
 
+/// How much the caller distrusts a stateful dispatch (see the class doc's
+/// responsibility contract). Every flavor of distrust exempts the slot's
+/// crash budget; they differ in routing.
+enum class Suspect : std::uint8_t {
+    /// Ordinary work.
+    No,
+    /// A quarantined document's probe compile: runs only on a worker
+    /// hosting no other document, so a crash takes nothing healthy along.
+    Isolated,
+    /// A quarantined document's recovery query: it must reach the worker
+    /// holding the AST, so it keeps owner routing; while it flies, the
+    /// worker is avoided by new-document assignment.
+    InPlace,
+};
+
 /// Multi-process scheduler for clice worker processes.
 ///
 /// Two kinds of workers are managed:
@@ -109,10 +124,12 @@ struct WorkerPoolOptions {
 ///     never blamed twice). worker_restarting: never dispatched, blameless.
 ///     worker_unavailable: a capacity window — retryable later when
 ///     revives_slots(). cancelled: deliberate preemption, requeue freely.
-///   - `suspect` is the single sanctioned policy hint INTO the pool: the
-///     caller already distrusts the workload (a quarantine probe), so its
-///     crash spends no slot budget and it only runs where it can take no
-///     healthy document with it.
+///   - Suspect is the single sanctioned policy hint INTO the pool: the
+///     caller already distrusts the workload, so its crash spends no slot
+///     budget. An Isolated probe additionally runs only where it can take
+///     no healthy document with it; an InPlace recovery query keeps owner
+///     routing (the AST lives there) and is merely avoided by new-document
+///     assignment while it flies.
 class WorkerPool {
 public:
     WorkerPool(kota::event_loop& loop) : loop(loop) {}
@@ -124,15 +141,14 @@ public:
     kota::task<> stop();
 
     /// Send a request to a stateful worker with path_id affinity routing.
-    /// `suspect` marks a workload the caller already distrusts (a
-    /// quarantined document's probe): if it crashes the worker, the crash
-    /// does not spend the slot's budget — the failure says something about
-    /// the document, not the slot.
+    /// A suspect dispatch's crash does not spend the slot's budget — the
+    /// failure says something about the document, not the slot; see
+    /// Suspect for the routing difference between its flavors.
     template <typename Params>
     RequestResult<Params> send_stateful(std::uint32_t path_id,
                                         const Params& params,
                                         kota::ipc::request_options opts = {},
-                                        bool suspect = false);
+                                        Suspect suspect = Suspect::No);
 
     /// Send a request to a stateless worker with priority-aware scheduling.
     template <typename Params>
@@ -519,17 +535,18 @@ template <typename Params>
 RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
                                                 const Params& params,
                                                 kota::ipc::request_options opts,
-                                                bool suspect) {
-    // A suspect workload only runs on a worker hosting no other document:
+                                                Suspect suspect) {
+    // An isolated probe only runs on a worker hosting no other document:
     // its crash must never take healthy sessions with it. With no such
     // worker available right now, the caller keeps the probe armed and
-    // tries again later instead of risking one.
-    auto idx = suspect ? assign_expendable(path_id) : assign_worker(path_id);
+    // tries again later instead of risking one. An in-place suspect stays
+    // with the owner — the AST it queries lives there.
+    auto idx = suspect == Suspect::Isolated ? assign_expendable(path_id) : assign_worker(path_id);
     if(idx == SIZE_MAX) {
-        co_return kota::outcome_error(
-            kota::ipc::Error{worker::dispatch_errc::worker_unavailable,
-                             suspect ? "No expendable stateful worker for quarantined probe"
-                                     : "No stateful workers available"});
+        co_return kota::outcome_error(kota::ipc::Error{
+            worker::dispatch_errc::worker_unavailable,
+            suspect == Suspect::Isolated ? "No expendable stateful worker for quarantined probe"
+                                         : "No stateful workers available"});
     }
 
     auto& assigned = stateful_workers[idx];
@@ -546,7 +563,7 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
     // moment the worker dies.
     auto peer = assigned.peer;
     auto gen = assigned.generation;
-    if(suspect) {
+    if(suspect != Suspect::No) {
         assigned.suspect_inflight += 1;
     }
     auto result = co_await peer->send_request(params, opts);
@@ -554,7 +571,7 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
     // a crash leaves it for the monitor's accounting to consume, and the
     // generation guard skips incarnations already torn down elsewhere.
     bool transport_dead = !result.has_value() && worker::is_transport_error(result.error());
-    if(suspect && !transport_dead && stateful_workers[idx].generation == gen &&
+    if(suspect != Suspect::No && !transport_dead && stateful_workers[idx].generation == gen &&
        stateful_workers[idx].suspect_inflight > 0) {
         stateful_workers[idx].suspect_inflight -= 1;
     }

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -351,6 +351,12 @@ private:
     /// the first crash, exponential from the second on.
     std::chrono::milliseconds backoff_delay(unsigned crash_streak) const;
 
+    /// A worker that ran healthily for a while starts a fresh streak: the
+    /// budget bounds crash loops, not lifetime bad luck. Called on crash
+    /// accounting and on preemption — a preempted slot must not carry a
+    /// stale streak past the healthy interval that would have cleared it.
+    void reset_streak_if_healthy(WorkerProcess& w);
+
     /// Permanently vacate a slot and fail waiters if it was the last one.
     void give_up_slot(std::size_t index, bool stateful);
 

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -301,11 +301,14 @@ private:
     }
 
     /// Reserve one worker for high-priority requests by capping low-priority
-    /// concurrency at capacity - 1. With a single worker this collapses to 1:
-    /// both priorities share it, and high wins only via queue ordering.
+    /// concurrency at one below the slots that can be scheduled right now.
+    /// A slot dying or awaiting respawn cannot serve; counting it would let
+    /// low-priority work occupy every live worker for the whole respawn
+    /// window. With a single live worker this collapses to 1: both
+    /// priorities share it, and high wins only via queue ordering.
     std::size_t max_low_limit() const {
-        auto capacity = stateless_capacity();
-        return capacity > 1 ? capacity - 1 : capacity;
+        auto live = alive_stateless();
+        return live > 1 ? live - 1 : live;
     }
 
     std::size_t effective_low_limit() const {

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -563,17 +563,37 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
     // moment the worker dies.
     auto peer = assigned.peer;
     auto gen = assigned.generation;
+
+    // RAII unwind: a cancellation that unwinds the frame mid-await must
+    // not leave the worker marked as hosting suspect work forever. On
+    // transport death the guard is disarmed instead — the monitor's crash
+    // accounting consumes the count — and the generation check skips
+    // incarnations already torn down elsewhere.
+    struct SuspectGuard {
+        WorkerPool& pool;
+        std::size_t idx;
+        unsigned gen;
+        bool armed;
+
+        ~SuspectGuard() {
+            if(!armed) {
+                return;
+            }
+            auto& w = pool.stateful_workers[idx];
+            if(w.generation == gen && w.suspect_inflight > 0) {
+                w.suspect_inflight -= 1;
+            }
+        }
+    };
+
     if(suspect != Suspect::No) {
         assigned.suspect_inflight += 1;
     }
+    SuspectGuard suspect_guard{*this, idx, gen, suspect != Suspect::No};
     auto result = co_await peer->send_request(params, opts);
-    // Unwind the counter only when the request did not die on transport:
-    // a crash leaves it for the monitor's accounting to consume, and the
-    // generation guard skips incarnations already torn down elsewhere.
     bool transport_dead = !result.has_value() && worker::is_transport_error(result.error());
-    if(suspect != Suspect::No && !transport_dead && stateful_workers[idx].generation == gen &&
-       stateful_workers[idx].suspect_inflight > 0) {
-        stateful_workers[idx].suspect_inflight -= 1;
+    if(transport_dead) {
+        suspect_guard.armed = false;
     }
 
     if(result.has_value() || !worker::is_transport_error(result.error()))

--- a/src/server/worker/worker_pool.h
+++ b/src/server/worker/worker_pool.h
@@ -91,12 +91,28 @@ struct WorkerPoolOptions {
 ///   - Stateful workers keep per-document ASTs; each open document is pinned
 ///     to one worker (path_id affinity), balanced by document count.
 ///
-/// The pool owns process lifecycle only: it respawns crashed workers with
-/// exponential backoff and gives a slot up once a streak exceeds
-/// `max_crash_streak` consecutive fast crashes. It never retries requests. A request that was
-/// in flight when its worker died fails with dispatch_errc::worker_crashed
-/// (or dispatch_errc::cancelled if the pool itself preempted the worker to
-/// relieve memory pressure); the caller decides whether to resend or requeue.
+/// Responsibility contract — the pool is mechanism, callers are policy:
+///
+///   - The pool owns PROCESSES and CAPACITY: spawn, monitor, respawn with
+///     backoff, per-slot crash budget (streak, healthy-uptime reset),
+///     give-up -> cooldown revival, scaling between min/max, preemption
+///     under memory pressure, scheduling (priority, affinity, probe
+///     isolation). Its guarantee: capacity is never permanently zero.
+///   - The pool NEVER retries a request. Requests do not survive a crash;
+///     slots do. Retry policy is semantic and lives with the caller: the
+///     compiler resends idempotent builds once, the indexer requeues with
+///     its own budget, a stateful compile never resends (the crash is
+///     evidence about the content — see state/quarantine.h).
+///   - The dispatch_errc taxonomy is the contract language. worker_crashed:
+///     the request died with its worker — the caller may blame its content
+///     (Error::data carries the dead incarnation's identity so one death is
+///     never blamed twice). worker_restarting: never dispatched, blameless.
+///     worker_unavailable: a capacity window — retryable later when
+///     revives_slots(). cancelled: deliberate preemption, requeue freely.
+///   - `suspect` is the single sanctioned policy hint INTO the pool: the
+///     caller already distrusts the workload (a quarantine probe), so its
+///     crash spends no slot budget and it only runs where it can take no
+///     healthy document with it.
 class WorkerPool {
 public:
     WorkerPool(kota::event_loop& loop) : loop(loop) {}
@@ -553,7 +569,8 @@ RequestResult<Params> WorkerPool::send_stateful(std::uint32_t path_id,
         mark_worker_dead(idx, true, true);
     co_return kota::outcome_error(
         kota::ipc::Error{worker::dispatch_errc::worker_crashed,
-                         "Stateful worker died during request: " + result.error().message});
+                         "Stateful worker died during request: " + result.error().message,
+                         worker::death_identity(idx, gen, true)});
 }
 
 template <typename Params>
@@ -604,7 +621,8 @@ RequestResult<Params> WorkerPool::send_stateless(const Params& params,
     }
     co_return kota::outcome_error(
         kota::ipc::Error{worker::dispatch_errc::worker_crashed,
-                         "Stateless worker died during request: " + result.error().message});
+                         "Stateless worker died during request: " + result.error().message,
+                         worker::death_identity(idx, gen, false)});
 }
 
 template <typename Params>

--- a/tests/integration/lifecycle/test_crash_recovery.py
+++ b/tests/integration/lifecycle/test_crash_recovery.py
@@ -1,0 +1,96 @@
+"""Crash-recovery of background indexing.
+
+Kills stateless workers while an indexing round is in flight and verifies the
+round still converges: in-flight files fail with worker_crashed, the indexer
+requeues them, and a follow-up round indexes every file.
+"""
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+import pytest
+from lsprotocol.types import WorkspaceSymbolParams
+
+from tests.tools.lifecycle import make_client, shutdown_client
+from tests.tools.compile_commands import write_cdb
+
+FILE_COUNT = 20
+
+
+def stateless_worker_pids(server_pid: int) -> list[int]:
+    pids = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text()
+            cmdline = (entry / "cmdline").read_bytes()
+        except OSError:
+            continue
+        ppid = int(stat.rsplit(")", 1)[1].split()[1])
+        if ppid == server_pid and b"SL-" in cmdline:
+            pids.append(int(entry.name))
+    return pids
+
+
+async def indexed_functions(client) -> set[str]:
+    result = await client.workspace_symbol_async(WorkspaceSymbolParams(query="func_"))
+    return {s.name for s in result or []}
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="worker discovery uses /proc")
+@pytest.mark.allow_anomaly
+async def test_crash_during_indexing(executable, tmp_path):
+    # Enough moderately heavy TUs that the indexing round is still in flight
+    # when the workers get killed.
+    files = []
+    for i in range(FILE_COUNT):
+        name = f"file_{i}.cpp"
+        (tmp_path / name).write_text(
+            f"#include <vector>\n#include <string>\n"
+            f'int func_{i}() {{ return (int)std::string("{i}").size(); }}\n'
+        )
+        files.append(name)
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    write_cdb(tmp_path, files + ["main.cpp"])
+
+    # The kills below surface as WorkerCrash anomalies; Debug builds abort on
+    # anomalies by design, so disable the trap like test_anomaly does.
+    os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
+    try:
+        client = await make_client(executable, tmp_path)
+    finally:
+        os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
+
+    try:
+        uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+
+        # Wait until the round demonstrably started (first symbols merged),
+        # then kill a stateless worker mid-round.
+        killed = False
+        for _ in range(300):
+            if await indexed_functions(client):
+                workers = stateless_worker_pids(client.server.pid)
+                if workers:
+                    os.kill(workers[0], signal.SIGKILL)
+                    killed = True
+                break
+            await asyncio.sleep(0.1)
+        assert killed, "indexing never started or no stateless worker found"
+
+        # The files that were in flight on the killed worker must be
+        # requeued and indexed by a follow-up round: every function
+        # eventually appears in the project index.
+        expected = {f"func_{i}" for i in range(FILE_COUNT)}
+        found: set[str] = set()
+        for _ in range(120):
+            found = await indexed_functions(client)
+            if expected <= found:
+                break
+            await asyncio.sleep(1)
+        assert expected <= found, f"missing after crash: {sorted(expected - found)}"
+    finally:
+        await shutdown_client(client)

--- a/tests/integration/lifecycle/test_poison_quarantine.py
+++ b/tests/integration/lifecycle/test_poison_quarantine.py
@@ -7,6 +7,7 @@ that fixes it earns a probe that brings it back.
 """
 
 import asyncio
+import os
 
 import pytest
 from lsprotocol.types import (
@@ -42,7 +43,12 @@ async def test_poison_quarantine(executable, tmp_path):
     (tmp_path / "poison.cpp").write_text(POISON.format(n=0))
     write_cdb(tmp_path, ["healthy.cpp", "poison.cpp"])
 
+    # Worker crashes are the point of this test; Debug builds trap
+    # anomalies with abort() unless told otherwise (same as
+    # test_crash_recovery.py).
+    os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
     client = await make_client(executable, tmp_path)
+    os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
     try:
         healthy_uri, _ = client.open(tmp_path / "healthy.cpp")
         poison_uri, _ = client.open(tmp_path / "poison.cpp")

--- a/tests/integration/lifecycle/test_poison_quarantine.py
+++ b/tests/integration/lifecycle/test_poison_quarantine.py
@@ -24,6 +24,13 @@ POISON = (
     "// edit {n}\n"
     "#pragma clang __debug crash\n"
 )
+# The pragma before any declaration lands in the preamble: the PCH build
+# crashes the stateless worker before any stateful compile runs.
+POISON_PREAMBLE = (
+    "#pragma clang __debug crash\n"
+    "// edit {n}\n"
+    "int add(int a, int b) {{ return a + b; }}\n"
+)
 FIXED = "int add(int a, int b) { return a + b; }\n"
 HEALTHY = "int healthy(int x) { return x * 2; }\n"
 
@@ -99,5 +106,58 @@ async def test_poison_quarantine(executable, tmp_path):
 
         hover = await client.hover_at(healthy_uri, 0, 5)
         assert hover is not None, "healthy hover failed after recovery"
+    finally:
+        await shutdown_client(client)
+
+
+@pytest.mark.allow_anomaly
+async def test_poison_preamble_quarantine(executable, tmp_path):
+    (tmp_path / "healthy.cpp").write_text(HEALTHY)
+    (tmp_path / "poison.cpp").write_text(POISON_PREAMBLE.format(n=0))
+    write_cdb(tmp_path, ["healthy.cpp", "poison.cpp"])
+
+    os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
+    client = await make_client(executable, tmp_path)
+    os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
+    try:
+        healthy_uri, _ = client.open(tmp_path / "healthy.cpp")
+        poison_uri, _ = client.open(tmp_path / "poison.cpp")
+
+        # PCH-build crashes count toward the same streak as compile crashes,
+        # so a poison preamble must still reach quarantine.
+        for i in range(1, 4):
+            await client.hover_at(poison_uri, 2, 5)
+            change_whole(client, poison_uri, i, POISON_PREAMBLE.format(n=i))
+            await asyncio.sleep(0.3)
+
+        deadline = 20
+        while deadline > 0:
+            diags = client.diagnostics.get(poison_uri, [])
+            if any("quarantined" in d.message for d in diags):
+                break
+            await asyncio.sleep(0.5)
+            deadline -= 1
+        assert any(
+            "quarantined" in d.message for d in client.diagnostics.get(poison_uri, [])
+        ), f"missing quarantine diagnostic: {client.diagnostics.get(poison_uri, [])}"
+
+        # Healthy documents survive the stateless carnage.
+        hover = None
+        for _ in range(10):
+            hover = await client.hover_at(healthy_uri, 0, 5)
+            if hover is not None:
+                break
+            await asyncio.sleep(0.5)
+        assert hover is not None, "healthy hover lost to poison preamble"
+
+        # Fixing the preamble earns a probe that brings the file back.
+        change_whole(client, poison_uri, 100, FIXED)
+        recovered = None
+        for _ in range(20):
+            await asyncio.sleep(0.5)
+            recovered = await client.hover_at(poison_uri, 0, 5)
+            if recovered is not None:
+                break
+        assert recovered is not None, "fixed preamble did not recover"
     finally:
         await shutdown_client(client)

--- a/tests/integration/lifecycle/test_poison_quarantine.py
+++ b/tests/integration/lifecycle/test_poison_quarantine.py
@@ -1,0 +1,97 @@
+"""A poison document must not kill the session (F19 quarantine).
+
+A file whose compiles crash the stateful worker is quarantined after two
+consecutive crashes: healthy documents keep answering through it, the poison
+file carries an explanatory diagnostic instead of an empty list, and an edit
+that fixes it earns a probe that brings it back.
+"""
+
+import asyncio
+
+import pytest
+from lsprotocol.types import (
+    DidChangeTextDocumentParams,
+    TextDocumentContentChangeWholeDocument,
+    VersionedTextDocumentIdentifier,
+)
+
+from tests.tools.lifecycle import make_client, shutdown_client
+from tests.tools.compile_commands import write_cdb
+
+POISON = (
+    "int add(int a, int b) {{ return a + b; }}\n"
+    "// edit {n}\n"
+    "#pragma clang __debug crash\n"
+)
+FIXED = "int add(int a, int b) { return a + b; }\n"
+HEALTHY = "int healthy(int x) { return x * 2; }\n"
+
+
+def change_whole(client, uri, version, text):
+    client.text_document_did_change(
+        DidChangeTextDocumentParams(
+            text_document=VersionedTextDocumentIdentifier(uri=uri, version=version),
+            content_changes=[TextDocumentContentChangeWholeDocument(text=text)],
+        )
+    )
+
+
+@pytest.mark.allow_anomaly
+async def test_poison_quarantine(executable, tmp_path):
+    (tmp_path / "healthy.cpp").write_text(HEALTHY)
+    (tmp_path / "poison.cpp").write_text(POISON.format(n=0))
+    write_cdb(tmp_path, ["healthy.cpp", "poison.cpp"])
+
+    client = await make_client(executable, tmp_path)
+    try:
+        healthy_uri, _ = client.open(tmp_path / "healthy.cpp")
+        poison_uri, _ = client.open(tmp_path / "poison.cpp")
+
+        hover = await client.hover_at(healthy_uri, 0, 5)
+        assert hover is not None, "healthy baseline hover failed"
+
+        async def healthy_answers(context: str):
+            # The first two crashes may transiently take healthy's worker
+            # with them (sub-second respawn); the guarantee under test is
+            # that healthy is never PERMANENTLY lost.
+            for _ in range(10):
+                if await client.hover_at(healthy_uri, 0, 5) is not None:
+                    return
+                await asyncio.sleep(0.5)
+            assert False, f"healthy hover permanently lost: {context}"
+
+        # Hammer the poison document: two crashes reach the quarantine
+        # threshold, each edit past it earns only a single probe. Healthy
+        # must keep answering through all of it.
+        for i in range(1, 5):
+            await client.hover_at(poison_uri, 0, 5)
+            change_whole(client, poison_uri, i, POISON.format(n=i))
+            await asyncio.sleep(0.3)
+            await healthy_answers(f"poison cycle {i}")
+
+        # The quarantined document explains itself.
+        deadline = 20
+        while deadline > 0:
+            diags = client.diagnostics.get(poison_uri, [])
+            if any("quarantined" in d.message for d in diags):
+                break
+            await asyncio.sleep(0.5)
+            deadline -= 1
+        assert any(
+            "quarantined" in d.message for d in client.diagnostics.get(poison_uri, [])
+        ), f"missing quarantine diagnostic: {client.diagnostics.get(poison_uri, [])}"
+
+        # Fixing the file earns a probe that brings it back.
+        change_whole(client, poison_uri, 100, FIXED)
+        recovered = None
+        for _ in range(20):
+            await asyncio.sleep(0.5)
+            recovered = await client.hover_at(poison_uri, 0, 5)
+            if recovered is not None:
+                break
+        assert recovered is not None, "fixed poison file did not recover"
+
+        hover = await client.hover_at(healthy_uri, 0, 5)
+        assert hover is not None, "healthy hover failed after recovery"
+    finally:
+        await shutdown_client(client)

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -147,7 +147,9 @@ TEST_CASE(PchCrashCountsStreak) {
                                                           directory,
                                                           arguments);
         EXPECT_FALSE(built);
-        EXPECT_EQ(session.quarantine.crashes(), 1u);
+        // Two strikes from one request: the retry's death is separate
+        // evidence — blame is counted per worker killed, not per request.
+        EXPECT_EQ(session.quarantine.crashes(), 2u);
 
         co_await pool.stop();
         done = true;
@@ -267,7 +269,8 @@ TEST_CASE(PchCrashBlocksBuild) {
         auto result = co_await compiler.forward_build(worker::BuildKind::Completion, {}, session);
         CO_ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
-        EXPECT_EQ(session->quarantine.crashes(), Quarantine::threshold);
+        // One inherited strike plus both deaths of the doomed PCH build.
+        EXPECT_EQ(session->quarantine.crashes(), 3u);
 
         co_await pool.stop();
         done = true;
@@ -337,12 +340,15 @@ TEST_CASE(PoisonPreambleBudget) {
                                                directory,
                                                arguments);
         };
+        // One request, two dead workers, two strikes: the key blocks after
+        // a single poison build instead of burning workers for a second
+        // session's attempt.
         CO_ASSERT_FALSE(co_await build(first));
-        EXPECT_EQ(first.quarantine.crashes(), 1u);
-        CO_ASSERT_FALSE(co_await build(second));
-        EXPECT_EQ(second.quarantine.crashes(), 1u);
+        EXPECT_EQ(first.quarantine.crashes(), 2u);
 
-        // The key's budget is spent: refused without touching a worker.
+        // Refused without touching a worker.
+        CO_ASSERT_FALSE(co_await build(second));
+        EXPECT_EQ(second.quarantine.crashes(), 0u);
         CO_ASSERT_FALSE(co_await build(third));
         EXPECT_EQ(third.quarantine.crashes(), 0u);
 

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -1,9 +1,13 @@
 #include <string>
 #include <vector>
 
+#include "test/temp_dir.h"
 #include "test/test.h"
 #include "server/compiler/compiler.h"
 #include "server/compiler/context_resolver.h"
+#include "server/worker_test_helpers.h"
+#include "support/anomaly.h"
+#include "support/cache_store.h"
 
 namespace clice::testing {
 
@@ -62,6 +66,67 @@ TEST_CASE(EpochGuardsPchWrite) {
     // The stale continuation left the session's PCH reference untouched.
     ASSERT_TRUE(session.pch_key.has_value());
     EXPECT_EQ(*session.pch_key, std::string("key"));
+}
+
+TEST_CASE(PchCrashCountsStreak) {
+    // A PCH build that kills its stateless worker must count toward the
+    // document's quarantine streak: the preamble is the document's content
+    // too, and without this a poison preamble never quarantines.
+    logging::set_anomaly_trap_for_testing([](logging::AnomalyId) {});
+
+    TempDir tmp;
+    tmp.touch("a.cpp", "");
+    auto src = tmp.path("a.cpp");
+
+    kota::event_loop loop;
+    Workspace workspace;
+    auto store = CacheStore::open(tmp.path("root"), 1);
+    ASSERT_TRUE(store.has_value());
+    store->register_namespace({.name = "pch",
+                               .extension = ".pch",
+                               .aux_extension = ".pch.idx",
+                               .policy = CachePolicy::LRU,
+                               .max_bytes = 1ull << 30});
+    workspace.store.emplace(std::move(*store));
+
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    Session session;
+    session.path_id = workspace.path_pool.intern(src);
+    session.text = "#pragma clang __debug crash\n";
+
+    std::string directory = tmp.path(".");
+    auto arguments = make_args(src);
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        WorkerPoolOptions opts;
+        opts.self_path = clice_binary();
+        opts.stateless_count = 1;
+        opts.stateful_count = 0;
+        CO_ASSERT_TRUE(pool.start(opts));
+        co_await kota::sleep(500);
+
+        bool built = co_await CompilerFixture::ensure_pch(compiler,
+                                                          session,
+                                                          session.generation,
+                                                          session.dirty_epoch,
+                                                          directory,
+                                                          arguments);
+        EXPECT_FALSE(built);
+        EXPECT_EQ(session.compile_crash_streak, 1u);
+
+        co_await pool.stop();
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+
+    logging::reset_anomaly_for_testing();
 }
 
 };  // TEST_SUITE(CompilerGuards)

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -156,6 +156,61 @@ TEST_CASE(PchCrashCountsStreak) {
     logging::reset_anomaly_for_testing();
 }
 
+TEST_CASE(PchCrashBlocksBuild) {
+    // A PCH crash inside a completion build's dependency prep can tip the
+    // document into quarantine after the entry gate: the build must stop
+    // instead of dispatching the same content to one more worker.
+    logging::set_anomaly_trap_for_testing([](logging::AnomalyId) {});
+
+    TempDir tmp;
+    tmp.touch("a.cpp", "");
+    auto src = tmp.path("a.cpp");
+
+    kota::event_loop loop;
+    Workspace workspace;
+    auto store = CacheStore::open(tmp.path("root"), 1);
+    ASSERT_TRUE(store.has_value());
+    store->register_namespace({.name = "pch",
+                               .extension = ".pch",
+                               .aux_extension = ".pch.idx",
+                               .policy = CachePolicy::LRU,
+                               .max_bytes = 1ull << 30});
+    workspace.store.emplace(std::move(*store));
+
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto session = std::make_shared<Session>();
+    session->path_id = workspace.path_pool.intern(src);
+    session->text = "#pragma clang __debug crash\n";
+    session->compile_crash_streak = Session::quarantine_threshold - 1;
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        WorkerPoolOptions opts;
+        opts.self_path = clice_binary();
+        opts.stateless_count = 1;
+        opts.stateful_count = 0;
+        CO_ASSERT_TRUE(pool.start(opts));
+        co_await kota::sleep(500);
+
+        auto result = co_await compiler.forward_build(worker::BuildKind::Completion, {}, session);
+        CO_ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
+        EXPECT_EQ(session->compile_crash_streak, Session::quarantine_threshold);
+
+        co_await pool.stop();
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+
+    logging::reset_anomaly_for_testing();
+}
+
 };  // TEST_SUITE(CompilerGuards)
 
 }  // namespace

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -68,6 +68,33 @@ TEST_CASE(EpochGuardsPchWrite) {
     EXPECT_EQ(*session.pch_key, std::string("key"));
 }
 
+TEST_CASE(QuarantineBlocksBuilds) {
+    // A quarantined document gets no stateless builds either: completion
+    // requests compile the same content the quarantine watches.
+    kota::event_loop loop;
+    Workspace workspace;
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto session = std::make_shared<Session>();
+    session->path_id = workspace.path_pool.intern("/proj/poison.cpp");
+    session->text = "int x;\n";
+    session->compile_crash_streak = Session::quarantine_threshold;
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        auto result = co_await compiler.forward_build(worker::BuildKind::Completion, {}, session);
+        CO_ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+}
+
 TEST_CASE(PchCrashCountsStreak) {
     // A PCH build that kills its stateless worker must count toward the
     // document's quarantine streak: the preamble is the document's content

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -80,13 +80,17 @@ TEST_CASE(QuarantineBlocksBuilds) {
     auto session = std::make_shared<Session>();
     session->path_id = workspace.path_pool.intern("/proj/poison.cpp");
     session->text = "int x;\n";
-    session->compile_crash_streak = Session::quarantine_threshold;
+    session->quarantine.on_crash();
+    session->quarantine.on_crash();
 
     bool done = false;
     auto body = [&]() -> kota::task<> {
         auto result = co_await compiler.forward_build(worker::BuildKind::Completion, {}, session);
         CO_ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
+        // The gate's message, not the empty pool's: without the gate this
+        // test would still see worker_unavailable and prove nothing.
+        EXPECT_TRUE(result.error().message.contains("quarantined"));
         done = true;
     };
     auto task = body();
@@ -143,7 +147,7 @@ TEST_CASE(PchCrashCountsStreak) {
                                                           directory,
                                                           arguments);
         EXPECT_FALSE(built);
-        EXPECT_EQ(session.compile_crash_streak, 1u);
+        EXPECT_EQ(session.quarantine.crashes(), 1u);
 
         co_await pool.stop();
         done = true;
@@ -154,6 +158,35 @@ TEST_CASE(PchCrashCountsStreak) {
     EXPECT_TRUE(done);
 
     logging::reset_anomaly_for_testing();
+}
+
+TEST_CASE(QuarantineBlocksFormat) {
+    // Formatting is still this document's content on a worker: quarantine
+    // refuses it like any other stateless build.
+    kota::event_loop loop;
+    Workspace workspace;
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto session = std::make_shared<Session>();
+    session->path_id = workspace.path_pool.intern("/proj/poison.cpp");
+    session->text = "int x;\n";
+    session->quarantine.on_crash();
+    session->quarantine.on_crash();
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        auto result = co_await compiler.forward_format(session, std::nullopt);
+        CO_ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
+        EXPECT_TRUE(result.error().message.contains("quarantined"));
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
 }
 
 TEST_CASE(GateAnnouncesQuarantine) {
@@ -169,7 +202,8 @@ TEST_CASE(GateAnnouncesQuarantine) {
     auto session = std::make_shared<Session>();
     session->path_id = workspace.path_pool.intern("/proj/poison.cpp");
     session->text = "int x;\n";
-    session->compile_crash_streak = Session::quarantine_threshold;
+    session->quarantine.on_crash();
+    session->quarantine.on_crash();
 
     int emits = 0;
     auto conn = compiler.on_output.connect([&](const std::shared_ptr<Session>&) { emits += 1; });
@@ -186,7 +220,7 @@ TEST_CASE(GateAnnouncesQuarantine) {
     EXPECT_TRUE(done);
 
     EXPECT_EQ(emits, 1);
-    EXPECT_TRUE(session->quarantine_announced);
+    EXPECT_FALSE(session->quarantine.needs_announcement());
     ASSERT_TRUE(session->output.has_value());
     EXPECT_TRUE(session->output->diagnostics.data.contains("quarantined"));
 }
@@ -219,7 +253,7 @@ TEST_CASE(PchCrashBlocksBuild) {
     auto session = std::make_shared<Session>();
     session->path_id = workspace.path_pool.intern(src);
     session->text = "#pragma clang __debug crash\n";
-    session->compile_crash_streak = Session::quarantine_threshold - 1;
+    session->quarantine.on_crash();
 
     bool done = false;
     auto body = [&]() -> kota::task<> {
@@ -233,7 +267,84 @@ TEST_CASE(PchCrashBlocksBuild) {
         auto result = co_await compiler.forward_build(worker::BuildKind::Completion, {}, session);
         CO_ASSERT_FALSE(result.has_value());
         EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_unavailable);
-        EXPECT_EQ(session->compile_crash_streak, Session::quarantine_threshold);
+        EXPECT_EQ(session->quarantine.crashes(), Quarantine::threshold);
+
+        co_await pool.stop();
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+
+    logging::reset_anomaly_for_testing();
+}
+
+TEST_CASE(PoisonPreambleBudget) {
+    // One document's quarantine cannot contain a poison preamble: the PCH
+    // is shared, so every session with the same preamble would re-trigger
+    // the build and burn workers of its own. After `threshold` crashed
+    // builds the key itself is refused — before any dispatch, which is why
+    // the third session records no crash at all.
+    logging::set_anomaly_trap_for_testing([](logging::AnomalyId) {});
+
+    TempDir tmp;
+    tmp.touch("a.cpp", "");
+    auto src = tmp.path("a.cpp");
+
+    kota::event_loop loop;
+    Workspace workspace;
+    auto store = CacheStore::open(tmp.path("root"), 1);
+    ASSERT_TRUE(store.has_value());
+    store->register_namespace({.name = "pch",
+                               .extension = ".pch",
+                               .aux_extension = ".pch.idx",
+                               .policy = CachePolicy::LRU,
+                               .max_bytes = 1ull << 30});
+    workspace.store.emplace(std::move(*store));
+
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto make_session = [&] {
+        Session session;
+        session.path_id = workspace.path_pool.intern(src);
+        session.text = "#pragma clang __debug crash\n";
+        return session;
+    };
+    auto first = make_session();
+    auto second = make_session();
+    auto third = make_session();
+
+    std::string directory = tmp.path(".");
+    auto arguments = make_args(src);
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        WorkerPoolOptions opts;
+        opts.self_path = clice_binary();
+        opts.stateless_count = 1;
+        opts.stateful_count = 0;
+        CO_ASSERT_TRUE(pool.start(opts));
+        co_await kota::sleep(500);
+
+        auto build = [&](Session& session) {
+            return CompilerFixture::ensure_pch(compiler,
+                                               session,
+                                               session.generation,
+                                               session.dirty_epoch,
+                                               directory,
+                                               arguments);
+        };
+        CO_ASSERT_FALSE(co_await build(first));
+        EXPECT_EQ(first.quarantine.crashes(), 1u);
+        CO_ASSERT_FALSE(co_await build(second));
+        EXPECT_EQ(second.quarantine.crashes(), 1u);
+
+        // The key's budget is spent: refused without touching a worker.
+        CO_ASSERT_FALSE(co_await build(third));
+        EXPECT_EQ(third.quarantine.crashes(), 0u);
 
         co_await pool.stop();
         done = true;

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -156,6 +156,41 @@ TEST_CASE(PchCrashCountsStreak) {
     logging::reset_anomaly_for_testing();
 }
 
+TEST_CASE(GateAnnouncesQuarantine) {
+    // A quarantine reached without a compile-failure landing (completion
+    // or PCH build tipped the streak) has published nothing; the entry
+    // gate must announce it exactly once instead of going silently dead.
+    kota::event_loop loop;
+    Workspace workspace;
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto session = std::make_shared<Session>();
+    session->path_id = workspace.path_pool.intern("/proj/poison.cpp");
+    session->text = "int x;\n";
+    session->compile_crash_streak = Session::quarantine_threshold;
+
+    int emits = 0;
+    auto conn = compiler.on_output.connect([&](const std::shared_ptr<Session>&) { emits += 1; });
+
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        CO_ASSERT_FALSE(co_await compiler.ensure_compiled(session));
+        CO_ASSERT_FALSE(co_await compiler.ensure_compiled(session));
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+
+    EXPECT_EQ(emits, 1);
+    EXPECT_TRUE(session->quarantine_announced);
+    ASSERT_TRUE(session->output.has_value());
+    EXPECT_TRUE(session->output->diagnostics.data.contains("quarantined"));
+}
+
 TEST_CASE(PchCrashBlocksBuild) {
     // A PCH crash inside a completion build's dependency prep can tip the
     // document into quarantine after the entry gate: the build must stop

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -49,6 +49,10 @@ struct IndexerFixture {
         return it == indexer.reindex_reasons.end() ? 0u : it->second.requeue_attempts;
     }
 
+    void set_attempts(std::uint32_t id, unsigned n) {
+        indexer.reindex_reasons.find(id)->second.requeue_attempts = n;
+    }
+
     /// Consume the queued slot as a dispatch would, so a later enqueue
     /// takes the fresh-slot (mid-flight) path.
     void consume(std::uint32_t id) {
@@ -153,14 +157,18 @@ TEST_CASE(CrashSpendsBudget) {
         ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
     }
     ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
-    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
 
     // A preemption still requeues a file whose crash budget is spent:
     // dropping it would erase the pending state and serve the stale
     // shard as fresh. Only the next crash gives up.
     ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::Requeued));
     ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
+
+    // Giving up clears the pending slot: nothing is left to requeue, and
+    // the stale shard serves as fresh — the accepted cost of abandoning.
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
+    ASSERT_FALSE(f.indexer.pending_reason(id).has_value());
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Dropped));
 }
 
 TEST_CASE(StaleCrashKeepsBudget) {
@@ -196,6 +204,22 @@ TEST_CASE(DepsDowngradeKeepsDebt) {
     ASSERT_EQ(int(f.fail_at(id, launch, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
     ASSERT_EQ(int(*f.indexer.pending_reason(id)), int(ReindexReason::ContentChanged));
     ASSERT_EQ(f.attempts(id), 1u);
+}
+
+TEST_CASE(GaveUpClearsDowngraded) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/d.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    auto launch = f.ticket(id);
+    f.set_attempts(id, IndexerFixture::budget);
+
+    // A deps-only enqueue lands mid-flight, then the content pass spends
+    // its last life. The downgraded entry must not stay queued: its retry
+    // is doomed, and the give-up already accepted the staleness.
+    f.consume(id);
+    f.indexer.enqueue(id, ReindexReason::DepsOnly);
+    ASSERT_EQ(int(f.fail_at(id, launch, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
+    ASSERT_FALSE(f.indexer.pending_reason(id).has_value());
 }
 
 TEST_CASE(DroppedWithoutPending) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -12,6 +12,30 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace clice::testing {
+
+/// Test fixture with friend access to Indexer internals.
+struct IndexerFixture {
+    using Verdict = Indexer::RequeueVerdict;
+
+    constexpr static unsigned budget = Indexer::max_requeue_attempts;
+
+    kota::event_loop loop;
+    Workspace workspace;
+    WorkerPool pool{loop};
+    ContextResolver contexts{workspace};
+    SessionStore sessions;
+    Indexer indexer{loop, workspace, pool, contexts, sessions};
+
+    Verdict fail(std::uint32_t id, bool crashed) {
+        return indexer.note_dispatch_failure(id, crashed);
+    }
+
+    unsigned attempts(std::uint32_t id) {
+        auto it = indexer.reindex_reasons.find(id);
+        return it == indexer.reindex_reasons.end() ? 0u : it->second.requeue_attempts;
+    }
+};
+
 namespace {
 
 TEST_SUITE(IndexerMerge) {
@@ -83,6 +107,45 @@ TEST_CASE(MergeSkipsMovedDisk) {
 }
 
 };  // TEST_SUITE(IndexerMerge)
+
+TEST_SUITE(IndexerRequeue) {
+
+TEST_CASE(PreemptionKeepsBudget) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/a.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+
+    // A preemption under memory pressure requeues without spending the
+    // crash budget, no matter how often it repeats.
+    for(unsigned i = 0; i < 2 * IndexerFixture::budget; ++i) {
+        ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::Requeued));
+    }
+    ASSERT_EQ(f.attempts(id), 0u);
+    ASSERT_TRUE(f.indexer.pending_reason(id).has_value());
+}
+
+TEST_CASE(CrashSpendsBudget) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/poison.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+
+    for(unsigned i = 0; i < IndexerFixture::budget; ++i) {
+        ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
+    }
+    ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
+
+    // A preemption cannot revive a file whose crash budget is spent.
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::GaveUp));
+}
+
+TEST_CASE(DroppedWithoutPending) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/gone.cpp");
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Dropped));
+}
+
+};  // TEST_SUITE(IndexerRequeue)
 
 }  // namespace
 }  // namespace clice::testing

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -145,6 +145,25 @@ TEST_CASE(DroppedWithoutPending) {
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Dropped));
 }
 
+TEST_CASE(ContentChangeResetsBudget) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/fixed.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
+    ASSERT_EQ(f.attempts(id), 2u);
+
+    // The user fixes the file: new content starts a fresh poison budget.
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    ASSERT_EQ(f.attempts(id), 0u);
+
+    // A deps-only cascade is not new content and keeps the ledger.
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
+    f.indexer.enqueue(id, ReindexReason::DepsOnly);
+    ASSERT_EQ(f.attempts(id), 1u);
+}
+
 };  // TEST_SUITE(IndexerRequeue)
 
 }  // namespace

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -26,8 +26,19 @@ struct IndexerFixture {
     SessionStore sessions;
     Indexer indexer{loop, workspace, pool, contexts, sessions};
 
+    /// Fail the entry's current dispatch: the launch ticket matches.
     Verdict fail(std::uint32_t id, bool crashed) {
-        return indexer.note_dispatch_failure(id, crashed);
+        return indexer.note_dispatch_failure(id, ticket(id), crashed);
+    }
+
+    /// Fail a dispatch launched with an explicit (possibly stale) ticket.
+    Verdict fail_at(std::uint32_t id, std::uint64_t ticket, bool crashed) {
+        return indexer.note_dispatch_failure(id, ticket, crashed);
+    }
+
+    std::uint64_t ticket(std::uint32_t id) {
+        auto it = indexer.reindex_reasons.find(id);
+        return it == indexer.reindex_reasons.end() ? UINT64_MAX : it->second.ticket;
     }
 
     unsigned attempts(std::uint32_t id) {
@@ -141,6 +152,22 @@ TEST_CASE(CrashSpendsBudget) {
     ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::Requeued));
     ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
+}
+
+TEST_CASE(StaleCrashKeepsBudget) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/edited.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    auto stale = f.ticket(id);
+
+    // The user fixes the file while the old bytes' dispatch is in flight:
+    // the stale crash must not spend the fixed content's budget or touch
+    // its pending slot.
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    ASSERT_EQ(int(f.fail_at(id, stale, /*crashed=*/true)),
+              int(IndexerFixture::Verdict::Superseded));
+    ASSERT_EQ(f.attempts(id), 0u);
+    ASSERT_TRUE(f.indexer.pending_reason(id).has_value());
 }
 
 TEST_CASE(DroppedWithoutPending) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "test/temp_dir.h"
 #include "test/test.h"
 #include "command/argument_parser.h"
@@ -38,7 +40,8 @@ struct IndexerFixture {
 
     std::uint64_t ticket(std::uint32_t id) {
         auto it = indexer.reindex_reasons.find(id);
-        return it == indexer.reindex_reasons.end() ? UINT64_MAX : it->second.ticket;
+        return it == indexer.reindex_reasons.end() ? std::numeric_limits<std::uint64_t>::max()
+                                                   : it->second.ticket;
     }
 
     unsigned attempts(std::uint32_t id) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -48,6 +48,12 @@ struct IndexerFixture {
         auto it = indexer.reindex_reasons.find(id);
         return it == indexer.reindex_reasons.end() ? 0u : it->second.requeue_attempts;
     }
+
+    /// Consume the queued slot as a dispatch would, so a later enqueue
+    /// takes the fresh-slot (mid-flight) path.
+    void consume(std::uint32_t id) {
+        indexer.pending_ids.erase(id);
+    }
 };
 
 namespace {
@@ -171,6 +177,25 @@ TEST_CASE(StaleCrashKeepsBudget) {
               int(IndexerFixture::Verdict::Superseded));
     ASSERT_EQ(f.attempts(id), 0u);
     ASSERT_TRUE(f.indexer.pending_reason(id).has_value());
+}
+
+TEST_CASE(DepsDowngradeKeepsDebt) {
+    IndexerFixture f;
+    auto id = f.workspace.path_pool.intern("/proj/c.cpp");
+    f.indexer.enqueue(id, ReindexReason::ContentChanged);
+    auto launch = f.ticket(id);
+
+    // The content pass is dispatched; a deps-only cascade lands mid-flight
+    // and downgrades the pending reason, betting on that pass to cover the
+    // edit. The pass fails — the requeue must restore the ContentChanged
+    // debt or the stale shard stops being suppressed.
+    f.consume(id);
+    f.indexer.enqueue(id, ReindexReason::DepsOnly);
+    ASSERT_EQ(int(*f.indexer.pending_reason(id)), int(ReindexReason::DepsOnly));
+
+    ASSERT_EQ(int(f.fail_at(id, launch, /*crashed=*/true)), int(IndexerFixture::Verdict::Requeued));
+    ASSERT_EQ(int(*f.indexer.pending_reason(id)), int(ReindexReason::ContentChanged));
+    ASSERT_EQ(f.attempts(id), 1u);
 }
 
 TEST_CASE(DroppedWithoutPending) {

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -135,8 +135,12 @@ TEST_CASE(CrashSpendsBudget) {
     ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
     ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
 
-    // A preemption cannot revive a file whose crash budget is spent.
-    ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::GaveUp));
+    // A preemption still requeues a file whose crash budget is spent:
+    // dropping it would erase the pending state and serve the stale
+    // shard as fresh. Only the next crash gives up.
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/false)), int(IndexerFixture::Verdict::Requeued));
+    ASSERT_EQ(f.attempts(id), IndexerFixture::budget);
+    ASSERT_EQ(int(f.fail(id, /*crashed=*/true)), int(IndexerFixture::Verdict::GaveUp));
 }
 
 TEST_CASE(DroppedWithoutPending) {

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -179,6 +179,23 @@ TEST_CASE(DeathCountedOnce) {
     EXPECT_EQ(q.crashes(), 4u);
 }
 
+TEST_CASE(ProbeRidesCrashingKind) {
+    Quarantine q;
+    q.on_kind_crash(1);
+    q.on_kind_crash(1);
+    q.on_edit(true);
+
+    // Only the crashing kind's dispatch is the recovery attempt: a
+    // harmless other kind or an innocent compile must not spend the probe.
+    EXPECT_FALSE(q.recovery_compile());
+    EXPECT_FALSE(q.recovery_kind(2));
+    EXPECT_TRUE(q.recovery_kind(1));
+
+    // Compile strikes make the compile the recovery vehicle.
+    q.on_crash();
+    EXPECT_TRUE(q.recovery_compile());
+}
+
 TEST_CASE(AnnounceOncePerSpell) {
     Quarantine q;
     EXPECT_FALSE(q.needs_announcement());

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -1,3 +1,5 @@
+#include <chrono>
+
 #include "test/test.h"
 #include "server/state/quarantine.h"
 
@@ -223,6 +225,16 @@ TEST_CASE(BudgetBlocksAtThreshold) {
 
     // Keys are independent: fresh content (fresh key) starts fresh.
     EXPECT_FALSE(budget.blocked("key-b"));
+}
+
+TEST_CASE(BudgetRearmsAfterCooldown) {
+    // The poison may live in content the key cannot see (a header included
+    // by the hashed preamble text): a block is a cooldown, not a verdict.
+    // Zero cooldown models "elapsed" — the key earns a fresh budget.
+    CrashBudget budget{std::chrono::milliseconds(0)};
+    budget.on_crash("key");
+    budget.on_crash("key");
+    EXPECT_FALSE(budget.blocked("key"));
 }
 
 };  // TEST_SUITE(QuarantineMachine)

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -108,40 +108,55 @@ TEST_CASE(ProbeSuccessRecovers) {
 
 TEST_CASE(QueryCrashSurvivesCompile) {
     Quarantine q;
-    q.on_query_crash();
+    q.on_kind_crash(1);
 
-    // A successful compile does not disprove a query crash: the same AST
+    // A successful compile does not disprove a kind crash: the same AST
     // crashes the same query again. Without the separate ledger, the
     // crash-triggered recompile would launder the evidence forever.
     q.land(q.begin_flight());
     EXPECT_EQ(q.crashes(), 1u);
-    q.on_query_crash();
+    q.on_kind_crash(1);
     EXPECT_TRUE(q.blocked());
 
     // Recovery: an edit grants the probe, its compile lands, and the
-    // first query that answers clears the ledger.
+    // crashing kind answering clears the ledger.
     q.on_edit(true);
     q.spend_probe();
     q.land(q.begin_flight());
     EXPECT_TRUE(q.active());
-    q.on_query_land();
+    q.on_kind_land(1);
     EXPECT_FALSE(q.active());
     EXPECT_FALSE(q.blocked());
+}
+
+TEST_CASE(KindsRecoverIndependently) {
+    Quarantine q;
+    q.on_kind_crash(1);
+    q.on_kind_crash(1);
+    EXPECT_TRUE(q.blocked());
+
+    // A harmless other kind answering (a hover while semantic tokens is
+    // the crasher) must not launder the crashing kind's evidence.
+    q.on_kind_land(2);
+    EXPECT_TRUE(q.blocked());
+
+    q.on_kind_land(1);
+    EXPECT_FALSE(q.active());
 }
 
 TEST_CASE(MixedEvidenceCounts) {
     Quarantine q;
     q.on_crash();
 
-    // Query evidence accrued mid-flight counts toward grew(); the landing
+    // Kind evidence accrued mid-flight counts toward grew(); the landing
     // clears only the inherited compile share.
     auto flight = q.begin_flight();
-    q.on_query_crash();
+    q.on_kind_crash(1);
     EXPECT_TRUE(q.grew(flight));
     q.land(flight);
     EXPECT_EQ(q.crashes(), 1u);
 
-    q.on_query_land();
+    q.on_kind_land(1);
     EXPECT_EQ(q.crashes(), 0u);
 }
 
@@ -151,7 +166,7 @@ TEST_CASE(DeathCountedOnce) {
     // One process death fails every request in flight on it: a compile and
     // a query blaming the same incarnation count once, across ledgers.
     q.on_crash("sf:1:7");
-    q.on_query_crash("sf:1:7");
+    q.on_kind_crash(1, "sf:1:7");
     EXPECT_EQ(q.crashes(), 1u);
 
     // A different incarnation is a different death.
@@ -199,7 +214,7 @@ TEST_CASE(ResetClearsAll) {
     q.on_edit(true);
     q.mark_announced();
 
-    q.on_query_crash();
+    q.on_kind_crash(1);
     q.reset();
     EXPECT_EQ(q.crashes(), 0u);
     EXPECT_FALSE(q.active());

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -104,6 +104,12 @@ TEST_CASE(ProbeSuccessRecovers) {
     EXPECT_EQ(q.crashes(), 0u);
     EXPECT_FALSE(q.active());
     EXPECT_FALSE(q.blocked());
+
+    // Recovery leaves no stale probe: the next spell blocks immediately
+    // instead of inheriting a free attempt from the last one.
+    q.on_crash();
+    q.on_crash();
+    EXPECT_TRUE(q.blocked());
 }
 
 TEST_CASE(QueryCrashSurvivesCompile) {
@@ -142,6 +148,14 @@ TEST_CASE(KindsRecoverIndependently) {
 
     q.on_kind_land(1);
     EXPECT_FALSE(q.active());
+
+    // Leaving quarantine via a kind landing retires an armed probe too —
+    // an adoption (PCH cache hit) can land a kind before any dispatch
+    // spent the probe, and the next spell must not inherit it.
+    q.on_edit(true);
+    q.on_kind_crash(3);
+    q.on_kind_crash(3);
+    EXPECT_TRUE(q.blocked());
 }
 
 TEST_CASE(MixedEvidenceCounts) {

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -227,6 +227,17 @@ TEST_CASE(BudgetBlocksAtThreshold) {
     EXPECT_FALSE(budget.blocked("key-b"));
 }
 
+TEST_CASE(BudgetClearsOnLand) {
+    // A successful build proves the strikes were transient: without the
+    // clear, two unrelated hiccups far apart would block a key that
+    // rebuilds fine in between.
+    CrashBudget budget;
+    budget.on_crash("key");
+    budget.on_land("key");
+    budget.on_crash("key");
+    EXPECT_FALSE(budget.blocked("key"));
+}
+
 TEST_CASE(BudgetRearmsAfterCooldown) {
     // The poison may live in content the key cannot see (a header included
     // by the hashed preamble text): a block is a cooldown, not a verdict.

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -104,6 +104,45 @@ TEST_CASE(ProbeSuccessRecovers) {
     EXPECT_FALSE(q.blocked());
 }
 
+TEST_CASE(QueryCrashSurvivesCompile) {
+    Quarantine q;
+    q.on_query_crash();
+
+    // A successful compile does not disprove a query crash: the same AST
+    // crashes the same query again. Without the separate ledger, the
+    // crash-triggered recompile would launder the evidence forever.
+    q.land(q.begin_flight());
+    EXPECT_EQ(q.crashes(), 1u);
+    q.on_query_crash();
+    EXPECT_TRUE(q.blocked());
+
+    // Recovery: an edit grants the probe, its compile lands, and the
+    // first query that answers clears the ledger.
+    q.on_edit(true);
+    q.spend_probe();
+    q.land(q.begin_flight());
+    EXPECT_TRUE(q.active());
+    q.on_query_land();
+    EXPECT_FALSE(q.active());
+    EXPECT_FALSE(q.blocked());
+}
+
+TEST_CASE(MixedEvidenceCounts) {
+    Quarantine q;
+    q.on_crash();
+
+    // Query evidence accrued mid-flight counts toward grew(); the landing
+    // clears only the inherited compile share.
+    auto flight = q.begin_flight();
+    q.on_query_crash();
+    EXPECT_TRUE(q.grew(flight));
+    q.land(flight);
+    EXPECT_EQ(q.crashes(), 1u);
+
+    q.on_query_land();
+    EXPECT_EQ(q.crashes(), 0u);
+}
+
 TEST_CASE(AnnounceOncePerSpell) {
     Quarantine q;
     EXPECT_FALSE(q.needs_announcement());
@@ -139,6 +178,7 @@ TEST_CASE(ResetClearsAll) {
     q.on_edit(true);
     q.mark_announced();
 
+    q.on_query_crash();
     q.reset();
     EXPECT_EQ(q.crashes(), 0u);
     EXPECT_FALSE(q.active());

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -1,0 +1,173 @@
+#include "test/test.h"
+#include "server/state/quarantine.h"
+
+namespace clice::testing {
+
+namespace {
+
+TEST_SUITE(QuarantineMachine) {
+
+TEST_CASE(CrashesAccumulate) {
+    Quarantine q;
+    EXPECT_FALSE(q.active());
+
+    q.on_crash();
+    EXPECT_EQ(q.crashes(), 1u);
+    EXPECT_FALSE(q.active());
+    EXPECT_FALSE(q.blocked());
+
+    q.on_crash();
+    EXPECT_EQ(q.crashes(), 2u);
+    EXPECT_TRUE(q.active());
+    EXPECT_TRUE(q.blocked());
+}
+
+TEST_CASE(LandClearsInherited) {
+    Quarantine q;
+    q.on_crash();
+
+    // A crash recorded while the flight was up survives its landing: the
+    // same content will kill again on the next request.
+    auto flight = q.begin_flight();
+    q.on_crash();
+    EXPECT_TRUE(q.grew(flight));
+    q.land(flight);
+    EXPECT_EQ(q.crashes(), 1u);
+
+    // A clean flight clears everything it inherited.
+    auto clean = q.begin_flight();
+    EXPECT_FALSE(q.grew(clean));
+    q.land(clean);
+    EXPECT_EQ(q.crashes(), 0u);
+}
+
+TEST_CASE(LandNeverUnderflows) {
+    Quarantine q;
+    q.on_crash();
+    auto flight = q.begin_flight();
+
+    // A reopen (reset) while the flight is up must not underflow the
+    // fresh record when the stale flight lands.
+    q.reset();
+    q.land(flight);
+    EXPECT_EQ(q.crashes(), 0u);
+}
+
+TEST_CASE(EditArmsOneProbe) {
+    Quarantine q;
+
+    // Below the threshold an edit grants nothing.
+    q.on_crash();
+    q.on_edit(true);
+    EXPECT_FALSE(q.blocked());
+    q.on_crash();
+    EXPECT_TRUE(q.blocked());
+
+    // Dropped and no-op edits grant nothing; a real one arms the probe.
+    q.on_edit(false);
+    EXPECT_TRUE(q.blocked());
+    q.on_edit(true);
+    EXPECT_FALSE(q.blocked());
+    EXPECT_TRUE(q.active());
+
+    // The attempt spends it; back to blocked. Re-arming is only honored
+    // while quarantined — a stray re-arm below the threshold must not
+    // pre-arm a future spell.
+    q.spend_probe();
+    EXPECT_TRUE(q.blocked());
+    q.land(q.begin_flight());
+    q.re_arm_probe();
+    q.on_crash();
+    q.on_crash();
+    EXPECT_TRUE(q.blocked());
+    q.on_edit(true);
+
+    // An attempt that never ran hands the license back.
+    q.on_edit(true);
+    q.spend_probe();
+    q.re_arm_probe();
+    EXPECT_FALSE(q.blocked());
+}
+
+TEST_CASE(ProbeSuccessRecovers) {
+    Quarantine q;
+    q.on_crash();
+    q.on_crash();
+    q.on_edit(true);
+
+    // The probe compile: takes off, spends the probe, lands clean.
+    auto flight = q.begin_flight();
+    q.spend_probe();
+    q.land(flight);
+    EXPECT_EQ(q.crashes(), 0u);
+    EXPECT_FALSE(q.active());
+    EXPECT_FALSE(q.blocked());
+}
+
+TEST_CASE(AnnounceOncePerSpell) {
+    Quarantine q;
+    EXPECT_FALSE(q.needs_announcement());
+
+    q.on_crash();
+    q.on_crash();
+    EXPECT_TRUE(q.needs_announcement());
+    q.mark_announced();
+    EXPECT_FALSE(q.needs_announcement());
+
+    // More crashes in the same spell do not re-announce, and neither does
+    // a landing that clears only part of the evidence and stays active.
+    q.on_crash();
+    EXPECT_FALSE(q.needs_announcement());
+    {
+        auto flight = q.begin_flight();
+        q.on_crash();
+        q.on_crash();
+        q.land(flight);
+        EXPECT_TRUE(q.active());
+        EXPECT_FALSE(q.needs_announcement());
+    }
+    q.land(q.begin_flight());
+    q.on_crash();
+    q.on_crash();
+    EXPECT_TRUE(q.needs_announcement());
+}
+
+TEST_CASE(ResetClearsAll) {
+    Quarantine q;
+    q.on_crash();
+    q.on_crash();
+    q.on_edit(true);
+    q.mark_announced();
+
+    q.reset();
+    EXPECT_EQ(q.crashes(), 0u);
+    EXPECT_FALSE(q.active());
+    EXPECT_FALSE(q.blocked());
+    EXPECT_FALSE(q.needs_announcement());
+
+    // reset() must clear the probe and the announcement, not just the
+    // streak: a fresh spell must block and announce again.
+    q.on_crash();
+    q.on_crash();
+    EXPECT_TRUE(q.blocked());
+    EXPECT_TRUE(q.needs_announcement());
+}
+
+TEST_CASE(BudgetBlocksAtThreshold) {
+    CrashBudget budget;
+    EXPECT_FALSE(budget.blocked("key-a"));
+
+    budget.on_crash("key-a");
+    EXPECT_FALSE(budget.blocked("key-a"));
+    budget.on_crash("key-a");
+    EXPECT_TRUE(budget.blocked("key-a"));
+
+    // Keys are independent: fresh content (fresh key) starts fresh.
+    EXPECT_FALSE(budget.blocked("key-b"));
+}
+
+};  // TEST_SUITE(QuarantineMachine)
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -208,6 +208,37 @@ TEST_CASE(ProbeRidesCrashingKind) {
     // Compile strikes make the compile the recovery vehicle.
     q.on_crash();
     EXPECT_TRUE(q.recovery_compile());
+
+    // The predicates require the armed probe: a concurrent request that
+    // lost the race to spend it holds no license, and the kind is simply
+    // blocked again.
+    q.spend_probe();
+    EXPECT_FALSE(q.recovery_compile());
+    EXPECT_FALSE(q.recovery_kind(1));
+    EXPECT_TRUE(q.kind_blocked(1));
+    EXPECT_FALSE(q.kind_blocked(2));
+}
+
+TEST_CASE(GuardReturnsUnspentProbe) {
+    Quarantine q;
+    q.on_kind_crash(1);
+    q.on_kind_crash(1);
+    q.on_edit(true);
+
+    // Unwinding with no strike recorded (a cancellation before dispatch)
+    // hands the license back.
+    {
+        Quarantine::ProbeGuard guard(q);
+        EXPECT_TRUE(q.blocked());
+    }
+    EXPECT_FALSE(q.blocked());
+
+    // A recorded strike keeps it spent: the attempt ran and crashed.
+    {
+        Quarantine::ProbeGuard guard(q);
+        q.on_kind_crash(1);
+    }
+    EXPECT_TRUE(q.blocked());
 }
 
 TEST_CASE(AnnounceOncePerSpell) {

--- a/tests/unit/server/quarantine_tests.cpp
+++ b/tests/unit/server/quarantine_tests.cpp
@@ -143,6 +143,25 @@ TEST_CASE(MixedEvidenceCounts) {
     EXPECT_EQ(q.crashes(), 0u);
 }
 
+TEST_CASE(DeathCountedOnce) {
+    Quarantine q;
+
+    // One process death fails every request in flight on it: a compile and
+    // a query blaming the same incarnation count once, across ledgers.
+    q.on_crash("sf:1:7");
+    q.on_query_crash("sf:1:7");
+    EXPECT_EQ(q.crashes(), 1u);
+
+    // A different incarnation is a different death.
+    q.on_crash("sf:1:8");
+    EXPECT_EQ(q.crashes(), 2u);
+
+    // Anonymous evidence (no identity) always counts.
+    q.on_crash();
+    q.on_crash();
+    EXPECT_EQ(q.crashes(), 4u);
+}
+
 TEST_CASE(AnnounceOncePerSpell) {
     Quarantine q;
     EXPECT_FALSE(q.needs_announcement());

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -221,6 +221,29 @@ TEST_CASE(QuarantineProbeOnEdit) {
     ASSERT_TRUE(session->quarantine_probe);
 }
 
+TEST_CASE(DroppedEditNoProbe) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "int a;\n", 1);
+    session->compile_crash_streak = Session::quarantine_threshold;
+
+    // The probe license is one attempt per real content change: an edit
+    // whose range does not fit the buffer is dropped, an empty change list
+    // and a no-op replacement change nothing — none may re-arm a compile
+    // of the unchanged poison bytes.
+    store.apply_change(*session, partial_change(99, 0, 99, 1, "junk"), 2);
+    ASSERT_FALSE(session->quarantine_probe);
+
+    store.apply_change(*session, {}, 3);
+    ASSERT_FALSE(session->quarantine_probe);
+
+    store.apply_change(*session, partial_change(0, 0, 0, 1, "i"), 4);
+    ASSERT_FALSE(session->quarantine_probe);
+
+    store.apply_change(*session, partial_change(0, 0, 0, 1, "u"), 5);
+    ASSERT_TRUE(session->quarantine_probe);
+}
+
 TEST_CASE(ReopenClearsQuarantine) {
     SessionStore store;
     auto session = store.open(1);

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -240,7 +240,13 @@ TEST_CASE(DroppedEditNoProbe) {
     store.apply_change(*session, partial_change(0, 0, 0, 1, "i"), 4);
     ASSERT_FALSE(session->quarantine_probe);
 
-    store.apply_change(*session, partial_change(0, 0, 0, 1, "u"), 5);
+    // A whole-document change carrying identical bytes is a no-op too.
+    protocol::TextDocumentContentChangeWholeDocument whole;
+    whole.text = session->text;
+    store.apply_change(*session, protocol::TextDocumentContentChangeEvent(whole), 5);
+    ASSERT_FALSE(session->quarantine_probe);
+
+    store.apply_change(*session, partial_change(0, 0, 0, 1, "u"), 6);
     ASSERT_TRUE(session->quarantine_probe);
 }
 

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -198,6 +198,41 @@ TEST_CASE(ForEachVisitsAll) {
     ASSERT_EQ(visited, 1);
 }
 
+TEST_CASE(QuarantineProbeOnEdit) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "int a;\n", 1);
+
+    // An edit never resets the streak — only a successful compile proves
+    // the document healthy. Resetting here would let a poison file under
+    // active editing crash one worker per keystroke without ever reaching
+    // quarantine.
+    session->compile_crash_streak = 1;
+    store.apply_change(*session, partial_change(0, 0, 0, 0, "x"), 2);
+    ASSERT_EQ(session->compile_crash_streak, 1u);
+    ASSERT_FALSE(session->quarantine_probe);
+
+    // At the threshold an edit re-arms one probe and keeps the streak: a
+    // quarantined document earns a single attempt per change, not a fresh
+    // budget.
+    session->compile_crash_streak = Session::quarantine_threshold;
+    store.apply_change(*session, partial_change(0, 0, 0, 0, "y"), 3);
+    ASSERT_EQ(session->compile_crash_streak, Session::quarantine_threshold);
+    ASSERT_TRUE(session->quarantine_probe);
+}
+
+TEST_CASE(ReopenClearsQuarantine) {
+    SessionStore store;
+    auto session = store.open(1);
+    session->compile_crash_streak = Session::quarantine_threshold;
+    session->quarantine_probe = true;
+
+    store.apply_open(*session, "int a;\n", 1);
+
+    ASSERT_EQ(session->compile_crash_streak, 0u);
+    ASSERT_FALSE(session->quarantine_probe);
+}
+
 };  // TEST_SUITE(SessionStore)
 
 }  // namespace

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -199,67 +199,68 @@ TEST_CASE(ForEachVisitsAll) {
 }
 
 TEST_CASE(QuarantineProbeOnEdit) {
+    // The state machine itself is pinned by quarantine_tests; this pins
+    // that apply_change feeds real edits into it without resetting the
+    // record — only a successful compile proves the document healthy.
     SessionStore store;
     auto session = store.open(1);
     store.apply_open(*session, "int a;\n", 1);
 
-    // An edit never resets the streak — only a successful compile proves
-    // the document healthy. Resetting here would let a poison file under
-    // active editing crash one worker per keystroke without ever reaching
-    // quarantine.
-    session->compile_crash_streak = 1;
+    session->quarantine.on_crash();
     store.apply_change(*session, partial_change(0, 0, 0, 0, "x"), 2);
-    ASSERT_EQ(session->compile_crash_streak, 1u);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_EQ(session->quarantine.crashes(), 1u);
 
     // At the threshold an edit re-arms one probe and keeps the streak: a
     // quarantined document earns a single attempt per change, not a fresh
     // budget.
-    session->compile_crash_streak = Session::quarantine_threshold;
+    session->quarantine.on_crash();
+    ASSERT_TRUE(session->quarantine.blocked());
     store.apply_change(*session, partial_change(0, 0, 0, 0, "y"), 3);
-    ASSERT_EQ(session->compile_crash_streak, Session::quarantine_threshold);
-    ASSERT_TRUE(session->quarantine_probe);
+    ASSERT_EQ(session->quarantine.crashes(), Quarantine::threshold);
+    ASSERT_FALSE(session->quarantine.blocked());
 }
 
 TEST_CASE(DroppedEditNoProbe) {
     SessionStore store;
     auto session = store.open(1);
     store.apply_open(*session, "int a;\n", 1);
-    session->compile_crash_streak = Session::quarantine_threshold;
+    session->quarantine.on_crash();
+    session->quarantine.on_crash();
+    ASSERT_TRUE(session->quarantine.blocked());
 
     // The probe license is one attempt per real content change: an edit
     // whose range does not fit the buffer is dropped, an empty change list
     // and a no-op replacement change nothing — none may re-arm a compile
     // of the unchanged poison bytes.
     store.apply_change(*session, partial_change(99, 0, 99, 1, "junk"), 2);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_TRUE(session->quarantine.blocked());
 
     store.apply_change(*session, {}, 3);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_TRUE(session->quarantine.blocked());
 
     store.apply_change(*session, partial_change(0, 0, 0, 1, "i"), 4);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_TRUE(session->quarantine.blocked());
 
     // A whole-document change carrying identical bytes is a no-op too.
     protocol::TextDocumentContentChangeWholeDocument whole;
     whole.text = session->text;
     store.apply_change(*session, protocol::TextDocumentContentChangeEvent(whole), 5);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_TRUE(session->quarantine.blocked());
 
     store.apply_change(*session, partial_change(0, 0, 0, 1, "u"), 6);
-    ASSERT_TRUE(session->quarantine_probe);
+    ASSERT_FALSE(session->quarantine.blocked());
 }
 
 TEST_CASE(ReopenClearsQuarantine) {
     SessionStore store;
     auto session = store.open(1);
-    session->compile_crash_streak = Session::quarantine_threshold;
-    session->quarantine_probe = true;
+    session->quarantine.on_crash();
+    session->quarantine.on_crash();
 
     store.apply_open(*session, "int a;\n", 1);
 
-    ASSERT_EQ(session->compile_crash_streak, 0u);
-    ASSERT_FALSE(session->quarantine_probe);
+    ASSERT_EQ(session->quarantine.crashes(), 0u);
+    ASSERT_FALSE(session->quarantine.blocked());
 }
 
 };  // TEST_SUITE(SessionStore)

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -758,6 +758,22 @@ TEST_CASE(EffectiveLimitClamped) {
     EXPECT_EQ(f.effective_low_limit(), 2u);
 }
 
+TEST_CASE(LowCapCountsLive) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(8);
+
+    f.mark_dead(1);
+
+    // A slot awaiting respawn is future capacity, not schedulable now: the
+    // reserve-one-for-high cap must not let low-priority work occupy both
+    // live workers for the whole respawn window.
+    EXPECT_EQ(f.max_low_limit(), 1u);
+    EXPECT_EQ(f.effective_low_limit(), 1u);
+}
+
 };  // TEST_SUITE(WorkerPoolScheduling)
 
 TEST_SUITE(WorkerPoolCrash) {

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -129,6 +129,10 @@ struct WorkerPoolFixture {
         return workers[idx].state == WorkerPool::SlotState::Dead;
     }
 
+    std::size_t stateless_count() const {
+        return pool.stateless_workers.size();
+    }
+
     /// Manually queue a waiter, as acquire_stateless_slot does when it
     /// cannot claim directly.
     auto enqueue_waiter(worker::Priority p) {
@@ -1522,6 +1526,56 @@ TEST_CASE(DeadSlotRevives) {
         // ...and is revived with a fresh budget after the cooldown: the
         // pool never stays at zero workers forever.
         for(int i = 0; i < 100 && !f.worker_alive(0); ++i) {
+            co_await kota::sleep(100);
+        }
+        EXPECT_TRUE(f.worker_alive(0));
+        EXPECT_EQ(f.crash_streak(0), 0u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(RevivesSlotsGate) {
+    // Revival — and with it the indexer's requeue-on-unavailable — is only
+    // promised by a started pool with a nonzero cooldown.
+    WorkerPoolFixture f;
+    EXPECT_FALSE(f.pool.revives_slots());
+
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(1, 0));
+        EXPECT_TRUE(f.pool.revives_slots());
+        f.set_revive_after(std::chrono::milliseconds(0));
+        EXPECT_FALSE(f.pool.revives_slots());
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(ScaleUpRevivesDead) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+        // Cooldown far in the future: only scale-up can bring the slot back.
+        f.set_revive_after(std::chrono::minutes(10));
+        f.set_max_crash_streak(0);
+        co_await kota::sleep(500);
+
+        f.kill_worker(0);
+        for(int i = 0; i < 50 && !f.slot_dead(0); ++i) {
+            co_await kota::sleep(100);
+        }
+        CO_ASSERT_TRUE(f.slot_dead(0));
+
+        // Scale-up pressure revives the dead slot instead of appending a
+        // third worker next to it.
+        CO_ASSERT_TRUE(f.scale_up());
+        EXPECT_EQ(f.stateless_count(), 2u);
+        for(int i = 0; i < 50 && !f.worker_alive(0); ++i) {
             co_await kota::sleep(100);
         }
         EXPECT_TRUE(f.worker_alive(0));

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -907,6 +907,7 @@ TEST_CASE(OperationalErrorCodes) {
     EXPECT_TRUE(
         worker::is_operational_error(Error{worker::dispatch_errc::worker_unavailable, "x"}));
     EXPECT_TRUE(worker::is_operational_error(Error{worker::dispatch_errc::worker_crashed, "x"}));
+    EXPECT_TRUE(worker::is_operational_error(Error{worker::dispatch_errc::worker_restarting, "x"}));
     EXPECT_FALSE(worker::is_operational_error(Error{"plain failure"}));
 }
 
@@ -1266,6 +1267,9 @@ TEST_CASE(CrashBudgetBoundary) {
 }
 
 TEST_CASE(StatefulDyingRejected) {
+    // A request landing in the restart window never reached a worker: it
+    // fails with worker_restarting, not worker_crashed, so crash accounting
+    // (document quarantine) does not blame the document for the window.
     WorkerPoolFixture f;
     f.add_stateful();
     f.assign_worker(7);
@@ -1275,7 +1279,7 @@ TEST_CASE(StatefulDyingRejected) {
     f.run([&]() -> kota::task<> {
         auto result = co_await f.pool.send_stateful(7, worker::DocumentLinkParams{"/x.cpp"});
         CO_ASSERT_FALSE(result.has_value());
-        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_crashed);
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_restarting);
         done = true;
     });
     EXPECT_TRUE(done);

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -12,6 +12,8 @@ namespace clice::testing {
 
 /// Test fixture with friend access to WorkerPool internals.
 struct WorkerPoolFixture {
+    using SlotState = WorkerPool::SlotState;
+
     kota::event_loop loop;
     WorkerPool pool;
 
@@ -33,16 +35,9 @@ struct WorkerPoolFixture {
         pool.stateless_workers.push_back(WorkerPool::WorkerProcess{});
         auto& w = pool.stateless_workers.back();
         w.name = "SL-" + std::to_string(idx);
-        w.alive = alive;
+        w.state = alive ? SlotState::Alive : SlotState::Dead;
         w.busy = busy;
         w.low_priority = busy && low;
-        if(alive)
-            pool.alive_stateless_count += 1;
-        if(busy) {
-            pool.stateless_busy_count += 1;
-            if(low)
-                pool.low_busy_count += 1;
-        }
     }
 
     void add_stateful(bool alive = true, std::size_t owned = 0) {
@@ -50,22 +45,26 @@ struct WorkerPoolFixture {
         pool.stateful_workers.push_back(WorkerPool::WorkerProcess{});
         auto& w = pool.stateful_workers.back();
         w.name = "SF-" + std::to_string(idx);
-        w.alive = alive;
+        w.state = alive ? SlotState::Alive : SlotState::Dead;
         w.owned_documents = owned;
     }
 
-    void set_limits(std::size_t low, std::size_t max_low) {
+    void set_low_limit(std::size_t low) {
         pool.low_limit = low;
-        pool.max_low_limit = max_low;
     }
 
-    void set_max_restarts(unsigned n) {
-        pool.options.max_restarts = n;
+    void set_max_crash_streak(unsigned n) {
+        pool.options.max_crash_streak = n;
     }
 
-    void set_restart_count(std::size_t idx, bool stateful, unsigned count) {
+    void set_crash_streak(std::size_t idx, bool stateful, unsigned streak) {
         auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
-        workers[idx].restart_count = count;
+        workers[idx].crash_streak = streak;
+    }
+
+    void set_uptime(std::size_t idx, bool stateful, std::chrono::milliseconds uptime) {
+        auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
+        workers[idx].spawn_time = std::chrono::steady_clock::now() - uptime;
     }
 
     std::size_t pick_least_loaded() {
@@ -104,11 +103,46 @@ struct WorkerPoolFixture {
         return pool.process_crash(index, stateful, exit_code, exit_signal);
     }
 
+    void mark_dead(std::size_t idx, bool stateful = false) {
+        pool.mark_worker_dead(idx, stateful, false);
+    }
+
+    /// Manually queue a waiter, as acquire_stateless_slot does when it
+    /// cannot claim directly.
+    auto enqueue_waiter(worker::Priority p) {
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(pool, p);
+        auto& queue = p == worker::Priority::High ? pool.high_queue : pool.low_queue;
+        queue.push_back(pending.get());
+        pending->queue = &queue;
+        return pending;
+    }
+
+    void dispatch_pending() {
+        pool.try_dispatch_pending();
+    }
+
+    void preempt(std::size_t count) {
+        pool.preempt_low_priority(count);
+    }
+
+    void tick_memory(double ratio) {
+        pool.tick_memory(ratio);
+    }
+
+    std::chrono::milliseconds backoff_delay(unsigned streak) {
+        return pool.backoff_delay(streak);
+    }
+
+    bool scale_up() {
+        return pool.scale_up_worker();
+    }
+
     bool start(std::uint32_t stateless = 2, std::uint32_t stateful = 0) {
         WorkerPoolOptions opts;
         opts.self_path = clice_binary();
         opts.stateless_count = stateless;
         opts.stateful_count = stateful;
+        opts.max_stateless = 8;
         return pool.start(opts);
     }
 
@@ -130,12 +164,36 @@ struct WorkerPoolFixture {
         return pool.low_limit;
     }
 
+    std::size_t effective_low_limit() const {
+        return pool.effective_low_limit();
+    }
+
+    std::size_t max_low_limit() const {
+        return pool.max_low_limit();
+    }
+
+    std::size_t w_max() const {
+        return pool.w_max;
+    }
+
+    void set_w_max(std::size_t value) {
+        pool.w_max = value;
+    }
+
     std::size_t alive_count() const {
-        return pool.alive_stateless_count;
+        return pool.alive_stateless();
     }
 
     std::size_t busy_count() const {
-        return pool.stateless_busy_count;
+        return pool.busy_stateless();
+    }
+
+    std::size_t low_busy() const {
+        return pool.low_busy_count();
+    }
+
+    std::size_t capacity() const {
+        return pool.stateless_capacity();
     }
 
     std::size_t stateful_owned(std::size_t idx) const {
@@ -154,25 +212,34 @@ struct WorkerPoolFixture {
         return pool.owner.find(path_id)->second;
     }
 
+    SlotState state(std::size_t idx, bool stateful = false) const {
+        return stateful ? pool.stateful_workers[idx].state : pool.stateless_workers[idx].state;
+    }
+
+    unsigned generation(std::size_t idx, bool stateful = false) const {
+        return stateful ? pool.stateful_workers[idx].generation
+                        : pool.stateless_workers[idx].generation;
+    }
+
+    bool preempted(std::size_t idx) const {
+        return pool.stateless_workers[idx].preempted;
+    }
+
+    unsigned crash_streak(std::size_t idx, bool stateful = false) const {
+        return stateful ? pool.stateful_workers[idx].crash_streak
+                        : pool.stateless_workers[idx].crash_streak;
+    }
+
     bool worker_alive(std::size_t idx) const {
-        return pool.stateless_workers[idx].alive;
+        return pool.stateless_workers[idx].state == SlotState::Alive;
     }
 
     int worker_pid(std::size_t idx) const {
         return pool.stateless_workers[idx].proc.pid();
     }
 
-    struct PriorityResult {
-        bool high_dispatched;
-        bool low_dispatched;
-    };
-
     unsigned get_backoff_cooldown() const {
         return pool.backoff_cooldown;
-    }
-
-    std::size_t max_low_limit() const {
-        return pool.max_low_limit;
     }
 
     std::size_t high_queue_size() const {
@@ -183,9 +250,14 @@ struct WorkerPoolFixture {
         return pool.low_queue.size();
     }
 
+    struct PriorityResult {
+        bool high_dispatched;
+        bool low_dispatched;
+    };
+
     PriorityResult test_priority_dispatch(std::size_t release_idx) {
-        auto high = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
-        auto low = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low);
+        auto high = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::High);
+        auto low = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::Low);
         pool.high_queue.push_back(high.get());
         high->queue = &pool.high_queue;
         pool.low_queue.push_back(low.get());
@@ -194,11 +266,19 @@ struct WorkerPoolFixture {
         return {high->ready.is_set(), low->ready.is_set()};
     }
 
-    std::size_t test_low_dispatch(std::size_t count) {
+    struct LowDispatchResult {
+        std::size_t dispatched;
+
+        /// Busy count observed while the waiters still hold their claims;
+        /// destroying an unconsumed dispatched waiter releases its slot.
+        std::size_t busy_at_dispatch;
+    };
+
+    LowDispatchResult test_low_dispatch(std::size_t count) {
         llvm::SmallVector<std::unique_ptr<WorkerPool::PendingStateless>> pending;
         for(std::size_t i = 0; i < count; ++i) {
             pending.push_back(
-                std::make_unique<WorkerPool::PendingStateless>(worker::Priority::Low));
+                std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::Low));
             pool.low_queue.push_back(pending.back().get());
             pending.back()->queue = &pool.low_queue;
         }
@@ -207,15 +287,14 @@ struct WorkerPoolFixture {
         for(auto& p: pending)
             if(p->ready.is_set())
                 dispatched += 1;
-        return dispatched;
+        return {dispatched, pool.busy_stateless()};
     }
 
     bool test_slot_raii(std::size_t idx) {
         pool.stateless_workers[idx].busy = true;
-        pool.stateless_busy_count += 1;
         { WorkerPool::StatelessSlot slot(pool, idx); }
-        return !pool.stateless_workers[idx].busy && pool.stateless_busy_count == 0 &&
-               pool.low_busy_count == 0;
+        return !pool.stateless_workers[idx].busy && pool.busy_stateless() == 0 &&
+               pool.low_busy_count() == 0;
     }
 
     struct ReleaseResult {
@@ -224,7 +303,7 @@ struct WorkerPoolFixture {
     };
 
     ReleaseResult test_release_dispatches() {
-        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::High);
         pool.high_queue.push_back(pending.get());
         pending->queue = &pool.high_queue;
         bool before = pending->ready.is_set();
@@ -235,7 +314,7 @@ struct WorkerPoolFixture {
 
     bool test_pending_cleanup_high() {
         {
-            WorkerPool::PendingStateless pending(worker::Priority::High);
+            WorkerPool::PendingStateless pending(pool, worker::Priority::High);
             pool.high_queue.push_back(&pending);
             pending.queue = &pool.high_queue;
             if(pool.high_queue.size() != 1)
@@ -246,7 +325,7 @@ struct WorkerPoolFixture {
 
     bool test_pending_cleanup_low() {
         {
-            WorkerPool::PendingStateless pending(worker::Priority::Low);
+            WorkerPool::PendingStateless pending(pool, worker::Priority::Low);
             pool.low_queue.push_back(&pending);
             pending.queue = &pool.low_queue;
             if(pool.low_queue.size() != 1)
@@ -267,7 +346,7 @@ struct WorkerPoolFixture {
     };
 
     DrainResult test_dead_pool_drain() {
-        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::High);
         pool.high_queue.push_back(pending.get());
         pending->queue = &pool.high_queue;
         simulate_crash(0, false);
@@ -275,19 +354,31 @@ struct WorkerPoolFixture {
     }
 
     bool test_slot_gen_guard() {
-        // Old StatelessSlot should NOT release a slot that was crash-replaced.
+        // Old StatelessSlot should NOT release a slot whose occupant died and
+        // was replaced (generation bumped) in the meantime.
         {
             WorkerPool::StatelessSlot slot(pool, 0);
-            // Simulate respawn bumping restart_count.
-            pool.stateless_workers[0].restart_count = 1;
+            pool.stateless_workers[0].generation += 1;
             pool.stateless_workers[0].busy = true;
         }
-        // Destructor saw mismatched gen → skipped release.
-        return pool.stateless_workers[0].busy && pool.stateless_busy_count == 1;
+        return pool.stateless_workers[0].busy && pool.busy_stateless() == 1;
+    }
+
+    bool test_pending_gen_guard() {
+        // A dispatched-but-unconsumed waiter must NOT release the slot if the
+        // claimed occupant died and a new claim owns it now.
+        auto pending = enqueue_waiter(worker::Priority::High);
+        pool.try_dispatch_pending();
+        if(!pending->ready.is_set() || pending->assigned_worker != 0)
+            return false;
+        pool.stateless_workers[0].generation += 1;
+        pool.stateless_workers[0].busy = true;
+        pending.reset();
+        return pool.stateless_workers[0].busy;
     }
 
     DispatchResult test_dispatch_clears_queue() {
-        auto pending = std::make_unique<WorkerPool::PendingStateless>(worker::Priority::High);
+        auto pending = std::make_unique<WorkerPool::PendingStateless>(pool, worker::Priority::High);
         pool.high_queue.push_back(pending.get());
         pending->queue = &pool.high_queue;
         pool.release_stateless_slot(0);
@@ -317,6 +408,16 @@ TEST_CASE(SkipDeadWorkers) {
     f.add_stateful(true, 5);
     f.add_stateful(true, 3);
     EXPECT_EQ(f.pick_least_loaded(), 2u);
+}
+
+TEST_CASE(AllDeadNoAssignment) {
+    WorkerPoolFixture f;
+    f.add_stateful(false, 0);
+    f.add_stateful(false, 0);
+    EXPECT_EQ(f.pick_least_loaded(), SIZE_MAX);
+    EXPECT_EQ(f.assign_worker(100), SIZE_MAX);
+    // A failed assignment must not pin the document to a dead worker.
+    EXPECT_FALSE(f.has_owner(100));
 }
 
 TEST_CASE(AssignNewPath) {
@@ -420,11 +521,18 @@ TEST_CASE(PickIdleSkipsDead) {
     EXPECT_EQ(f.pick_idle(), 1u);
 }
 
+TEST_CASE(PickIdleNoneAvailable) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.add_stateless(false, false);
+    EXPECT_EQ(f.pick_idle(), SIZE_MAX);
+}
+
 TEST_CASE(AcquireHighImmediate) {
     WorkerPoolFixture f;
     f.add_stateless();
     f.add_stateless();
-    f.set_limits(2, 2);
+    f.set_low_limit(2);
     bool done = false;
     f.run([&]() -> kota::task<> {
         auto idx = co_await f.acquire_slot(worker::Priority::High);
@@ -438,7 +546,7 @@ TEST_CASE(AcquireHighImmediate) {
 TEST_CASE(AcquireLowImmediate) {
     WorkerPoolFixture f;
     f.add_stateless();
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     bool done = false;
     f.run([&]() -> kota::task<> {
         auto idx = co_await f.acquire_slot(worker::Priority::Low);
@@ -451,7 +559,7 @@ TEST_CASE(AcquireLowImmediate) {
 TEST_CASE(HighBypassesLimit) {
     WorkerPoolFixture f;
     f.add_stateless();
-    f.set_limits(0, 0);
+    f.set_low_limit(0);
     bool done = false;
     f.run([&]() -> kota::task<> {
         auto idx = co_await f.acquire_slot(worker::Priority::High);
@@ -464,7 +572,7 @@ TEST_CASE(HighBypassesLimit) {
 TEST_CASE(HighDispatchedFirst) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     auto r = f.test_priority_dispatch(0);
     EXPECT_TRUE(r.high_dispatched);
     EXPECT_FALSE(r.low_dispatched);
@@ -474,15 +582,18 @@ TEST_CASE(LowLimitEnforced) {
     WorkerPoolFixture f;
     f.add_stateless();
     f.add_stateless();
-    f.set_limits(1, 1);
-    EXPECT_EQ(f.test_low_dispatch(2), 1u);
-    EXPECT_EQ(f.busy_count(), 1u);
+    f.set_low_limit(1);
+    auto r = f.test_low_dispatch(2);
+    EXPECT_EQ(r.dispatched, 1u);
+    EXPECT_EQ(r.busy_at_dispatch, 1u);
+    // Destroying the unconsumed waiters released their claims.
+    EXPECT_EQ(f.busy_count(), 0u);
 }
 
 TEST_CASE(ReleaseDispatchesPending) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     auto r = f.test_release_dispatches();
     EXPECT_FALSE(r.pending_before);
     EXPECT_TRUE(r.dispatched_after);
@@ -498,7 +609,7 @@ TEST_CASE(ConcurrencyLimit) {
     WorkerPoolFixture f;
     f.add_stateless();
     f.add_stateless();
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
 
     int concurrent = 0;
     int max_concurrent = 0;
@@ -527,7 +638,7 @@ TEST_CASE(ConcurrencyLimit) {
 TEST_CASE(PriorityOrdering) {
     WorkerPoolFixture f;
     f.add_stateless();
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
 
     std::size_t order = 0;
     std::size_t high_order = 0;
@@ -564,7 +675,7 @@ TEST_CASE(PriorityOrdering) {
 TEST_CASE(SingleWorkerShared) {
     WorkerPoolFixture f;
     f.add_stateless();
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     EXPECT_EQ(f.max_low_limit(), 1u);
 
     bool done = false;
@@ -590,11 +701,61 @@ TEST_CASE(PendingCleanupOnDestroy) {
 TEST_CASE(DispatchClearsQueue) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     auto r = f.test_dispatch_clears_queue();
     EXPECT_TRUE(r.dispatched);
     EXPECT_TRUE(r.queue_cleared);
     EXPECT_TRUE(r.queue_ptr_nulled);
+}
+
+TEST_CASE(FreshAcquireRespectsQueue) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_low_limit(1);
+
+    bool acquired = false;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto queued = f.enqueue_waiter(worker::Priority::High);
+
+        kota::task_group<> group(f.loop);
+        auto fresh = [&]() -> kota::task<> {
+            auto idx = co_await f.acquire_slot(worker::Priority::High);
+            acquired = true;
+            f.release_slot(idx);
+        };
+        group.spawn(fresh());
+        co_await kota::sleep(10);
+
+        // The fresh acquire lined up behind the queued waiter instead of
+        // claiming the idle worker over its head.
+        EXPECT_FALSE(acquired);
+        EXPECT_EQ(f.high_queue_size(), 2u);
+
+        // The idle worker goes to the queued waiter first.
+        f.dispatch_pending();
+        EXPECT_FALSE(acquired);
+        EXPECT_TRUE(f.is_busy(0));
+
+        // Destroying the unconsumed claim releases the slot to the fresh
+        // waiter.
+        queued.reset();
+        co_await group.join();
+        EXPECT_TRUE(acquired);
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(EffectiveLimitClamped) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(8);
+    // Capacity 3 caps the effective allowance at 2 regardless of low_limit.
+    EXPECT_EQ(f.max_low_limit(), 2u);
+    EXPECT_EQ(f.effective_low_limit(), 2u);
 }
 
 };  // TEST_SUITE(WorkerPoolScheduling)
@@ -605,7 +766,7 @@ TEST_CASE(StatelessCleanup) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
     f.add_stateless(true, false);
-    f.set_limits(2, 2);
+    f.set_low_limit(2);
 
     EXPECT_EQ(f.alive_count(), 2u);
     EXPECT_EQ(f.busy_count(), 1u);
@@ -692,7 +853,18 @@ TEST_CASE(OperationalErrorCodes) {
     EXPECT_TRUE(worker::is_operational_error(Error{worker::dispatch_errc::cancelled, "x"}));
     EXPECT_TRUE(
         worker::is_operational_error(Error{worker::dispatch_errc::worker_unavailable, "x"}));
+    EXPECT_TRUE(worker::is_operational_error(Error{worker::dispatch_errc::worker_crashed, "x"}));
     EXPECT_FALSE(worker::is_operational_error(Error{"plain failure"}));
+}
+
+TEST_CASE(TransportErrorClassification) {
+    /// kota surfaces transport failures with the default RequestFailed code;
+    /// remote handler errors carry specific codes and must pass through.
+    using worker::protocol::Error;
+    using worker::protocol::ErrorCode;
+    EXPECT_TRUE(worker::is_transport_error(Error{"transport closed"}));
+    EXPECT_FALSE(worker::is_transport_error(Error{ErrorCode::InternalError, "handler threw"}));
+    EXPECT_FALSE(worker::is_transport_error(Error{ErrorCode::RequestCancelled, "cancelled"}));
 }
 
 TEST_CASE(CrashInfoSignal) {
@@ -718,37 +890,88 @@ TEST_CASE(CrashInfoExitCode) {
     EXPECT_EQ(f.crash_reports[0].exit_signal, 0);
 }
 
-TEST_CASE(WillRestart) {
+TEST_CASE(WillRestartWithinBudget) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
-    f.set_max_restarts(3);
-    f.set_restart_count(0, false, 1);
+    f.set_max_crash_streak(3);
+    f.set_crash_streak(0, false, 1);
 
     auto should_restart = f.simulate_crash(0, false);
 
     EXPECT_TRUE(should_restart);
     ASSERT_EQ(f.crash_reports.size(), 1u);
     EXPECT_TRUE(f.crash_reports[0].will_restart);
-    EXPECT_EQ(f.crash_reports[0].restart_count, 1u);
+    EXPECT_EQ(f.crash_reports[0].crash_streak, 2u);
 }
 
-TEST_CASE(MaxRestartsExceeded) {
+TEST_CASE(CrashBudgetExhausted) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
-    f.set_max_restarts(3);
-    f.set_restart_count(0, false, 3);
+    f.set_max_crash_streak(3);
+    f.set_crash_streak(0, false, 3);
 
     auto should_restart = f.simulate_crash(0, false);
 
     EXPECT_FALSE(should_restart);
     ASSERT_EQ(f.crash_reports.size(), 1u);
     EXPECT_FALSE(f.crash_reports[0].will_restart);
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dead);
+}
+
+TEST_CASE(HealthyUptimeResetsStreak) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_max_crash_streak(3);
+    f.set_crash_streak(0, false, 3);
+    // Ran healthily past the reset threshold: this crash starts a new streak
+    // instead of exhausting the budget.
+    f.set_uptime(0, false, std::chrono::milliseconds(60'000));
+
+    auto should_restart = f.simulate_crash(0, false);
+
+    EXPECT_TRUE(should_restart);
+    EXPECT_EQ(f.crash_streak(0), 1u);
+}
+
+TEST_CASE(BackoffDelaySchedule) {
+    WorkerPoolFixture f;
+    using ms = std::chrono::milliseconds;
+    // First crash respawns immediately; later ones back off exponentially,
+    // capped so a long streak cannot produce absurd delays.
+    EXPECT_EQ(f.backoff_delay(0), ms(0));
+    EXPECT_EQ(f.backoff_delay(1), ms(0));
+    EXPECT_EQ(f.backoff_delay(2), ms(500));
+    EXPECT_EQ(f.backoff_delay(3), ms(1000));
+    EXPECT_EQ(f.backoff_delay(4), ms(2000));
+    EXPECT_EQ(f.backoff_delay(10), ms(8000));
+}
+
+TEST_CASE(MarkDeadRemovesSlot) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.add_stateless(true, false);
+    f.set_low_limit(2);
+
+    EXPECT_EQ(f.busy_count(), 1u);
+    f.mark_dead(0);
+
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dying);
+    EXPECT_EQ(f.generation(0), 1u);
+    EXPECT_EQ(f.busy_count(), 0u);
+    // The dying slot still counts as future capacity (its verdict is
+    // pending), but is not schedulable.
+    EXPECT_EQ(f.capacity(), 2u);
+    EXPECT_EQ(f.pick_idle(), 1u);
+
+    // Idempotent: a second mark (e.g. the monitor's) is a no-op.
+    f.mark_dead(0);
+    EXPECT_EQ(f.generation(0), 1u);
 }
 
 TEST_CASE(ReleaseIdempotent) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
 
     EXPECT_EQ(f.busy_count(), 1u);
     f.release_slot(0);
@@ -760,7 +983,7 @@ TEST_CASE(ReleaseIdempotent) {
 TEST_CASE(CrashThenRelease) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
 
     f.simulate_crash(0, false);
     EXPECT_EQ(f.busy_count(), 0u);
@@ -791,7 +1014,7 @@ TEST_CASE(StatefulCrashClearsOwnership) {
 
 TEST_CASE(AIMDBackoff) {
     WorkerPoolFixture f;
-    f.set_limits(8, 8);
+    f.set_low_limit(8);
     f.apply_backoff();
     EXPECT_EQ(f.low_limit(), 6u);
     f.apply_backoff();
@@ -804,7 +1027,7 @@ TEST_CASE(AIMDBackoff) {
 
 TEST_CASE(AIMDMinimum) {
     WorkerPoolFixture f;
-    f.set_limits(1, 4);
+    f.set_low_limit(1);
     f.apply_backoff();
     EXPECT_EQ(f.low_limit(), 1u);
 }
@@ -812,7 +1035,7 @@ TEST_CASE(AIMDMinimum) {
 TEST_CASE(CrashAppliesBackoff) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
-    f.set_limits(8, 8);
+    f.set_low_limit(8);
 
     f.simulate_crash(0, false);
 
@@ -823,7 +1046,7 @@ TEST_CASE(IdleStatelessCrash) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
     f.add_stateless(true, false);
-    f.set_limits(2, 2);
+    f.set_low_limit(2);
 
     EXPECT_EQ(f.alive_count(), 2u);
     EXPECT_EQ(f.busy_count(), 0u);
@@ -840,7 +1063,7 @@ TEST_CASE(RapidCrashSequence) {
     f.add_stateless(true, true);
     f.add_stateless(true, true);
     f.add_stateless(true, false);
-    f.set_limits(8, 8);
+    f.set_low_limit(8);
 
     f.simulate_crash(0, false);
     f.simulate_crash(1, false);
@@ -854,7 +1077,7 @@ TEST_CASE(RapidCrashSequence) {
 
 TEST_CASE(BackoffSetsCooldown) {
     WorkerPoolFixture f;
-    f.set_limits(8, 8);
+    f.set_low_limit(8);
     EXPECT_EQ(f.get_backoff_cooldown(), 0u);
     f.apply_backoff();
     EXPECT_GT(f.get_backoff_cooldown(), 0u);
@@ -863,7 +1086,7 @@ TEST_CASE(BackoffSetsCooldown) {
 TEST_CASE(CrashSetsCooldown) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
-    f.set_limits(8, 8);
+    f.set_low_limit(8);
 
     f.simulate_crash(0, false);
 
@@ -883,11 +1106,12 @@ TEST_CASE(StatefulCrashNoCooldown) {
 TEST_CASE(DeadPoolReturnsError) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
-    f.set_limits(1, 1);
-    f.set_max_restarts(0);
+    f.set_low_limit(1);
+    f.set_max_crash_streak(0);
 
     f.simulate_crash(0, false);
     EXPECT_EQ(f.alive_count(), 0u);
+    EXPECT_EQ(f.capacity(), 0u);
 
     bool done = false;
     f.run([&]() -> kota::task<> {
@@ -901,8 +1125,8 @@ TEST_CASE(DeadPoolReturnsError) {
 TEST_CASE(DeadPoolDrainsPending) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
-    f.set_max_restarts(0);
+    f.set_low_limit(1);
+    f.set_max_crash_streak(0);
 
     auto r = f.test_dead_pool_drain();
     EXPECT_TRUE(r.drained);
@@ -913,26 +1137,158 @@ TEST_CASE(DeadPoolDrainsPending) {
 TEST_CASE(SlotGenGuard) {
     WorkerPoolFixture f;
     f.add_stateless(true, true);
-    f.set_limits(1, 1);
+    f.set_low_limit(1);
     EXPECT_TRUE(f.test_slot_gen_guard());
 }
 
-TEST_CASE(MaxLowLimitClamped) {
+TEST_CASE(PendingClaimGenGuard) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.set_low_limit(1);
+    EXPECT_TRUE(f.test_pending_gen_guard());
+}
+
+TEST_CASE(CrashBudgetBoundary) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, false);
+    f.set_max_crash_streak(3);
+    f.set_crash_streak(0, false, 2);
+
+    // Exactly at the budget: the streak reaches 3 == max, still restarts.
+    EXPECT_TRUE(f.simulate_crash(0, false));
+    EXPECT_EQ(f.crash_streak(0), 3u);
+
+    // One past the budget: give up.
+    EXPECT_FALSE(f.simulate_crash(0, false));
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dead);
+}
+
+TEST_CASE(StatefulDyingRejected) {
+    WorkerPoolFixture f;
+    f.add_stateful();
+    f.assign_worker(7);
+    f.mark_dead(0, true);
+
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        auto result = co_await f.pool.send_stateful(7, worker::DocumentLinkParams{"/x.cpp"});
+        CO_ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_crashed);
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(DyingSlotKeepsWaiters) {
+    // A slot marked dead but without a verdict still counts as future
+    // capacity: waiters must keep waiting for the respawn instead of
+    // failing out.
+    WorkerPoolFixture f;
+    f.add_stateless(true, true);
+    f.set_low_limit(1);
+
+    f.mark_dead(0);
+    EXPECT_EQ(f.test_low_dispatch(1).dispatched, 0u);
+    EXPECT_EQ(f.low_queue_size(), 0u);  // helper destroys its waiters
+}
+
+TEST_CASE(MaxLowLimitShrinks) {
     WorkerPoolFixture f;
     f.add_stateless(true, false);
     f.add_stateless(true, false);
     f.add_stateless(true, false);
-    f.set_limits(2, 2);
-    f.set_max_restarts(0);
+    f.set_low_limit(2);
+    f.set_max_crash_streak(0);
 
     f.simulate_crash(0, false);
 
-    // max_low_limit should shrink to alive-1 (or alive if 1).
+    // Capacity dropped to 2; the derived ceiling reserves one for high and
+    // clamps the stored allowance of 2 down to it.
     EXPECT_EQ(f.max_low_limit(), 1u);
-    EXPECT_LE(f.low_limit(), f.max_low_limit());
+    EXPECT_EQ(f.effective_low_limit(), 1u);
 }
 
 };  // TEST_SUITE(WorkerPoolCrash)
+
+TEST_SUITE(WorkerPoolMemory) {
+
+TEST_CASE(PreemptKillsLowWorkers) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);   // busy low
+    f.add_stateless(true, true, false);  // busy high — must survive
+    f.set_low_limit(2);
+
+    f.preempt(2);
+
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dying);
+    EXPECT_TRUE(f.preempted(0));
+    EXPECT_EQ(f.state(1), WorkerPoolFixture::SlotState::Alive);
+    EXPECT_TRUE(f.is_busy(1));
+    EXPECT_EQ(f.low_busy(), 0u);
+    // Preemption is not a crash: no report, no crash accounting.
+    EXPECT_TRUE(f.crash_reports.empty());
+    EXPECT_EQ(f.crash_streak(0), 0u);
+}
+
+TEST_CASE(SevereMemoryTick) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, true, true);
+    f.add_stateless(true, false);
+    f.set_low_limit(2);
+
+    f.tick_memory(0.05);
+
+    // Floor the allowance, remember the recovery target, kill the low work.
+    EXPECT_EQ(f.low_limit(), 1u);
+    EXPECT_EQ(f.w_max(), 2u);
+    EXPECT_EQ(f.low_busy(), 0u);
+    EXPECT_EQ(f.state(0), WorkerPoolFixture::SlotState::Dying);
+    EXPECT_EQ(f.state(1), WorkerPoolFixture::SlotState::Dying);
+}
+
+TEST_CASE(PressureDecrementsLimit) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(2);
+
+    f.tick_memory(0.15);
+    EXPECT_EQ(f.low_limit(), 1u);
+    EXPECT_EQ(f.w_max(), 2u);
+}
+
+TEST_CASE(RecoveryClosesGap) {
+    WorkerPoolFixture f;
+    for(int i = 0; i < 9; ++i)
+        f.add_stateless();
+    f.set_low_limit(2);
+    // Simulate an earlier reduction from 8.
+    f.set_w_max(8);
+
+    f.tick_memory(0.5);
+    EXPECT_EQ(f.low_limit(), 5u);  // gap 6 → +3
+    f.tick_memory(0.5);
+    EXPECT_EQ(f.low_limit(), 6u);  // gap 3 → +1 (integer halving)
+}
+
+TEST_CASE(CooldownSkipsDecrement) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(2);
+    f.apply_backoff();  // low_limit -> 1, cooldown = 3
+
+    f.set_low_limit(2);
+    f.tick_memory(0.15);
+    // Cooldown consumed instead of a second decrement.
+    EXPECT_EQ(f.low_limit(), 2u);
+    EXPECT_LT(f.get_backoff_cooldown(), 3u);
+}
+
+};  // TEST_SUITE(WorkerPoolMemory)
 
 TEST_SUITE(WorkerPoolIntegration) {
 
@@ -948,7 +1304,7 @@ TEST_CASE(StartAndStop) {
 }
 
 TEST_CASE(StopIsPrompt) {
-    // Regression guard: stop() must cancel monitor_memory()'s 3s poll
+    // Regression guard: stop() must cancel the monitor loop's 3s poll
     // sleep instead of waiting it out.
     WorkerPoolFixture f;
     std::chrono::milliseconds elapsed{};
@@ -1033,6 +1389,113 @@ TEST_CASE(CrashNotification) {
         EXPECT_FALSE(f.crash_reports[0].stateful);
         EXPECT_EQ(f.crash_reports[0].exit_signal, 9);
         EXPECT_TRUE(f.crash_reports[0].will_restart);
+        EXPECT_EQ(f.crash_reports[0].crash_streak, 1u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(CrashDuringRequest) {
+    TempDir tmp;
+    tmp.touch("test.cpp", "int x = 1;\n");
+    auto src = tmp.path("test.cpp");
+
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+        co_await kota::sleep(500);
+
+        // Kill both workers, then send without yielding: the claim lands on
+        // a dead-but-not-yet-reaped slot, and the pool must surface
+        // worker_crashed instead of retrying internally.
+        f.kill_worker(0);
+        f.kill_worker(1);
+
+        worker::BuildParams params;
+        params.priority = worker::Priority::Low;
+        params.kind = worker::BuildKind::Index;
+        params.file = src;
+        params.directory = "/tmp";
+        params.arguments = make_args(src);
+
+        auto result = co_await f.pool.send_stateless(params);
+        CO_ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, worker::dispatch_errc::worker_crashed);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(PreemptCancelsRequest) {
+    TempDir tmp;
+    tmp.touch("slow.cpp", "#include <vector>\n#include <string>\nint x = 1;\n");
+    auto src = tmp.path("slow.cpp");
+
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+        co_await kota::sleep(500);
+
+        worker::BuildParams params;
+        params.priority = worker::Priority::Low;
+        params.kind = worker::BuildKind::Index;
+        params.file = src;
+        params.directory = "/tmp";
+        params.arguments = make_args(src);
+
+        worker::protocol::integer code = 0;
+        kota::task_group<> group(f.loop);
+        auto sender = [&]() -> kota::task<> {
+            auto result = co_await f.pool.send_stateless(params);
+            if(!result.has_value())
+                code = result.error().code;
+        };
+        group.spawn(sender());
+        // Long enough for the claim + request write, far shorter than the
+        // worker needs to compile the file.
+        co_await kota::sleep(10);
+
+        f.preempt(1);
+        co_await group.join();
+        EXPECT_EQ(code, worker::dispatch_errc::cancelled);
+
+        // Preemption is not a crash: no report, and the worker comes back
+        // with an untouched budget.
+        EXPECT_TRUE(f.crash_reports.empty());
+        for(int i = 0; i < 50; ++i) {
+            co_await kota::sleep(100);
+            if(f.worker_alive(0))
+                break;
+        }
+        EXPECT_TRUE(f.worker_alive(0));
+        EXPECT_EQ(f.crash_streak(0), 0u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(ScaleUpKeepsLimit) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(3, 0));
+        // Simulate pressure having reduced the allowance below the ceiling.
+        f.set_low_limit(1);
+
+        CO_ASSERT_TRUE(f.scale_up());
+
+        // The new worker adds exactly one to the allowance; it must not
+        // reset the reduction back to the ceiling (which is now 3).
+        EXPECT_EQ(f.max_low_limit(), 3u);
+        EXPECT_EQ(f.low_limit(), 2u);
 
         co_await f.stop();
         done = true;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -107,6 +107,10 @@ struct WorkerPoolFixture {
         pool.mark_worker_dead(idx, stateful, false);
     }
 
+    void set_retiring(std::size_t idx) {
+        pool.stateless_workers[idx].retiring = true;
+    }
+
     /// Manually queue a waiter, as acquire_stateless_slot does when it
     /// cannot claim directly.
     auto enqueue_waiter(worker::Priority p) {
@@ -770,6 +774,21 @@ TEST_CASE(LowCapCountsLive) {
     // A slot awaiting respawn is future capacity, not schedulable now: the
     // reserve-one-for-high cap must not let low-priority work occupy both
     // live workers for the whole respawn window.
+    EXPECT_EQ(f.max_low_limit(), 1u);
+    EXPECT_EQ(f.effective_low_limit(), 1u);
+}
+
+TEST_CASE(LowCapSkipsRetiring) {
+    WorkerPoolFixture f;
+    f.add_stateless();
+    f.add_stateless();
+    f.add_stateless();
+    f.set_low_limit(8);
+
+    f.set_retiring(1);
+
+    // A retiring slot is alive but takes no new work, so it must not
+    // count toward the schedulable pool the cap reserves from.
     EXPECT_EQ(f.max_low_limit(), 1u);
     EXPECT_EQ(f.effective_low_limit(), 1u);
 }

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -1230,6 +1230,32 @@ TEST_CASE(PreemptKillsLowWorkers) {
     EXPECT_EQ(f.crash_streak(0), 0u);
 }
 
+TEST_CASE(PreemptCreditsHealthyRun) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.set_crash_streak(0, false, 2);
+    f.set_uptime(0, false, std::chrono::milliseconds(60'000));
+
+    f.preempt(1);
+
+    // The healthy interval before the preemption clears the stale streak,
+    // exactly as the next crash's accounting would have.
+    EXPECT_EQ(f.crash_streak(0), 0u);
+}
+
+TEST_CASE(PreemptKeepsYoungStreak) {
+    WorkerPoolFixture f;
+    f.add_stateless(true, true, true);
+    f.set_crash_streak(0, false, 2);
+    f.set_uptime(0, false, std::chrono::milliseconds(0));
+
+    f.preempt(1);
+
+    // A slot that has not yet earned the healthy credit keeps its streak:
+    // preemption neither punishes nor forgives.
+    EXPECT_EQ(f.crash_streak(0), 2u);
+}
+
 TEST_CASE(SevereMemoryTick) {
     WorkerPoolFixture f;
     f.add_stateless(true, true, true);

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -167,13 +167,20 @@ struct WorkerPoolFixture {
         return pool.scale_up_worker();
     }
 
-    bool start(std::uint32_t stateless = 2, std::uint32_t stateful = 0) {
+    bool start(std::uint32_t stateless = 2,
+               std::uint32_t stateful = 0,
+               std::uint32_t min_stateless = 0) {
         WorkerPoolOptions opts;
         opts.self_path = clice_binary();
         opts.stateless_count = stateless;
         opts.stateful_count = stateful;
+        opts.min_stateless = min_stateless;
         opts.max_stateless = 8;
         return pool.start(opts);
+    }
+
+    std::size_t min_stateless() const {
+        return pool.options.min_stateless;
     }
 
     kota::task<> stop() {
@@ -1566,6 +1573,21 @@ TEST_CASE(DeadSlotRevives) {
         EXPECT_TRUE(f.worker_alive(0));
         EXPECT_EQ(f.crash_streak(0), 0u);
 
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(FloorAboveStartupKept) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        // A floor configured above the startup count survives start():
+        // scale-up may grow past it later, and idle scale-down must hold
+        // the configured warm set instead of shrinking back to startup.
+        CO_ASSERT_TRUE(f.start(2, 0, /*min_stateless=*/4));
+        EXPECT_EQ(f.min_stateless(), 4u);
         co_await f.stop();
         done = true;
     });

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -183,6 +183,16 @@ struct WorkerPoolFixture {
         return pool.options.min_stateless;
     }
 
+    void force_owner(std::uint32_t path_id, std::size_t idx) {
+        pool.owner[path_id] = idx;
+        pool.stateful_workers[idx].owned_documents += 1;
+    }
+
+    unsigned suspect_inflight(std::size_t idx, bool stateful) const {
+        auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
+        return workers[idx].suspect_inflight;
+    }
+
     kota::task<> stop() {
         return pool.stop();
     }
@@ -1572,6 +1582,33 @@ TEST_CASE(DeadSlotRevives) {
         }
         EXPECT_TRUE(f.worker_alive(0));
         EXPECT_EQ(f.crash_streak(0), 0u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(InPlaceKeepsOwner) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(0, 2));
+        co_await kota::sleep(500);
+
+        // Two documents pin worker 0: it is the owner but not expendable.
+        f.force_owner(7, 0);
+        f.force_owner(8, 0);
+
+        // An in-place suspect keeps owner routing — the AST lives there —
+        // instead of migrating to the free worker like an isolated probe,
+        // and its budget exemption unwinds once the reply lands.
+        auto result = co_await f.pool.send_stateful(7,
+                                                    worker::DocumentLinkParams{"/x.cpp"},
+                                                    {},
+                                                    Suspect::InPlace);
+        EXPECT_EQ(f.owner_of(7), 0u);
+        EXPECT_EQ(f.suspect_inflight(0, true), 0u);
 
         co_await f.stop();
         done = true;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -1457,10 +1457,12 @@ TEST_CASE(PreemptCancelsRequest) {
                 code = result.error().code;
         };
         group.spawn(sender());
-        // Long enough for the claim + request write, far shorter than the
-        // worker needs to compile the file.
-        co_await kota::sleep(10);
-
+        // Wait until the claim is visible, then preempt within the same
+        // loop turn: with no suspension in between, the worker's response
+        // cannot be processed first, so the preemption deterministically
+        // catches the request in flight.
+        while(f.low_busy() == 0)
+            co_await kota::sleep(1);
         f.preempt(1);
         co_await group.join();
         EXPECT_EQ(code, worker::dispatch_errc::cancelled);

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -440,6 +440,37 @@ TEST_CASE(SkipDeadWorkers) {
     EXPECT_EQ(f.pick_least_loaded(), 2u);
 }
 
+TEST_CASE(ProbeWorkerNotPicked) {
+    WorkerPoolFixture f;
+    f.add_stateful(true, 5);
+    f.add_stateful(true, 0);
+    f.set_suspect_inflight(1, true, 1);
+
+    // The idle worker hosts an in-flight quarantine probe — a known crash
+    // risk. A new document goes to the busier worker instead.
+    EXPECT_EQ(f.pick_least_loaded(), 0u);
+
+    // With no alternative, the probe worker still serves.
+    f.mark_dead(0, true);
+    EXPECT_EQ(f.pick_least_loaded(), 1u);
+}
+
+TEST_CASE(StaleEvictionIgnored) {
+    WorkerPoolFixture f;
+    f.add_stateful();
+    f.add_stateful();
+    auto idx = f.assign_worker(7);
+
+    // An eviction from a worker that lost ownership (probe reassignment
+    // left it a stale copy) must not unseat the current owner.
+    EXPECT_FALSE(f.pool.remove_owner_from(7, idx + 1));
+    EXPECT_TRUE(f.has_owner(7));
+
+    EXPECT_TRUE(f.pool.remove_owner_from(7, idx));
+    EXPECT_FALSE(f.has_owner(7));
+    EXPECT_EQ(f.stateful_owned(idx), 0u);
+}
+
 TEST_CASE(AllDeadNoAssignment) {
     WorkerPoolFixture f;
     f.add_stateful(false, 0);

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -111,6 +111,20 @@ struct WorkerPoolFixture {
         pool.stateless_workers[idx].retiring = true;
     }
 
+    void set_suspect_inflight(std::size_t idx, bool stateful, unsigned n) {
+        auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
+        workers[idx].suspect_inflight = n;
+    }
+
+    void set_revive_after(std::chrono::milliseconds cooldown) {
+        pool.options.revive_after = cooldown;
+    }
+
+    bool slot_dead(std::size_t idx, bool stateful = false) const {
+        auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
+        return workers[idx].state == WorkerPool::SlotState::Dead;
+    }
+
     /// Manually queue a waiter, as acquire_stateless_slot does when it
     /// cannot claim directly.
     auto enqueue_waiter(worker::Priority p) {
@@ -968,6 +982,21 @@ TEST_CASE(HealthyUptimeResetsStreak) {
     EXPECT_EQ(f.crash_streak(0), 1u);
 }
 
+TEST_CASE(SuspectCrashKeepsBudget) {
+    WorkerPoolFixture f;
+    f.add_stateful(true);
+    f.set_crash_streak(0, true, 2);
+    f.set_suspect_inflight(0, true, 1);
+
+    // A crash with a suspect request (a quarantined document's probe) in
+    // flight says something about the document, not the slot: the streak
+    // stays where it was and the slot respawns.
+    auto should_restart = f.simulate_crash(0, true);
+
+    EXPECT_TRUE(should_restart);
+    EXPECT_EQ(f.crash_streak(0, true), 2u);
+}
+
 TEST_CASE(BackoffDelaySchedule) {
     WorkerPoolFixture f;
     using ms = std::chrono::milliseconds;
@@ -1425,6 +1454,36 @@ TEST_CASE(CrashAndRestart) {
         }
         EXPECT_TRUE(f.worker_alive(0));
         EXPECT_NE(f.worker_pid(0), pid);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(DeadSlotRevives) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(1, 0));
+        f.set_revive_after(std::chrono::milliseconds(300));
+        f.set_max_crash_streak(0);
+        co_await kota::sleep(500);
+
+        // The very first crash exceeds the zero budget: the slot dies...
+        f.kill_worker(0);
+        for(int i = 0; i < 50 && !f.slot_dead(0); ++i) {
+            co_await kota::sleep(100);
+        }
+        EXPECT_TRUE(f.slot_dead(0));
+
+        // ...and is revived with a fresh budget after the cooldown: the
+        // pool never stays at zero workers forever.
+        for(int i = 0; i < 100 && !f.worker_alive(0); ++i) {
+            co_await kota::sleep(100);
+        }
+        EXPECT_TRUE(f.worker_alive(0));
+        EXPECT_EQ(f.crash_streak(0), 0u);
 
         co_await f.stop();
         done = true;

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -75,6 +75,10 @@ struct WorkerPoolFixture {
         return pool.assign_worker(path_id);
     }
 
+    std::size_t assign_expendable(std::uint32_t path_id) {
+        return pool.assign_expendable(path_id);
+    }
+
     void remove_owner(std::uint32_t path_id) {
         pool.remove_owner(path_id);
     }
@@ -980,6 +984,40 @@ TEST_CASE(HealthyUptimeResetsStreak) {
 
     EXPECT_TRUE(should_restart);
     EXPECT_EQ(f.crash_streak(0), 1u);
+}
+
+TEST_CASE(ExpendableSkipsHosts) {
+    WorkerPoolFixture f;
+    f.add_stateful(true);
+    f.add_stateful(true);
+
+    // A healthy document lives on worker 0 (least-loaded first pick)...
+    ASSERT_EQ(f.assign_worker(1), 0u);
+
+    // ...so a suspect compile may only sacrifice worker 1, and the
+    // document's ownership moves there.
+    ASSERT_EQ(f.assign_expendable(2), 1u);
+    ASSERT_EQ(f.owner_of(2), 1u);
+
+    // The current owner is kept while it hosts nothing else.
+    ASSERT_EQ(f.assign_expendable(2), 1u);
+
+    // With every live worker hosting someone else's document, there is
+    // nothing to sacrifice: the probe stays armed instead of running.
+    ASSERT_EQ(f.assign_worker(3), 0u);
+    ASSERT_EQ(f.assign_expendable(4), SIZE_MAX);
+}
+
+TEST_CASE(SingleWorkerProbes) {
+    WorkerPoolFixture f;
+    f.add_stateful(true);
+
+    // A single-worker pool has nothing to preserve by refusing the
+    // probe: it runs on the lone worker rather than quarantining the
+    // document until the session reopens.
+    ASSERT_EQ(f.assign_worker(1), 0u);
+    ASSERT_EQ(f.assign_expendable(2), 0u);
+    ASSERT_EQ(f.owner_of(2), 0u);
 }
 
 TEST_CASE(SuspectCrashKeepsBudget) {

--- a/tests/unit/server/worker_pool_tests.cpp
+++ b/tests/unit/server/worker_pool_tests.cpp
@@ -124,6 +124,10 @@ struct WorkerPoolFixture {
         pool.options.revive_after = cooldown;
     }
 
+    void set_max_stateless(std::size_t n) {
+        pool.options.max_stateless = n;
+    }
+
     bool slot_dead(std::size_t idx, bool stateful = false) const {
         auto& workers = stateful ? pool.stateful_workers : pool.stateless_workers;
         return workers[idx].state == WorkerPool::SlotState::Dead;
@@ -1530,6 +1534,26 @@ TEST_CASE(DeadSlotRevives) {
         }
         EXPECT_TRUE(f.worker_alive(0));
         EXPECT_EQ(f.crash_streak(0), 0u);
+
+        co_await f.stop();
+        done = true;
+    });
+    EXPECT_TRUE(done);
+}
+
+TEST_CASE(RetiringHoldsScaleUp) {
+    WorkerPoolFixture f;
+    bool done = false;
+    f.run([&]() -> kota::task<> {
+        CO_ASSERT_TRUE(f.start(2, 0));
+        f.set_max_stateless(2);
+        f.set_retiring(0);
+
+        // The retiring worker still holds its process until the monitor
+        // reaps it: a replacement now would run three processes against a
+        // ceiling of two, worsening the pressure that retired it.
+        EXPECT_FALSE(f.scale_up());
+        EXPECT_EQ(f.stateless_count(), 2u);
 
         co_await f.stop();
         done = true;


### PR DESCRIPTION
## Worker pool refactor

Replaces the worker pool's ad-hoc bookkeeping with an explicit design:

- **Slot state machine** (`Alive → Dying → Respawning`, terminal `Retired`/`Dead`) with a per-slot generation bumped on every death; all occupancy counts are derived from slot state instead of hand-maintained counters.
- **No in-pool request retry.** A transport failure marks the slot dead immediately (plus a safety SIGKILL) and surfaces the new `dispatch_errc::worker_crashed`; callers own the policy — the compiler resends idempotent builds once, the indexer requeues the file (bounded at 3 attempts, so a poison file cannot drain the pool's crash budget; `worker_unavailable` is never requeued to avoid a dead-pool spin).
- **Real memory preemption.** Under severe pressure the pool kills low-priority workers (immediately reclaiming their RSS), floors the low allowance, and respawns without crash accounting; the sender observes `cancelled`. Master-side accounting no longer diverges from worker reality.
- **Crash budget with recovery.** Consecutive crash streak, reset after 30s healthy uptime, exponential respawn backoff (immediate/500ms/1s/... capped); spawn failures count into the streak and retry. Replaces the lifetime `max_restarts=2` that permanently killed slots and could be burned in milliseconds.
- **Peer lifetime via `shared_ptr`** (senders hold their own reference), removing the unbounded `retired_peers` retention.
- **Controllers split** into `tick_memory(ratio)` / `tick_scaling(ratio)` (unit-testable with injected ratios); scale-up grows `low_limit` by exactly one instead of resetting pressure/backoff state.
- Stateful side: least-loaded assignment can no longer pin a document to a dead worker; crash-window sends fail fast with `worker_crashed`.

Fixes found during the investigation and covered by new tests: retry-after-failure could land on the same dead worker (the `exclude` parameter was never forwarded), cancelled index requests were silently dropped, `scale_up` wiped AIMD state, dispatch was not triggered when a death freed a busy claim.

## Staleness fix (pre-existing flake)

`test_staleness.py` flaked on main (2/4 local runs on RelWithDebInfo): `DepsSnapshot`'s fast path compared dep mtimes against a wall-clock `build_at`, so an edit made after the system clock stepped backwards (NTP sync, VM resume) got an "older" mtime and was silently skipped — stale ASTs/diagnostics until an unrelated invalidation. Now each dep records its nanosecond mtime at capture and is compared by equality, falling through to the content-hash check on any mismatch (the file tracker's existing scheme). Old `cache.json` files load unchanged and re-validate by hash once. 10 consecutive local runs of the suite pass.

Note: the index-side staleness gate (`merged_index.cpp`, `mtime <= build_at`) has the same wall-clock hazard; fixing it needs an index schema change and is left as a follow-up.

## Testing

- Unit: 884 pass (Debug + RelWithDebInfo); new coverage for backoff schedule, crash budget boundaries, healthy-uptime reset, preemption accounting, FIFO fairness, generation guards, transport-error classification, clock-rollback staleness.
- Integration: 263 pass on both configs, including new `test_crash_during_indexing` (SIGKILL a stateless worker mid-round, assert full index convergence).
- Smoke: 3/3 on both configs.


## Follow-up (2026-07-13)

- Rebased onto current main (#501 preamble index, #505 TUIndex fid fix, #506 embed deps). The one conflict (`workspace.cpp` cache load/save) resolved in favor of #501's `.pch.idx` fields plus this branch's per-dep mtime scheme; legacy `cache.json` compatibility re-verified against the JSON codec (unknown fields ignored, absent `mtime` re-validates by hash once).
- Addressed both review comments:
  - `preempt_low_priority` now cancels the preempt source **before** killing the worker. Investigation note: the old order was not an observable bug (kotatsu's `event.set()` only queues waiters and there is no suspension point between the calls), so this is a defensive ordering, documented as such.
  - The index requeue cap now counts only `worker_crashed`; a memory-pressure cancellation requeues without spending the poison-file budget. The policy moved into `Indexer::note_dispatch_failure` with a friend fixture and three new unit tests pinning it.
- Cleanup: refreshed comments that still described the removed `DepsSnapshot::build_at`, and the pool class doc's off-by-one crash-budget wording.
- Updated totals: unit 927 (Debug + RelWithDebInfo), integration 271, smoke 3/3 — all green locally.


## Document quarantine (F19) — 2026-07-14/15

The pool's per-slot crash budget cannot contain a poison *document*: the budget lives on slots, the poison lives in content, and one file could burn slot after slot until the whole pool was dead (bughunt F19). This branch adds content-side crash containment, hardened over ten codex review rounds (24 findings — 23 fixed, 1 documented acceptance) and consolidated into a single-writer architecture whose invariants are stated in `state/quarantine.h`:

- **`Quarantine`**: per-document state machine with private fields — every transition is a method. Two ledger families with distinct disproof rules: the **compile streak** (cleared only by a successful compile of the same content, via a `Flight` token that pins "a landing clears exactly the evidence it inherited at takeoff") and **per-kind ledgers** (queries by `QueryKind`, stateless builds by `BuildKind`, document links) cleared only when *that kind* answers — a hover cannot launder semantic-tokens evidence, a compile cannot launder format strikes. Evidence is counted **per worker killed** (the retry's death is a second strike) and deduplicated by the dead incarnation's identity carried in `Error::data`, so one process death failing several in-flight requests is blamed at most once per document.
- **Recovery licensing**: a real content change arms one probe; only the dispatch that can disprove the evidence (`recovery_compile` / `recovery_kind`) may spend it, concurrent racers see the kind as plainly blocked, and `ProbeGuard` hands the license back if the attempt provably never dispatched (cancellation unwind, capacity window) while a recorded strike keeps it spent. While quarantined, everything except the recovery dispatch is refused.
- **Visibility**: `publish_quarantined` is the single materialization point for the quarantine diagnostic (announce-once per spell, including quarantines reached via completion/PCH paths that never run a compile); `publish_recovered` clears it when a stateless/query recovery lifts the quarantine without a compile.
- **`CrashBudget`**: content-keyed budget for shared artifacts (PCH/PCM) that document quarantine cannot reach — every dependent stops re-triggering a build that keeps killing workers. Full lifecycle: blocks are five-minute cooldowns rather than verdicts (the poison may live in a header the key cannot see), a successful build clears the key's strikes, and the PCM budget key embeds the module's content hash so fixing the module unlocks immediately.
- **Pool-side isolation** (`Suspect`): probes run `Isolated` on document-free workers (single-worker pools excepted) and never spend slot budget; recovery queries run `InPlace` — owner routing, budget-exempt, avoided by new-document assignment while in flight, with the counter unwound by RAII across cancellations. Dead slots revive after a cooldown and are preferred by scale-up; the scale-up ceiling counts every live process including retiring ones; the configured `min_stateless` floor survives above the startup count. The pool's responsibility contract (mechanism vs. policy, the `dispatch_errc` taxonomy, `worker_restarting` for blameless restart windows) is documented on the class.
- Indexer debt hardening: failures attribute by launch ticket (stale crashes never spend fresh content's budget), giving up clears the pending slot even past a mid-flight deps-only downgrade, `worker_unavailable` requeues while slot revival is pending, and a failed content pass keeps its `ContentChanged` debt.
- One documented acceptance: the same-generation eviction ABA (a live worker's stale-copy eviction draining after the path was assigned back to it) costs one spurious recompile in a one-notification-drain window; fixing it needs an ownership epoch in the worker protocol.

Verified end to end by the F19 stress scenario (healthy files answer throughout, quarantined streak freezes, fixed file recovers via probe within ms, worker count never reaches zero), poison / poison-preamble integration tests, and 30+ type-level state-machine unit tests (several validated by reverting the fix and watching them fail).

- Final totals: unit 976 (Debug + RelWithDebInfo), integration 279 (both configs), smoke 3/3 — all green locally and on CI (17 checks).
