### PR TITLE
fix(index): prevent untracked module FileIDs from crashing TU indexing

### DIFF
--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -32,6 +32,14 @@ public:
         result.graph = IncludeGraph::from(unit);
     }
 
+    FileIndex* file_index(clang::FileID fid) {
+        // Imported PCM sources are AST-visible but are not owned by this TU's include graph.
+        if(!result.graph.file_table.contains(fid)) {
+            return nullptr;
+        }
+        return &result.file_indices[fid];
+    }
+
     void handleDeclOccurrence(const clang::NamedDecl* decl,
                               RelationKind kind,
                               clang::SourceLocation location) {
@@ -52,7 +60,10 @@ public:
         }
 
         auto [fid, range] = unit.decompose_range(location);
-        auto& index = result.file_indices[fid];
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         auto symbol_id = unit.getSymbolID(decl);
         auto [it, success] = result.symbols.try_emplace(symbol_id.hash);
@@ -62,7 +73,7 @@ public:
             symbol.kind = SymbolKind::from(decl);
             symbol.scope = classify_scope(decl);
         }
-        index.occurrences.emplace_back(range, symbol_id.hash);
+        index->occurrences.emplace_back(range, symbol_id.hash);
     }
 
     void handleMacroOccurrence(const clang::MacroInfo* def,
@@ -74,10 +85,13 @@ public:
         }
 
         auto [fid, range] = unit.decompose_range(location);
-        auto& index = result.file_indices[fid];
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         auto symbol_id = unit.getSymbolID(def);
-        index.occurrences.emplace_back(range, symbol_id.hash);
+        index->occurrences.emplace_back(range, symbol_id.hash);
 
         Relation relation{
             .kind = kind,
@@ -85,7 +99,7 @@ public:
             .target_symbol = 0,
         };
 
-        index.relations[symbol_id.hash].emplace_back(relation);
+        index->relations[symbol_id.hash].emplace_back(relation);
     }
 
     void handleRelation(const clang::NamedDecl* decl,
@@ -93,6 +107,10 @@ public:
                         const clang::NamedDecl* target,
                         clang::SourceRange range) {
         auto [fid, relation_range] = unit.decompose_expansion_range(range);
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         Relation relation{.kind = kind};
 
@@ -120,9 +138,8 @@ public:
             std::unreachable();
         }
 
-        auto& index = result.file_indices[fid];
         auto symbol_id = unit.getSymbolID(ast::normalize(decl));
-        index.relations[symbol_id.hash].emplace_back(relation);
+        index->relations[symbol_id.hash].emplace_back(relation);
     }
 
     /// Module names are indexed like macro names: an occurrence plus a
@@ -137,12 +154,14 @@ public:
                 return;
             if(interested_only && fid != unit.interested_file())
                 return;
+            auto* index = file_index(fid);
+            if(!index)
+                return;
             llvm::SmallString<64> usr("@module@");
             usr += name;
             auto hash = llvm::xxh3_64bits(usr);
 
