### PR TITLE
fix(compile): include embedded files in unit deps

### DIFF
--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -1,6 +1,7 @@
 #include "compile/implement.h"
 #include "index/usr.h"
 #include "semantic/ast_utility.h"
+#include "support/filesystem.h"
 
 #include "kota/ipc/lsp/text.h"
 
@@ -82,25 +83,29 @@ auto CompilationUnitRef::file_offset(clang::SourceLocation location) -> std::uin
     return self->SM().getFileOffset(location);
 }
 
-auto CompilationUnitRef::file_path(clang::FileID fid) -> llvm::StringRef {
-    if(!fid.isValid())
-        return {};
-    if(auto it = self->path_cache.find(fid); it != self->path_cache.end()) {
+auto CompilationUnitRef::file_path(clang::FileEntryRef entry) -> llvm::StringRef {
+    if(auto it = self->path_cache.find(&entry.getFileEntry()); it != self->path_cache.end()) {
         return it->second;
     }
 
-    auto entry = self->SM().getFileEntryRefForID(fid);
-    if(!entry) {
-        return {};
-    }
+    auto& fm = self->SM().getFileManager();
 
-    llvm::SmallString<128> path;
+    /// Absolutize against the compile's working directory first, then
+    /// resolve through the compiler's VFS so remapped and in-memory
+    /// files canonicalize like on-disk ones. Since the cache is keyed
+    /// by the inode-unique FileEntry, every symlinked spelling of a
+    /// file collapses to a single path.
+    llvm::SmallString<128> path(entry.getName());
+    fm.makeAbsolutePath(path);
 
-    /// Try to get the real path of the file.
-    auto name = entry->getName();
-    if(auto error = llvm::sys::fs::real_path(name, path)) {
-        /// If failed, use the virtual path.
-        path = name;
+    llvm::SmallString<128> real;
+    if(auto error = fm.getVirtualFileSystem().getRealPath(path, real)) {
+        /// The VFS cannot resolve it; keep the absolute path with dot
+        /// segments removed rather than a raw spelling — consumers stat
+        /// these paths from a different working directory.
+        path::remove_dots(path, /*remove_dot_dot=*/true);
+    } else {
+        path = real;
     }
     assert(!path.empty() && "Invalid file path");
 
@@ -110,9 +115,22 @@ auto CompilationUnitRef::file_path(clang::FileID fid) -> llvm::StringRef {
     memcpy(data, path.data(), size);
     data[size] = '\0';
 
-    auto [it, inserted] = self->path_cache.try_emplace(fid, llvm::StringRef(data, size));
+    auto [it, inserted] =
+        self->path_cache.try_emplace(&entry.getFileEntry(), llvm::StringRef(data, size));
     assert(inserted && "File path already exists");
     return it->second;
+}
+
+auto CompilationUnitRef::file_path(clang::FileID fid) -> llvm::StringRef {
+    if(!fid.isValid())
+        return {};
+
+    auto entry = self->SM().getFileEntryRefForID(fid);
+    if(!entry) {
+        return {};
+    }
+
+    return file_path(*entry);
 }
 
 auto CompilationUnitRef::file_content(clang::FileID fid) -> llvm::StringRef {
@@ -255,7 +273,16 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
 std::vector<std::string> CompilationUnitRef::deps() {
     llvm::StringSet<> deps;
 
-    /// FIXME: consider `#embed` and `__has_embed`.
+    /// Embedded files have no FileID (clang delivers their contents as a
+    /// single annotation token), so they are resolved through their file
+    /// entry instead.
+    auto add_file = [&](clang::OptionalFileEntryRef file) {
+        if(file) {
+            if(auto path = file_path(*file); !path.empty()) {
+                deps.try_emplace(path);
+            }
+        }
+    };
 
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
@@ -274,6 +301,14 @@ std::vector<std::string> CompilationUnitRef::deps() {
                     deps.try_emplace(path);
                 }
             }
+        }
+
+        for(auto& embed: directive.embeds) {
+            add_file(embed.file);
+        }
+
+        for(auto& has_embed: directive.has_embeds) {
+            add_file(has_embed.file);
         }
     }
 

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -84,7 +84,7 @@ auto CompilationUnitRef::file_offset(clang::SourceLocation location) -> std::uin
 }
 
 auto CompilationUnitRef::file_path(clang::FileEntryRef entry) -> llvm::StringRef {
-    if(auto it = self->path_cache.find(&entry.getFileEntry()); it != self->path_cache.end()) {
+    if(auto it = self->path_cache.find(entry); it != self->path_cache.end()) {
         return it->second;
     }
 
@@ -92,9 +92,11 @@ auto CompilationUnitRef::file_path(clang::FileEntryRef entry) -> llvm::StringRef
 
     /// Absolutize against the compile's working directory first, then
     /// resolve through the compiler's VFS so remapped and in-memory
-    /// files canonicalize like on-disk ones. Since the cache is keyed
-    /// by the inode-unique FileEntry, every symlinked spelling of a
-    /// file collapses to a single path.
+    /// files canonicalize like on-disk ones. Symlinked spellings of a
+    /// file collapse into one path here; hardlinked spellings do not
+    /// (`real_path` does not fold them), and the cache is keyed by the
+    /// spelling-level FileEntryRef so each keeps its own path — the
+    /// dependency set must cover every spelling the compile read.
     llvm::SmallString<128> path(entry.getName());
     fm.makeAbsolutePath(path);
 
@@ -115,8 +117,7 @@ auto CompilationUnitRef::file_path(clang::FileEntryRef entry) -> llvm::StringRef
     memcpy(data, path.data(), size);
     data[size] = '\0';
 
-    auto [it, inserted] =
-        self->path_cache.try_emplace(&entry.getFileEntry(), llvm::StringRef(data, size));
+    auto [it, inserted] = self->path_cache.try_emplace(entry, llvm::StringRef(data, size));
     assert(inserted && "File path already exists");
     return it->second;
 }
@@ -283,6 +284,11 @@ std::vector<std::string> CompilationUnitRef::deps() {
             }
         }
 
+        /// FIXME: Not-found `__has_include`/`__has_embed` probes leave no
+        /// trace here, so creating the probed file later cannot invalidate
+        /// products built while it was missing. Tracking them requires the
+        /// candidate paths of the failed lookup (clang's preamble keeps a
+        /// MissingFiles set for exactly this), not just the hits.
         for(auto& has_include: directive.has_includes) {
             if(has_include.fid.isValid()) {
                 deps.try_emplace(file_path(has_include.fid));

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -286,9 +286,13 @@ std::vector<std::string> CompilationUnitRef::deps() {
 
         /// FIXME: Not-found `__has_include`/`__has_embed` probes leave no
         /// trace here, so creating the probed file later cannot invalidate
-        /// products built while it was missing. Tracking them requires the
-        /// candidate paths of the failed lookup (clang's preamble keeps a
-        /// MissingFiles set for exactly this), not just the hits.
+        /// products built while it was missing. `clang -MD` drops misses
+        /// the same way — the build ecosystem accepts this hole, and even
+        /// clang's preamble simulates the failed lookup's candidate paths
+        /// only for `#include` misses. Rather than stat'ing candidate sets
+        /// per freshness check, the right home is the invalidation
+        /// pipeline: persist unresolved lookups and match them against
+        /// file-creation events from the workspace watcher.
         for(auto& has_include: directive.has_includes) {
             if(has_include.fid.isValid()) {
                 deps.try_emplace(file_path(has_include.fid));

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -122,11 +122,13 @@ auto CompilationUnitRef::file_path(clang::FileEntryRef entry) -> llvm::StringRef
 }
 
 auto CompilationUnitRef::file_path(clang::FileID fid) -> llvm::StringRef {
-    if(!fid.isValid())
-        return {};
+    assert(fid.isValid() && "file_path: invalid fid");
 
     auto entry = self->SM().getFileEntryRefForID(fid);
+    assert(entry && "file_path: fid has no backing file entry, check is_builtin_file first");
     if(!entry) {
+        /// Callers violating the contract get a degraded result in release
+        /// builds; the worker must not crash on it.
         return {};
     }
 
@@ -273,42 +275,33 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
 std::vector<std::string> CompilationUnitRef::deps() {
     llvm::StringSet<> deps;
 
-    /// Embedded files have no FileID (clang delivers their contents as a
-    /// single annotation token), so they are resolved through their file
-    /// entry instead.
-    auto add_file = [&](clang::OptionalFileEntryRef file) {
-        if(file) {
-            if(auto path = file_path(*file); !path.empty()) {
-                deps.try_emplace(path);
-            }
-        }
-    };
-
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
-            if(!include.skipped) {
-                auto path = file_path(include.fid);
-                if(!path.empty()) {
-                    deps.try_emplace(path);
-                }
+            /// A failed include leaves an invalid fid — nothing to depend on.
+            if(!include.skipped && include.fid.isValid()) {
+                deps.try_emplace(file_path(include.fid));
             }
         }
 
         for(auto& has_include: directive.has_includes) {
             if(has_include.fid.isValid()) {
-                auto path = file_path(has_include.fid);
-                if(!path.empty()) {
-                    deps.try_emplace(path);
-                }
+                deps.try_emplace(file_path(has_include.fid));
             }
         }
 
+        /// Embedded files have no FileID (clang delivers their contents as
+        /// a single annotation token), so they are resolved through their
+        /// file entry instead.
         for(auto& embed: directive.embeds) {
-            add_file(embed.file);
+            if(embed.file) {
+                deps.try_emplace(file_path(*embed.file));
+            }
         }
 
         for(auto& has_embed: directive.has_embeds) {
-            add_file(has_embed.file);
+            if(has_embed.file) {
+                deps.try_emplace(file_path(*has_embed.file));
+            }
         }
     }
 

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -131,8 +131,10 @@ public:
     /// null-terminated.
     auto file_path(clang::FileEntryRef entry) -> llvm::StringRef;
 
-    /// Same, for the file entry backing `fid`; empty for fids without
-    /// one (builtin and scratch buffers).
+    /// Same, for the file entry backing `fid`. The fid must be valid and
+    /// backed by a file entry (asserted): synthetic buffers (<built-in>,
+    /// <command line>, <scratch space>) have none — callers must filter
+    /// them out first, see `is_builtin_file`.
     auto file_path(clang::FileID fid) -> llvm::StringRef;
 
     /// Get the file content of the file ID.

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -123,9 +123,16 @@ public:
     /// Get the file offset of the file location.
     auto file_offset(clang::SourceLocation location) -> std::uint32_t;
 
-    /// Get the file path of the file ID. If the file exists the path
-    /// will be real path, otherwise it will be virtual path. The result
-    /// makes sure the path is ended with '/0'.
+    /// Get the canonical path of the file entry: absolutized against the
+    /// compile's working directory and resolved through the compiler's
+    /// VFS, falling back to the absolute path with dot segments removed.
+    /// The cache is keyed by the inode-unique FileEntry, so all symlinked
+    /// spellings of a file yield one path. The result is guaranteed to be
+    /// null-terminated.
+    auto file_path(clang::FileEntryRef entry) -> llvm::StringRef;
+
+    /// Same, for the file entry backing `fid`; empty for fids without
+    /// one (builtin and scratch buffers).
     auto file_path(clang::FileID fid) -> llvm::StringRef;
 
     /// Get the file content of the file ID.

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -126,8 +126,8 @@ public:
     /// Get the canonical path of the file entry: absolutized against the
     /// compile's working directory and resolved through the compiler's
     /// VFS, falling back to the absolute path with dot segments removed.
-    /// The cache is keyed by the inode-unique FileEntry, so all symlinked
-    /// spellings of a file yield one path. The result is guaranteed to be
+    /// Symlinked spellings of a file resolve to one path; hardlinked
+    /// spellings each keep their own. The result is guaranteed to be
     /// null-terminated.
     auto file_path(clang::FileEntryRef entry) -> llvm::StringRef;
 

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -78,7 +78,7 @@ struct CompilationUnitRef::Self {
     llvm::DenseMap<clang::FileID, Directive> directives;
 
     /// Cache for file path. It is used to avoid multiple file path lookup.
-    llvm::DenseMap<const clang::FileEntry*, llvm::StringRef> path_cache;
+    llvm::DenseMap<clang::FileEntryRef, llvm::StringRef> path_cache;
 
     /// Cache for symbol id.
     llvm::DenseMap<const void*, std::uint64_t> symbol_hash_cache;

--- a/src/compile/implement.h
+++ b/src/compile/implement.h
@@ -78,7 +78,7 @@ struct CompilationUnitRef::Self {
     llvm::DenseMap<clang::FileID, Directive> directives;
 
     /// Cache for file path. It is used to avoid multiple file path lookup.
-    llvm::DenseMap<clang::FileID, llvm::StringRef> path_cache;
+    llvm::DenseMap<const clang::FileEntry*, llvm::StringRef> path_cache;
 
     /// Cache for symbol id.
     llvm::DenseMap<const void*, std::uint64_t> symbol_hash_cache;

--- a/src/feature/diagnostics.cpp
+++ b/src/feature/diagnostics.cpp
@@ -28,7 +28,9 @@ void add_related(protocol::Diagnostic& diagnostic,
                  CompilationUnitRef unit,
                  const Diagnostic& raw,
                  PositionEncoding encoding) {
-    if(raw.fid.isInvalid() || !raw.range.valid()) {
+    /// Related information can point into a synthetic buffer, e.g. a
+    /// macro defined on the command line; there is no file to link to.
+    if(raw.fid.isInvalid() || unit.is_builtin_file(raw.fid) || !raw.range.valid()) {
         return;
     }
 

--- a/tests/unit/compile/diagnostic_tests.cpp
+++ b/tests/unit/compile/diagnostic_tests.cpp
@@ -1,6 +1,7 @@
 #include "test/test.h"
 #include "compile/compilation.h"
 #include "compile/diagnostic.h"
+#include "feature/feature.h"
 
 namespace clice::testing {
 
@@ -181,6 +182,33 @@ void foo() {}
 
     auto unit = compile(dp.params);
     ASSERT_TRUE(unit.completed());
+}
+
+TEST_CASE(CommandLineNote) {
+    /// A macro-redefinition note points into <command line>; related
+    /// information must skip it instead of emitting an empty URI.
+    DiagParams dp(R"(
+#define FOO 2
+int main() { return 0; }
+)",
+                  {"-DFOO=1"});
+
+    auto unit = compile(dp.params);
+    ASSERT_TRUE(unit.completed());
+
+    auto diagnostics = feature::diagnostics(unit);
+    bool redefined = false;
+    for(auto& diag: diagnostics) {
+        if(auto* text = std::get_if<std::string>(&diag.message)) {
+            redefined |= text->find("macro redefined") != std::string::npos;
+        }
+        if(diag.related_information.has_value()) {
+            for(auto& related: *diag.related_information) {
+                ASSERT_FALSE(related.location.uri.empty());
+            }
+        }
+    }
+    ASSERT_TRUE(redefined);
 }
 
 };  // TEST_SUITE(Diagnostic)

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -278,6 +278,42 @@ TEST_CASE(HasEmbed) {
     EXPECT_HAS_EMBED(1, "1", "non-existed.bin", /*exists=*/false);
 };
 
+TEST_CASE(EmbedInDeps) {
+    run(R"cpp(
+#[data.h]
+
+#[data.bin]
+0123456789
+
+#[probe.bin]
+AB
+
+#[main.cpp]
+#include "data.h"
+
+const char e[] = {
+#embed "data.bin"
+};
+
+#if __has_embed("probe.bin")
+#endif
+)cpp");
+
+    auto deps = unit->deps();
+    bool header_found = false;
+    bool data_found = false;
+    bool probe_found = false;
+    for(auto& dep: deps) {
+        ASSERT_TRUE(path::is_absolute(dep));
+        header_found |= dep == TestVFS::path("data.h");
+        data_found |= dep == TestVFS::path("data.bin");
+        probe_found |= dep == TestVFS::path("probe.bin");
+    }
+    ASSERT_TRUE(header_found);
+    ASSERT_TRUE(data_found);
+    ASSERT_TRUE(probe_found);
+};
+
 };  // TEST_SUITE(Directive)
 
 }  // namespace

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -314,6 +314,24 @@ const char e[] = {
     ASSERT_TRUE(probe_found);
 };
 
+TEST_CASE(FailedIncludeDeps) {
+    // A failed include records an invalid fid; deps must skip it
+    // instead of resolving it to a path.
+    add_files("main.cpp", R"cpp(
+#[test.h]
+
+#[main.cpp]
+#include "test.h"
+#include "missing.h"
+)cpp");
+    prepare();
+    auto built = clice::compile(params);
+
+    auto deps = built.deps();
+    ASSERT_EQ(deps.size(), 1U);
+    ASSERT_EQ(deps[0], TestVFS::path("test.h"));
+};
+
 };  // TEST_SUITE(Directive)
 
 }  // namespace


### PR DESCRIPTION
## Problem

`deps()` only collected `#include` and `__has_include` hits, so a change to an `#embed`ed file never invalidated the products built from it — stale PCH/AST/index served indefinitely until an unrelated dependency changed. The directive collector already records embeds with their file entries; they just never reached the dependency set.

## Changes

**1. `#embed` / `__has_embed` files enter the dependency set** (split out of #505 as promised there).

**2. `file_path` gains a `FileEntryRef` overload as the single canonicalization point.** Embedded files have no FileID (clang delivers their contents as one annotation token), which surfaced that path resolution was about to be duplicated — and that the existing implementation was VFS-blind:

- absolutize via `FileManager::makeAbsolutePath`, i.e. against the **compile's working directory** (the old `llvm::sys::fs::real_path` resolved relative spellings against the server process CWD);
- resolve through the **compiler's VFS** (`getVirtualFileSystem().getRealPath()`); the old call bypassed the VFS entirely and silently fell back to the raw — possibly relative — spelling for VFS-only files;
- on failure, fall back to the absolute path with dot segments removed — a relative dep is never handed out.

The cache is keyed by the **spelling-level `FileEntryRef`** (review finding): symlinked spellings still collapse into one path through `getRealPath`, while hardlinked spellings — which `real_path` does not fold — each keep their own, so the dependency set covers every spelling the compile read. For on-disk, symlink-free absolute paths (the production common case) the produced bytes are identical to before, so persisted `cache.json` snapshots validate without spurious rebuilds.

**3. `file_path` invalid input is now an asserted contract, not a silent empty return.** The old empty-`StringRef` error channel had no checking callers — it only spread empty paths silently. Auditing callers under the new contract surfaced two spots that were leaning on it:

- `deps()` let **failed includes** (file not found → invalid fid) flow into `file_path` and relied on the empty return to drop them; it now skips them explicitly;
- diagnostics' related information followed notes into **synthetic buffers** (`-DFOO=1` redefinition notes point into `<command line>`) and emitted **empty-URI locations** to the client; it now skips them.

Debug builds assert on contract violations (the full Debug test matrix acts as caller verification); release degrades gracefully — the worker never crashes on it.

**Explicitly out of scope — not-found probe tracking** (review finding): a `__has_include`/`__has_embed` miss leaves no dependency trace, so creating the probed file later cannot invalidate products built while it was missing. Investigation showed `clang -MD` drops misses the same way (the build ecosystem accepts this hole), and even clang's preamble simulates the failed lookup's candidate paths only for `#include` misses. Rather than stat'ing candidate sets on every freshness check, the right home is the invalidation pipeline — persist unresolved lookups and match them against file-creation events from the workspace watcher. Documented in a FIXME; belongs with the unresolved-include invisibility work.

## Testing

- `Directive.EmbedInDeps`: `#embed`, `__has_embed`, and `#include` files all land in `deps()` with exact path equality, and every dep is absolute (pins the relative-fallback fix; the in-memory test VFS exercises the VFS resolution branch the old implementation couldn't handle).
- `Directive.FailedIncludeDeps` and `Diagnostic.CommandLineNote` pin the two contract guards; each was verified to abort a Debug build with its guard removed, and both also fail against the old empty-return behavior (the empty-URI related-info was real, observable bad output).
- Existing `EXPECT_INCLUDE`/`EXPECT_HAS_INL` full-path assertions double as regression guards for the resolution change.
- Unit 896 (RelWithDebInfo + Debug/asserts), integration 270, smoke 3/3 — all green; CI fully green across the platform matrix.