### PR TITLE
fix(index): resolve preamble PCH fids in TUIndex build

### DIFF
--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -124,6 +124,16 @@ object_ptr<CompilationInfo>
 
         /// Handle CMake's Xclang PCH workaround:
         /// -Xclang -include-pch -Xclang <pchfile> → discard both pairs.
+        ///
+        /// TODO: Dropping the project's own PCH here (and OPT_include_pch in
+        /// the parser table) is required for correctness: it may be produced
+        /// by GCC or a different clang version we cannot load. Open sessions
+        /// lose nothing — the plain -include survives and our own preamble
+        /// PCH covers it. Background indexing however compiles without any
+        /// PCH at all, so projects that use one to speed up their build
+        /// (e.g. LLVM's cmake_pch) index noticeably slower than they
+        /// compile. Index results are unaffected; consider building a
+        /// clice-owned PCH for indexing to win that speed back.
         if(is_xclang_option(id) && arg.values.size() == 1) {
             if(remove_pch) {
                 remove_pch = false;

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -315,21 +315,6 @@ index::SymbolID CompilationUnitRef::getSymbolID(const clang::MacroInfo* macro) {
     return index::SymbolID{hash, name.str()};
 }
 
-const llvm::DenseSet<clang::FileID>& CompilationUnitRef::files() {
-    if(self->all_files.empty()) {
-        /// FIXME: handle preamble and embed file id.
-        for(auto& [fid, directive]: directives()) {
-            for(auto& include: directive.includes) {
-                if(!include.skipped && include.fid.isValid()) {
-                    self->all_files.insert(include.fid);
-                }
-            }
-        }
-        self->all_files.insert(self->SM().getMainFileID());
-    }
-    return self->all_files;
-}
-
 clang::TranslationUnitDecl* CompilationUnitRef::tu() {
     return self->instance->getASTContext().getTranslationUnitDecl();
 }

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -255,21 +255,7 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
 std::vector<std::string> CompilationUnitRef::deps() {
     llvm::StringSet<> deps;
 
-    /// Embedded files have no FileID (clang delivers their contents as a
-    /// single annotation token), so they are resolved through their file
-    /// entry rather than `file_path`.
-    auto add_file = [&](clang::OptionalFileEntryRef file) {
-        if(!file) {
-            return;
-        }
-        llvm::SmallString<128> path;
-        if(auto error = llvm::sys::fs::real_path(file->getName(), path)) {
-            path = file->getName();
-        }
-        if(!path.empty()) {
-            deps.try_emplace(path);
-        }
-    };
+    /// FIXME: consider `#embed` and `__has_embed`.
 
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
@@ -288,14 +274,6 @@ std::vector<std::string> CompilationUnitRef::deps() {
                     deps.try_emplace(path);
                 }
             }
-        }
-
-        for(auto& embed: directive.embeds) {
-            add_file(embed.file);
-        }
-
-        for(auto& has_embed: directive.has_embeds) {
-            add_file(has_embed.file);
         }
     }
 

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -255,7 +255,21 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
 std::vector<std::string> CompilationUnitRef::deps() {
     llvm::StringSet<> deps;
 
-    /// FIXME: consider `#embed` and `__has_embed`.
+    /// Embedded files have no FileID (clang delivers their contents as a
+    /// single annotation token), so they are resolved through their file
+    /// entry rather than `file_path`.
+    auto add_file = [&](clang::OptionalFileEntryRef file) {
+        if(!file) {
+            return;
+        }
+        llvm::SmallString<128> path;
+        if(auto error = llvm::sys::fs::real_path(file->getName(), path)) {
+            path = file->getName();
+        }
+        if(!path.empty()) {
+            deps.try_emplace(path);
+        }
+    };
 
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
@@ -274,6 +288,14 @@ std::vector<std::string> CompilationUnitRef::deps() {
                     deps.try_emplace(path);
                 }
             }