-            auto& index = result.file_indices[fid];
-            index.occurrences.emplace_back(range, hash);
+            index->occurrences.emplace_back(range, hash);
             Relation relation{
                 .kind = kind,
                 .range = range,
@@ -154,7 +173,7 @@ public:
             if(kind.isDeclOrDef()) {
                 relation.set_definition_range(range);
             }
-            index.relations[hash].emplace_back(relation);
+            index->relations[hash].emplace_back(relation);
 
             auto& symbol = result.symbols[hash];
             if(symbol.name.empty()) {
@@ -259,6 +278,17 @@ public:
         run();
 
         index_modules();
+
+        std::vector<clang::FileID> untracked_files;
+        for(auto& entry: result.file_indices) {
+            auto fid = entry.first;
+            if(!result.graph.file_table.contains(fid)) {
+                untracked_files.push_back(fid);
+            }
+        }
+        for(auto fid: untracked_files) {
+            result.file_indices.erase(fid);
+        }
 
         for(auto& [fid, index]: result.file_indices) {
             for(auto& [symbol_id, relations]: index.relations) {
@@ -408,6 +438,9 @@ void TUIndex::serialize(llvm::raw_ostream& os) const {
     /// Convert FileID-keyed file_indices to path_id-keyed entries.
     llvm::SmallVector<fbs::Offset<binary::TUFileIndexEntry>> file_idx_vec;
     for(auto& [fid, index]: file_indices) {
+        if(!graph.file_table.contains(fid)) {
+            continue;
+        }
         auto pid = graph.path_id(fid);
         file_idx_vec.push_back(serialize_file_index(pid, index));
     }

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -484,6 +484,22 @@ TEST_CASE(CrossFileHeaderIndex) {
     ASSERT_TRUE(found_in_header);
 }
 
+TEST_CASE(SerializeUntrackedFile) {
+    build_index("int value = 42;");
+
+    auto fid = unit->interested_file();
+    tu_index.file_indices[fid] = tu_index.main_file_index;
+    tu_index.graph.file_table.erase(fid);
+
+    std::string serialized;
+    llvm::raw_string_ostream os(serialized);
+    tu_index.serialize(os);
+    ASSERT_FALSE(serialized.empty());
+
+    auto restored = index::TUIndex::from(serialized.data());
+    ASSERT_TRUE(restored.path_file_indices.empty());
+}
+
 TEST_CASE(SymbolKinds) {
     build_index(R"(
             struct $(cls)MyClass {};


### PR DESCRIPTION
### What was broken

Clice assumed that every `clang::FileID` encountered during semantic AST traversal belonged to the current translation unit's `IncludeGraph`

That's not the case for C++ modules, declarations loaded from imported PCMs can be visible in Clang's AST even though their source files are not represented in the importing TU's `graph.file_table`

The indexer previously inserted file IDs unconditionally:

```cpp
auto [fid, range] = unit.decompose_range(location);
auto& index = result.file_indices[fid];
```

This occurred while indexing declarations, macros, relations, and module names.

Later, `Builder::build()` converted every collected file ID into a graph path:

```cpp
result.graph.path_id(fid)
```

When an imported PCM contributed a `FileID` is not it `graph.file_table`, `path_id()` attempted to use the failed lookup. In release builds this resulted in undefined behavior and could terminate the indexing worker with:

```text
0xC0000005
IncludeGraph::path_id
Builder::build
TUIndex::build
```

`TUIndex::serialize()` made the same unchecked assumption, making a second crash path for inconsistent indexes.

### Changes

A central `file_index()` helper now verifies that a file is owned by the current TU's include graph:

```cpp
FileIndex* file_index(clang::FileID fid) {
    if(!result.graph.file_table.contains(fid)) {
        return nullptr;
    }

    return &result.file_indices[fid];
}
```

All semantic insertion paths use this helper:

```cpp
auto* index = file_index(fid);
if(!index) {
    return;
}
```

This prevents AST-visible sources owned by imported PCMs from entering the importing TU's `file_indices`. `Builder::build()` also removes any remaining untracked entries before calling `path_id()`, helps against future insertion paths that might bypass the helper.

Serialization now independently checks graph membership:

```cpp
for(auto& [fid, index]: file_indices) {
    if(!graph.file_table.contains(fid)) {
        continue;
    }

    auto pid = graph.path_id(fid);
    file_idx_vec.push_back(serialize_file_index(pid, index));
}
```

`TUIndex` now cannot turn an invalid file mapping into an access violation. Valid file indexes are unchanged, unrepresentable entries are discarded rather than incorrectly attributed to the importing translation unit.

### Tests

Added `SerializeUntrackedFile`

Before:

```text
SerializeUntrackedFile
- TUIndex::serialize()
- graph.path_id(fid)
- invalid graph lookup
- test runner terminates
```

After:

```text
SerializeUntrackedFile
- untracked entry skipped
- serialization completes
- deserialized index contains no invalid file entry
```

The test is fail-before/pass-after, removing the guard caused the test runner to terminate.

### Test results

```text
853 tests passed
17 tests skipped
0 tests failed
```

Commands run:

```powershell
pixi run build RelWithDebInfo
pixi run unit-test RelWithDebInfo -- --test-filter=tu_index.SerializeUntrackedFile
pixi run unit-test RelWithDebInfo -- --test-filter=tu_index.*
pixi run unit-test RelWithDebInfo
```

`partition_with_external_import` also passed:

```text
1 passed, 30 deselected
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of files missing from a translation unit’s include graph.
  * Prevented invalid file entries from being included during indexing and serialization.
  * Ensured module and file relationships are skipped safely when file metadata is unavailable.
  * Added coverage verifying serialization and deserialization remain valid for untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->