+        }
+
+        for(auto& embed: directive.embeds) {
+            add_file(embed.file);
+        }
+
+        for(auto& has_embed: directive.has_embeds) {
+            add_file(has_embed.file);
         }
     }
 

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -14,7 +14,6 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "clang/Tooling/Syntax/Tokens.h"
 
 namespace clice {
@@ -238,9 +237,6 @@ public:
     llvm::DenseMap<clang::FileID, Directive>& directives();
 
     clang::TranslationUnitDecl* tu();
-
-    /// All files involved in building the unit.
-    const llvm::DenseSet<clang::FileID>& files();
 
     std::vector<std::string> deps();
 

--- a/src/compile/directive.cpp
+++ b/src/compile/directive.cpp
@@ -57,6 +57,13 @@ private:
             return;
         }
 
+        /// FIXME: This drops macros living in synthetic buffers (<built-in>,
+        /// <command line>), so a `-D` macro has no definition anywhere in the
+        /// index and go-to-definition on it fails with no feedback. These
+        /// buffers have real content in the SourceManager (`#define FOO 1`
+        /// lines); keep such definitions and serve them through a generated
+        /// preview document (a temp file on disk, or LSP 3.18
+        /// `workspace/textDocumentContent`) instead of dropping them.
         if(unit.is_builtin_file(unit.file_id(loc))) {
             return;
         }

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -77,8 +77,6 @@ struct CompilationUnitRef::Self {
     /// All directive information collected during the preprocessing.
     llvm::DenseMap<clang::FileID, Directive> directives;
 
-    llvm::DenseSet<clang::FileID> all_files;
-
     /// Cache for file path. It is used to avoid multiple file path lookup.
     llvm::DenseMap<clang::FileID, llvm::StringRef> path_cache;
 

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -1,6 +1,7 @@
 #include "index/include_graph.h"
 
 #include "compile/compilation_unit.h"
+#include "support/logging.h"
 
 namespace clice::index {
 
@@ -45,14 +46,39 @@ static std::uint32_t addIncludeChain(CompilationUnitRef unit,
     return index;
 }
 
-IncludeGraph IncludeGraph::from(CompilationUnitRef unit) {
+IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
+                                llvm::ArrayRef<clang::FileID> indexed_fids) {
     llvm::StringMap<std::uint32_t> path_table;
     IncludeGraph graph;
-    for(auto fid: unit.files()) {
+
+    /// FIXME: consider `#embed` file ids.
+    for(auto& [fid, directive]: unit.directives()) {
+        for(auto& include: directive.includes) {
+            if(!include.skipped && include.fid.isValid()) {
+                graph.file_table[include.fid] =
+                    addIncludeChain(unit, include.fid, graph, path_table);
+            }
+        }
+    }
+
+    for(auto fid: indexed_fids) {
         graph.file_table[fid] = addIncludeChain(unit, fid, graph, path_table);
     }
-    graph.paths.emplace_back(unit.file_path(unit.interested_file()));
+
+    auto interested = unit.interested_file();
+    graph.file_table[interested] = addIncludeChain(unit, interested, graph, path_table);
+    graph.paths.emplace_back(unit.file_path(interested));
     return graph;
+}
+
+std::uint32_t IncludeGraph::include_location_id(clang::FileID fid) const {
+    auto it = file_table.find(fid);
+    if(it == file_table.end()) [[unlikely]] {
+        LOG_WARN("IncludeGraph: fid {} missing from file table, attributing to interested file",
+                 fid.getHashValue());
+        return -1;
+    }
+    return it->second;
 }
 
 }  // namespace clice::index

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -51,7 +51,9 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
     llvm::StringMap<std::uint32_t> path_table;
     IncludeGraph graph;
 
-    /// FIXME: consider `#embed` file ids.
+    /// Note that `#embed`ed files never get a FileID — clang delivers
+    /// their contents as a single annotation token — so include
+    /// directives are the only directive kind that introduces fids here.
     for(auto& [fid, directive]: unit.directives()) {
         for(auto& include: directive.includes) {
             if(!include.skipped && include.fid.isValid()) {

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -51,9 +51,6 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
     llvm::StringMap<std::uint32_t> path_table;
     IncludeGraph graph;
 
-    /// Note that `#embed`ed files never get a FileID — clang delivers
-    /// their contents as a single annotation token — so include
-    /// directives are the only directive kind that introduces fids here.
     for(auto& [fid, directive]: unit.directives()) {
         for(auto& include: directive.includes) {
             if(!include.skipped && include.fid.isValid()) {

--- a/src/index/include_graph.h
+++ b/src/index/include_graph.h
@@ -7,6 +7,7 @@
 
 #include "syntax/token.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace clice {
@@ -36,7 +37,10 @@ struct IncludeGraph {
     /// don't want to save its path repeatedly, so cache it here.
     std::vector<std::string> paths;
 
-    /// All include locations in this tu.
+    /// All include locations in this tu. Besides backing `path_id`
+    /// lookups, this doubles as the TU's dependency set for shard
+    /// freshness checks, so it must keep every include edge of the
+    /// parse even when no index row lands in the included file.
     std::vector<IncludeLocation> locations;
 
     /// Each `FileID` represents a new header context and is introduced
@@ -44,19 +48,39 @@ struct IncludeGraph {
     /// context. A map between FileID and its include location.
     llvm::DenseMap<clang::FileID, std::uint32_t> file_table;
 
-    static IncludeGraph from(CompilationUnitRef unit);
+    /// Build the graph for `unit`. The file table covers the union of
+    /// every file included in this parse (from the replayed directives)
+    /// and `indexed_fids` — the files the index actually recorded rows
+    /// for. The latter can lie outside the directives universe: with a
+    /// preamble PCH the preamble headers' FileIDs are loaded from the
+    /// AST file and this parse's preprocessor callbacks never see them.
+    /// Their include chains are recovered through the SourceManager,
+    /// which preserves include locations across PCH boundaries.
+    ///
+    /// The interested file's path is always the last entry of `paths`;
+    /// serialization and the indexer rely on this convention.
+    static IncludeGraph from(CompilationUnitRef unit,
+                             llvm::ArrayRef<clang::FileID> indexed_fids = {});
 
     llvm::StringRef path(std::uint32_t path_ref) const {
         assert(path_ref < paths.size());
         return paths[path_ref];
     }
 
-    std::uint32_t include_location_id(clang::FileID fid) const {
-        auto it = file_table.find(fid);
-        assert(it != file_table.end());
-        return it->second;
-    }
+    /// The include location introducing `fid`, or -1 for a file entered
+    /// without an include directive (the interested file, synthetic
+    /// buffers) — and, defensively, for a fid missing from the table:
+    /// the indexer must never crash on unexpected input.
+    std::uint32_t include_location_id(clang::FileID fid) const;
 
+    /// The path of the file `fid` refers to. An fid without an include
+    /// location resolves to the interested file's path.
+    ///
+    /// FIXME: Synthetic buffers (<built-in>, <command line>) also resolve
+    /// to the interested file here. Once macro definitions from those
+    /// buffers are indexed (see add_macro in directive.cpp), give them
+    /// named path entries so consumers can route them to a preview
+    /// document instead of misattributing them.
     std::uint32_t path_id(clang::FileID fid) const {
         auto include = include_location_id(fid);
         if(include != -1) {

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -28,8 +28,19 @@ SymbolScope classify_scope(const clang::NamedDecl* decl) {
 class Builder : public SemanticVisitor<Builder> {
 public:
     Builder(TUIndex& result, CompilationUnitRef unit, bool interested_only) :
-        SemanticVisitor<Builder>(unit, interested_only), result(result) {
-        result.graph = IncludeGraph::from(unit);
+        SemanticVisitor<Builder>(unit, interested_only), result(result) {}
+
+    /// The only gate through which rows enter `file_indices`. With
+    /// interested_only, the index covers just the interested file — yet
+    /// AST nodes reachable from its top-level decls can carry locations
+    /// in other files: inherited default arguments and base specifiers
+    /// of classes defined in a preamble header land there. Such rows
+    /// belong to the preamble's own index, so they are dropped here.
+    FileIndex* file_index(clang::FileID fid) {
+        if(interested_only && fid != unit.interested_file()) {
+            return nullptr;
+        }
+        return &result.file_indices[fid];
     }
 
     void handleDeclOccurrence(const clang::NamedDecl* decl,
@@ -52,7 +63,10 @@ public:
         }
 
         auto [fid, range] = unit.decompose_range(location);
-        auto& index = result.file_indices[fid];
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         auto symbol_id = unit.getSymbolID(decl);
         auto [it, success] = result.symbols.try_emplace(symbol_id.hash);
@@ -62,7 +76,7 @@ public:
             symbol.kind = SymbolKind::from(decl);
             symbol.scope = classify_scope(decl);
         }
-        index.occurrences.emplace_back(range, symbol_id.hash);
+        index->occurrences.emplace_back(range, symbol_id.hash);
     }
 
     void handleMacroOccurrence(const clang::MacroInfo* def,
@@ -74,7 +88,10 @@ public:
         }
 
         auto [fid, range] = unit.decompose_range(location);
-        auto& index = result.file_indices[fid];
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         auto symbol_id = unit.getSymbolID(def);
         // Macros get a symbol-table entry like declarations do; without it
@@ -88,7 +105,7 @@ public:
             symbol.kind = SymbolKind::Macro;
             symbol.scope = SymbolScope::External;
         }
-        index.occurrences.emplace_back(range, symbol_id.hash);
+        index->occurrences.emplace_back(range, symbol_id.hash);
 
         Relation relation{
             .kind = kind,
@@ -107,7 +124,7 @@ public:
             }
         }
 
-        index.relations[symbol_id.hash].emplace_back(relation);
+        index->relations[symbol_id.hash].emplace_back(relation);
     }
 
     void handleRelation(const clang::NamedDecl* decl,
@@ -115,6 +132,10 @@ public:
                         const clang::NamedDecl* target,
                         clang::SourceRange range) {
         auto [fid, relation_range] = unit.decompose_expansion_range(range);
+        auto* index = file_index(fid);
+        if(!index) {
+            return;
+        }
 
         Relation relation{.kind = kind};
 
@@ -142,9 +163,8 @@ public:
             std::unreachable();
         }
 
-        auto& index = result.file_indices[fid];
         auto symbol_id = unit.getSymbolID(ast::normalize(decl));
-        index.relations[symbol_id.hash].emplace_back(relation);
+        index->relations[symbol_id.hash].emplace_back(relation);
     }
 
     /// Module names are indexed like macro names: an occurrence plus a
@@ -157,14 +177,14 @@ public:
                         RelationKind kind) {
             if(name.empty())
                 return;
-            if(interested_only && fid != unit.interested_file())
+            auto* index = file_index(fid);
+            if(!index)
                 return;
             llvm::SmallString<64> usr("@module@");
             usr += name;
             auto hash = llvm::xxh3_64bits(usr);
 
-            auto& index = result.file_indices[fid];
-            index.occurrences.emplace_back(range, hash);
+            index->occurrences.emplace_back(range, hash);
             Relation relation{
                 .kind = kind,
                 .range = range,
@@ -176,7 +196,7 @@ public:
             if(kind.isDeclOrDef()) {
                 relation.set_definition_range(range);
             }
-            index.relations[hash].emplace_back(relation);
+            index->relations[hash].emplace_back(relation);
 
             auto& symbol = result.symbols[hash];
             if(symbol.name.empty()) {
@@ -281,6 +301,16 @@ public:
         run();
 
         index_modules();
+
+        // Build the include graph from what the index actually recorded:
+        // every fid keying `file_indices` gets its include chain resolved
+        // through the SourceManager, so the lookups below cannot miss.
+        llvm::SmallVector<clang::FileID, 16> indexed_fids;
+        indexed_fids.reserve(result.file_indices.size());
+        for(auto& [fid, index]: result.file_indices) {
+            indexed_fids.push_back(fid);
+        }
+        result.graph = IncludeGraph::from(unit, indexed_fids);
 
         for(auto& [fid, index]: result.file_indices) {
             for(auto& [symbol_id, relations]: index.relations) {

--- a/src/index/tu_index.h
+++ b/src/index/tu_index.h
@@ -108,6 +108,12 @@ struct TUIndex {
 
     FileIndex main_file_index;
 
+    /// Build the index for `unit`. With interested_only, only rows in
+    /// the interested file are kept. Note that a full build over a unit
+    /// compiled with a preamble PCH is not a production combination
+    /// (background indexing compiles without PCH): rows landing in the
+    /// PCH's loaded copy of the main file would serialize a second entry
+    /// under the main path id.
     static TUIndex build(CompilationUnitRef unit, bool interested_only = false);
 
     void serialize(llvm::raw_ostream& os) const;

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -278,6 +278,34 @@ TEST_CASE(HasEmbed) {
     EXPECT_HAS_EMBED(1, "1", "non-existed.bin", /*exists=*/false);
 };
 
+TEST_CASE(EmbedInDeps) {
+    run(R"cpp(
+#[data.bin]
+0123456789
+
+#[probe.bin]
+AB
+
+#[main.cpp]
+const char e[] = {
+#embed "data.bin"
+};
+
+#if __has_embed("probe.bin")
+#endif
+)cpp");
+
+    auto deps = unit->deps();
+    bool data_found = false;
+    bool probe_found = false;
+    for(auto& dep: deps) {
+        data_found |= llvm::StringRef(dep).ends_with("data.bin");
+        probe_found |= llvm::StringRef(dep).ends_with("probe.bin");
+    }
+    ASSERT_TRUE(data_found);
+    ASSERT_TRUE(probe_found);
+};
+
 };  // TEST_SUITE(Directive)
 
 }  // namespace

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -278,34 +278,6 @@ TEST_CASE(HasEmbed) {
     EXPECT_HAS_EMBED(1, "1", "non-existed.bin", /*exists=*/false);
 };
 
-TEST_CASE(EmbedInDeps) {
-    run(R"cpp(
-#[data.bin]
-0123456789
-
-#[probe.bin]
-AB
-
-#[main.cpp]
-const char e[] = {
-#embed "data.bin"
-};
-
-#if __has_embed("probe.bin")
-#endif
-)cpp");
-
-    auto deps = unit->deps();
-    bool data_found = false;
-    bool probe_found = false;
-    for(auto& dep: deps) {
-        data_found |= llvm::StringRef(dep).ends_with("data.bin");
-        probe_found |= llvm::StringRef(dep).ends_with("probe.bin");
-    }
-    ASSERT_TRUE(data_found);
-    ASSERT_TRUE(probe_found);
-};
-
 };  // TEST_SUITE(Directive)
 
 }  // namespace

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -698,6 +698,130 @@ TEST_CASE(ScopeTULocal) {
     ASSERT_EQ(found, expected);
 }
 
+TEST_CASE(PreambleDefaultArgument) {
+    // An out-of-line definition inherits the default argument expression
+    // from the in-class declaration; its DeclRefExpr is located in the
+    // preamble header, whose FileID is loaded from the PCH.
+    add_file("foo.h", R"(
+struct Foo {
+    static constexpr int npos = -1;
+    int find(int x = npos) const;
+};
+)");
+    add_main("main.cpp", R"(
+#include "foo.h"
+int Foo::@def[$(1)find](int x) const { return 0; }
+)");
+    ASSERT_TRUE(compile_with_pch());
+
+    // A full build keeps the preamble rows: this proves the row exists
+    // (so the gate test below cannot pass vacuously) and that the loaded
+    // fid resolves through the graph to the header's path.
+    tu_index = index::TUIndex::build(*unit);
+    bool found = false;
+    for(auto& [fid, index]: tu_index.file_indices) {
+        found |= tu_index.graph.path(tu_index.graph.path_id(fid)).ends_with("foo.h");
+    }
+    ASSERT_TRUE(found);
+
+    tu_index = index::TUIndex::build(*unit, true);
+
+    // Rows resolving into the preamble are dropped: the preamble's own
+    // index covers them. Only the main file's rows remain.
+    ASSERT_TRUE(tu_index.file_indices.empty());
+    EXPECT_SELECT("1", "def");
+}
+
+TEST_CASE(PreambleBaseSpecifier) {
+    // A forward declaration reaches the definition's base specifiers via
+    // the shared DefinitionData; their source ranges are in the preamble
+    // header, whose FileID is loaded from the PCH.
+    add_file("bar.h", R"(
+struct Base {};
+struct Derived : Base {};
+)");
+    add_main("main.cpp", R"(
+#include "bar.h"
+struct Derived;
+Derived* use();
+)");
+    ASSERT_TRUE(compile_with_pch());
+
+    // Full build: the base-specifier rows land in the preamble header
+    // and its loaded fid resolves to the header's path.
+    tu_index = index::TUIndex::build(*unit);
+    bool found = false;
+    for(auto& [fid, index]: tu_index.file_indices) {
+        found |= tu_index.graph.path(tu_index.graph.path_id(fid)).ends_with("bar.h");
+    }
+    ASSERT_TRUE(found);
+
+    tu_index = index::TUIndex::build(*unit, true);
+
+    ASSERT_TRUE(tu_index.file_indices.empty());
+    ASSERT_FALSE(tu_index.main_file_index.occurrences.empty());
+}
+
+TEST_CASE(HeaderMacroDropped) {
+    // Macro occurrences flow through the same gate: a definition in an
+    // included header is dropped from an interested-only build, while
+    // the reference in the main file is kept.
+    add_file("baz.h", R"(
+#define BAZ 1
+)");
+    add_main("main.cpp", R"(
+#include "baz.h"
+int x = $(1)BAZ;
+)");
+    ASSERT_TRUE(compile());
+
+    tu_index = index::TUIndex::build(*unit, true);
+    ASSERT_TRUE(tu_index.file_indices.empty());
+    ASSERT_FALSE(tu_index.main_file_index.occurrences.empty());
+}
+
+TEST_CASE(UnknownFidFallback) {
+    // A preamble header's loaded FileID is unknown to a graph built
+    // without indexed fids; lookups must degrade to the interested
+    // file instead of crashing.
+    add_file("foo.h", R"(
+struct Foo {};
+)");
+    add_main("main.cpp", R"(
+#include "foo.h"
+int x = 1;
+)");
+    ASSERT_TRUE(compile_with_pch());
+
+    auto graph = index::IncludeGraph::from(*unit);
+    auto fid = unit->file_id(TestVFS::path("foo.h"));
+    ASSERT_TRUE(fid.isValid());
+    ASSERT_EQ(graph.include_location_id(fid), static_cast<std::uint32_t>(-1));
+    ASSERT_EQ(graph.path_id(fid), static_cast<std::uint32_t>(graph.paths.size() - 1));
+}
+
+TEST_CASE(PreambleFidResolved) {
+    // When a preamble header's fid is passed as an indexed fid, its
+    // include chain is recovered through the SourceManager even though
+    // this parse's preprocessor callbacks never saw the include.
+    add_file("foo.h", R"(
+struct Foo {};
+)");
+    add_main("main.cpp", R"(
+#include "foo.h"
+int x = 1;
+)");
+    ASSERT_TRUE(compile_with_pch());
+
+    auto fid = unit->file_id(TestVFS::path("foo.h"));
+    ASSERT_TRUE(fid.isValid());
+
+    auto graph = index::IncludeGraph::from(*unit, {fid});
+    auto include = graph.include_location_id(fid);
+    ASSERT_TRUE(include != static_cast<std::uint32_t>(-1));
+    ASSERT_TRUE(graph.path(graph.path_id(fid)).ends_with("foo.h"));
+}
+
 };  // TEST_SUITE(tu_index)
 
 }  // namespace


### PR DESCRIPTION
## Problem

With a preamble PCH attached, `TUIndex::build` crashed the stateful worker (SIGSEGV in RelWithDebInfo, assert in Debug) on `didOpen` of many real-world files — 100% reproducible on e.g. `llvm/ADT/StringRef.cpp` and `BasicBlockUtils.h` (bughunt F18, Critical).

Root cause: FileIDs loaded from the PCH (negative internal IDs) entered `file_indices` through two AST paths reachable from main-file top-level decls —

1. **Inherited function default arguments**: an out-of-line method definition inherits the default argument expression from the in-class declaration in a preamble header (`int find(int x = npos)` pattern). RecursiveASTVisitor traverses these without an inherited-guard (unlike default *template* arguments).
2. **Forward declarations + shared DefinitionData**: `class X;` in the main file reaches the definition's base specifiers, whose source ranges live in the preamble header.

Meanwhile `IncludeGraph::file_table` derived its fid universe from replayed preprocessor directives — which never fire for preamble includes when a PCH is attached. `include_location_id` then dereferenced `end()`. Combined with the worker restart budget this killed all semantic features for the session (F19).

## Fix (three layers)

- **Emission gate**: `Builder::file_index(fid)` is now the single write path into `file_indices`; interested-only builds drop rows outside the interested file. Zero information loss: the master only consumes `main_file_index` + `symbols` from such builds, and the preamble region is served by the PCH-side index (#501). Mirrors clangd's `FID == SM.getMainFileID()` filtering.
- **Fact-driven graph**: `IncludeGraph::from(unit, indexed_fids)` is built after traversal, from the directive-seen includes (preserving `locations`' role as the TU dependency set) united with the fids the index actually recorded. Loaded fids resolve their include chains through the SourceManager, which preserves include locations across PCH boundaries. `CompilationUnitRef::files()` (and its FIXME) is deleted; the directive iteration moved into `from()`.
- **Defense**: `include_location_id` returns a logged `-1` sentinel for unknown fids instead of asserting — the indexer must never crash the worker on user code. This also hardens the `PreambleState` serializer, which shares the lookup.

Also documents two adjacent gaps found during the investigation: macro definitions in synthetic buffers (`<built-in>`, `<command line>`) are dropped with no go-to-definition feedback (FIXME in directive.cpp / include_graph.h), and background indexing compiles without the project's own PCH — slower indexing on PCH-built projects like LLVM (TODO in command.cpp).

Note: an earlier revision of this branch also made `deps()` include `#embed`ed files; that change was split out into a follow-up PR so this one stays a pure crash fix (the last two commits add and then remove it).

## Testing

- 5 new unit tests: the two emission paths (`PreambleDefaultArgument`, `PreambleBaseSpecifier`, each also asserting the full build resolves the loaded fid to the header's path), the macro path of the gate (`HeaderMacroDropped`), the defensive fallback (`UnknownFidFallback`), and loaded-fid chain recovery (`PreambleFidResolved`). The three crash-regression cases were each individually validated to abort the pre-fix code at the old assert.
- Unit 893 (RelWithDebInfo + Debug/asserts), integration 270, smoke 3/3 — all green.
- End-to-end repros (minimal fixture + `BasicBlockUtils.h` against the llvm CDB) flip from 100% CRASH to NOCRASH, with the defensive fallback confirmed never firing.