### PR TITLE
fix(server): unify dependency freshness on consumed-content snapshots

### DIFF
--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -7,6 +7,7 @@
 #include "support/logging.h"
 
 #include "llvm/Support/Error.h"
+#include "llvm/Support/xxhash.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -367,10 +368,6 @@ CompilationUnit compile(CompilationParams& params) {
 CompilationUnit compile(CompilationParams& params, PCHInfo& out) {
     assert(!params.output_file.empty() && "PCH file path cannot be empty");
 
-    /// Record the begin time of PCH building.
-    auto now = std::chrono::system_clock::now().time_since_epoch();
-    out.mtime = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
-
     return run_clang(
         params,
         std::make_unique<clang::GeneratePCHAction>(),
@@ -410,6 +407,13 @@ CompilationUnit compile(CompilationParams& params, PCMInfo& out) {
         },
         [&](CompilationUnitRef unit) {
             out.path = params.output_file.str();
+            out.deps = unit.deps();
+            // deps() collects include targets only; the module source is a
+            // build input of its PCM all the same. Canonicalize it like
+            // every other dep — srcPath keeps the command line's raw
+            // spelling, which consumers cannot stat reliably.
+            out.deps.emplace_back(std::string(unit.file_path(unit.interested_file())),
+                                  llvm::xxh3_64bits(unit.interested_content()));
 
             for(auto& [name, path]: params.pcms) {
                 out.mods.emplace_back(name);

--- a/src/compile/compilation.h
+++ b/src/compile/compilation.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "compile/compilation_unit.h"
+#include "compile/dep_file.h"
 #include "support/filesystem.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -27,14 +28,11 @@ struct PCHInfo {
     /// The path of the output PCH file.
     std::string path;
 
-    /// The building time of this PCH.
-    std::int64_t mtime;
-
     /// The content used to build this PCH.
     std::string preamble;
 
-    /// All files involved in building this PCH.
-    std::vector<std::string> deps;
+    /// All files involved in building this PCH, with consumed-content hashes.
+    std::vector<DepFile> deps;
 
     /// The command arguments used to build this PCH.
     std::vector<const char*> arguments;
@@ -59,8 +57,11 @@ struct PCMInfo : ModuleInfo {
     /// Source file path.
     std::string srcPath;
 
-    /// Files involved in building this PCM(not include module).
-    std::vector<std::string> deps;
+    /// Files involved in building this PCM (not including imported modules),
+    /// with consumed-content hashes. Contains the module source file itself:
+    /// unlike the PCH key, the PCM cache key does not embed any content, so
+    /// the deps snapshot is the only thing that can see the source change.
+    std::vector<DepFile> deps;
 };
 
 struct CompilationParams {

--- a/src/compile/compilation_unit.cpp
+++ b/src/compile/compilation_unit.cpp
@@ -140,6 +140,10 @@ auto CompilationUnitRef::file_content(clang::FileID fid) -> llvm::StringRef {
     return self->SM().getBufferData(fid);
 }
 
+auto CompilationUnitRef::loaded_file_content(clang::FileID fid) -> std::optional<llvm::StringRef> {
+    return self->SM().getBufferDataOrNone(fid);
+}
+
 auto CompilationUnitRef::interested_file() -> clang::FileID {
     return self->SM().getMainFileID();
 }
@@ -273,14 +277,53 @@ clang::LangOptions& CompilationUnitRef::lang_options() {
     return self->instance->getLangOpts();
 }
 
-std::vector<std::string> CompilationUnitRef::deps() {
-    llvm::StringSet<> deps;
+std::vector<DepFile> CompilationUnitRef::deps() {
+    llvm::StringMap<std::uint64_t> deps;
+
+    // Hash the buffer the compiler read for this fid — the consumed bytes.
+    // The same path can appear under several fids (repeated includes); any
+    // of their buffers holds the same content, so the first one wins.
+    auto add_fid = [&](clang::FileID fid) {
+        auto path = file_path(fid);
+        if(path.empty()) {
+            return;
+        }
+        auto it = deps.try_emplace(path, 0).first;
+        if(it->second == 0) {
+            if(auto buffer = self->SM().getBufferDataOrNone(fid)) {
+                it->second = llvm::xxh3_64bits(*buffer);
+            }
+        }
+    };
+
+    /// Embedded files have no FileID (clang delivers their contents as a
+    /// single annotation token). Processing the directive loaded the file
+    /// into the SourceManager's content cache, so this looks up the very
+    /// buffer the build consumed; only an existence-only probe whose
+    /// content was never read loads it here instead. An unreadable file
+    /// hashes as 0 and the snapshot capture falls back to a
+    /// build_at-guarded disk hash.
+    auto add_file = [&](clang::OptionalFileEntryRef file) {
+        if(!file) {
+            return;
+        }
+        auto path = file_path(*file);
+        if(path.empty()) {
+            return;
+        }
+        auto it = deps.try_emplace(path, 0).first;
+        if(it->second == 0) {
+            if(auto buffer = self->SM().getMemoryBufferForFileOrNone(*file)) {
+                it->second = llvm::xxh3_64bits(buffer->getBuffer());
+            }
+        }
+    };
 
     for(auto& [fid, directive]: directives()) {
         for(auto& include: directive.includes) {
             /// A failed include leaves an invalid fid — nothing to depend on.
             if(!include.skipped && include.fid.isValid()) {
-                deps.try_emplace(file_path(include.fid));
+                add_fid(include.fid);
             }
         }
 
@@ -295,30 +338,24 @@ std::vector<std::string> CompilationUnitRef::deps() {
         /// file-creation events from the workspace watcher.
         for(auto& has_include: directive.has_includes) {
             if(has_include.fid.isValid()) {
-                deps.try_emplace(file_path(has_include.fid));
+                add_fid(has_include.fid);
             }
         }
 
-        /// Embedded files have no FileID (clang delivers their contents as
-        /// a single annotation token), so they are resolved through their
-        /// file entry instead.
         for(auto& embed: directive.embeds) {
-            if(embed.file) {
-                deps.try_emplace(file_path(*embed.file));
-            }
+            add_file(embed.file);
         }
 
         for(auto& has_embed: directive.has_embeds) {
-            if(has_embed.file) {
-                deps.try_emplace(file_path(*has_embed.file));
-            }
+            add_file(has_embed.file);
         }
     }
 
-    std::vector<std::string> result;
+    std::vector<DepFile> result;
+    result.reserve(deps.size());
 
-    for(auto& deps: deps) {
-        result.emplace_back(deps.getKey().str());
+    for(auto& dep: deps) {
+        result.emplace_back(dep.getKey().str(), dep.getValue());
     }
 
     return result;

--- a/src/compile/compilation_unit.h
+++ b/src/compile/compilation_unit.h
@@ -2,11 +2,13 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "compile/dep_file.h"
 #include "compile/diagnostic.h"
 #include "compile/directive.h"
 #include "semantic/resolver.h"
@@ -140,6 +142,11 @@ public:
     /// Get the file content of the file ID.
     auto file_content(clang::FileID fid) -> llvm::StringRef;
 
+    /// The buffer this compilation read for `fid`, or nullopt when it was
+    /// never loaded here (e.g. a preamble header served from a PCH). Unlike
+    /// file_content, never falls back to a fake buffer.
+    auto loaded_file_content(clang::FileID fid) -> std::optional<llvm::StringRef>;
+
     /// Get the interested file ID. Currently, it is the same as the main
     /// file id，i.e. the file id of source file.
     auto interested_file() -> clang::FileID;
@@ -247,7 +254,9 @@ public:
 
     clang::TranslationUnitDecl* tu();
 
-    std::vector<std::string> deps();
+    /// The files this compilation read (include and __has_include targets),
+    /// each with the hash of the bytes the compiler actually consumed.
+    std::vector<DepFile> deps();
 
     /// Get symbol ID for given declaration.
     index::SymbolID getSymbolID(const clang::NamedDecl* decl);

--- a/src/compile/dep_file.h
+++ b/src/compile/dep_file.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace clice {
+
+/// One compile input paired with the hash of the bytes the compiler actually
+/// consumed for it — taken from the compiler's own in-memory buffers at build
+/// time, never from a later disk read. A later disk read could describe
+/// content the build never saw (the file may change while the build runs),
+/// which would poison every staleness check built on it.
+///
+/// hash == 0 means the consumed bytes were not available for hashing; the
+/// staleness check treats such an entry conservatively (rebuild once).
+struct DepFile {
+    std::string path;
+    std::uint64_t hash = 0;
+};
+
+}  // namespace clice

--- a/src/index/include_graph.cpp
+++ b/src/index/include_graph.cpp
@@ -3,6 +3,8 @@
 #include "compile/compilation_unit.h"
 #include "support/logging.h"
 
+#include "llvm/Support/xxhash.h"
+
 namespace clice::index {
 
 static std::uint32_t addIncludeChain(CompilationUnitRef unit,
@@ -14,7 +16,7 @@ static std::uint32_t addIncludeChain(CompilationUnitRef unit,
         return -1;
     }
 
-    auto& [paths, locations, file_table] = graph;
+    auto& [paths, locations, path_hashes, file_table] = graph;
 
     auto [iter, success] = file_table.try_emplace(fid, locations.size());
     if(!success) {
@@ -67,6 +69,27 @@ IncludeGraph IncludeGraph::from(CompilationUnitRef unit,
     auto interested = unit.interested_file();
     graph.file_table[interested] = addIncludeChain(unit, interested, graph, path_table);
     graph.paths.emplace_back(unit.file_path(interested));
+
+    // Hash the consumed bytes per path from the compiler's own buffers.
+    // Freshness checks compare the disk against these, so they must
+    // describe what the rows were built from — a fid whose buffer never
+    // loaded here (preamble header behind a PCH) contributes no hash and
+    // its consumers stay conservative.
+    graph.path_hashes.assign(graph.paths.size(), 0);
+    auto hash_fid = [&](clang::FileID fid, std::uint32_t path_id) {
+        if(graph.path_hashes[path_id] != 0) {
+            return;
+        }
+        if(auto content = unit.loaded_file_content(fid)) {
+            graph.path_hashes[path_id] = llvm::xxh3_64bits(*content);
+        }
+    };
+    for(auto& [fid, location]: graph.file_table) {
+        if(location != static_cast<std::uint32_t>(-1)) {
+            hash_fid(fid, graph.locations[location].path_id);
+        }
+    }
+    hash_fid(interested, graph.paths.size() - 1);
     return graph;
 }
 

--- a/src/index/include_graph.h
+++ b/src/index/include_graph.h
@@ -43,6 +43,12 @@ struct IncludeGraph {
     /// parse even when no index row lands in the included file.
     std::vector<IncludeLocation> locations;
 
+    /// Parallel to `paths`: hash of the bytes this compilation actually
+    /// consumed per file (0 = the buffer was unavailable for hashing).
+    /// Freshness baselines built from these describe what the index rows
+    /// were built from, never a later disk state.
+    std::vector<std::uint64_t> path_hashes;
+
     /// Each `FileID` represents a new header context and is introduced
     /// by a new include directive. So a include directive is a new header
     /// context. A map between FileID and its include location.

--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -3,6 +3,7 @@
 #include <ranges>
 #include <tuple>
 
+#include "compile/dep_file.h"
 #include "index/path_pool.h"
 #include "index/serialization.h"
 #include "support/filesystem.h"
@@ -88,6 +89,19 @@ struct DepHash {
     friend bool operator==(const DepHash&, const DepHash&) = default;
 };
 
+/// Stat fast path for one dependency, recorded at merge time only when the
+/// file provably did not change since before the indexed build started.
+/// Layout must mirror `binary::DepStamp` so `safe_cast` can alias it.
+/// The server's mutable, in-place-repairing form of the same fast path is
+/// `DepState` (server/state/workspace.h).
+struct DepStamp {
+    std::uint32_t path_id;
+    std::uint64_t size;
+    std::int64_t mtime_ns;
+
+    friend bool operator==(const DepStamp&, const DepStamp&) = default;
+};
+
 namespace {
 
 /// Hash a file's content with the same scheme the server layer uses for its
@@ -101,34 +115,34 @@ std::uint64_t hash_file(llvm::StringRef path) {
 }
 
 /// Two-layer staleness test for a single dependency, mirroring the server's
-/// `deps_changed`: Layer 1 trusts an unchanged mtime (no file read); Layer 2
-/// re-hashes a file whose mtime moved and treats a matching hash as a mere
-/// touch, not a real edit.
+/// `deps_changed`: Layer 1 trusts a stat EQUAL to the recorded stamp (no
+/// file read) — equality, not a watermark, so backdated or preserved mtimes
+/// cannot masquerade as fresh; Layer 2 re-hashes the disk against the
+/// consumed-content hash and treats a match as a mere touch, not an edit.
 bool dep_stale(llvm::StringRef path,
-               std::uint64_t build_at,
+               const DepStamp* stamp,
                std::optional<std::uint64_t> stored_hash) {
     fs::file_status status;
     if(auto err = fs::status(path, status)) {
         return true;
     }
 
-    auto mtime = std::chrono::duration_cast<std::chrono::milliseconds>(
-        status.getLastModificationTime().time_since_epoch());
-    if(mtime.count() <= static_cast<std::int64_t>(build_at)) {
+    if(stamp && stamp->size == status.getSize() && stamp->mtime_ns == fs::mtime_ns(status)) {
         return false;
     }
 
-    // mtime moved: without a baseline hash we cannot prove the content is
-    // unchanged, so fall back to the conservative rebuild.
+    // The stat moved (or no stamp was recorded): without a baseline hash we
+    // cannot prove the content unchanged, so fall back to the conservative
+    // rebuild.
     if(!stored_hash) {
         return true;
     }
     // A matching hash means the file was only touched, not edited. We do NOT
-    // refresh the stored mtime baseline on a match: the baseline lives inside
-    // the immutable serialized shard, and updating it would mean re-serializing
-    // the whole shard just to skip a rebuild. So a touched-but-unchanged file is
-    // re-hashed on every check until a real edit forces a genuine reindex — a
-    // cheap single read, far cheaper than a needless full reindex.
+    // refresh the stored stamp on a match: the baseline lives inside the
+    // immutable serialized shard, and updating it would mean re-serializing
+    // the whole shard just to skip a rebuild. So a touched-but-unchanged file
+    // is re-hashed on every check until a real edit forces a genuine reindex
+    // — a cheap single read, far cheaper than a needless full reindex.
     return hash_file(path) != *stored_hash;
 }
 
@@ -159,9 +173,14 @@ struct CompilationContext {
 
     std::vector<IncludeLocation> include_locations;
 
-    /// Content hash of each distinct dependency (first-seen order), used by
-    /// the Layer 2 staleness check to distinguish a real edit from a touch.
+    /// Consumed-content hash of each distinct dependency (first-seen order),
+    /// used by the Layer 2 staleness check to distinguish an edit from a
+    /// touch. Reported by the indexing worker from the compiler's buffers.
     llvm::SmallVector<DepHash> dep_hashes;
+
+    /// Stat fast paths for the dependencies that provably did not change
+    /// since before the indexed build started (sparse, like dep_hashes).
+    llvm::SmallVector<DepStamp> dep_stamps;
 
     friend bool operator==(const CompilationContext&, const CompilationContext&) = default;
 };
@@ -322,6 +341,13 @@ void MergedIndex::load_in_memory(this Self& self) {
                 context.dep_hashes.emplace_back(*safe_cast<DepHash>(dep));
             }
         }
+        // Absent from shards written before the stamp field existed: their
+        // deps simply have no fast path and validate by hash.
+        if(entry->dep_stamps()) {
+            for(auto stamp: *entry->dep_stamps()) {
+                context.dep_stamps.emplace_back(*safe_cast<DepStamp>(stamp));
+            }
+        }
         index.compilation_contexts.try_emplace(path, std::move(context));
     }
 
@@ -455,7 +481,8 @@ void MergedIndex::serialize(this const Self& self, llvm::raw_ostream& out) {
             context.canonical_id,
             context.build_at,
             CreateStructVector<binary::IncludeLocation>(builder, context.include_locations),
-            CreateStructVector<binary::DepHash>(builder, context.dep_hashes));
+            CreateStructVector<binary::DepHash>(builder, context.dep_hashes),
+            CreateStructVector<binary::DepStamp>(builder, context.dep_stamps));
     });
 
     llvm::SmallVector<const Occurrence*> occurrence_keys;
@@ -675,28 +702,39 @@ bool MergedIndex::need_update(this const Self& self) {
             return true;
         }
 
-        auto& context = self.impl->compilation_contexts.begin()->getSecond();
         auto& paths = self.impl->paths.paths;
 
-        llvm::DenseMap<std::uint32_t, std::uint64_t> hashes;
-        for(auto& dep: context.dep_hashes) {
-            hashes.try_emplace(dep.path_id, dep.content_hash);
-        }
+        // Every context must be validated: shards normally hold one, but
+        // whichever a partial iteration skipped would keep serving stale
+        // rows behind a fresh verdict.
+        for(auto& entry: self.impl->compilation_contexts) {
+            auto& context = entry.getSecond();
 
-        llvm::DenseSet<std::uint32_t> deps;
-        for(auto& location: context.include_locations) {
-            if(!deps.insert(location.path_id).second) {
-                continue;
+            llvm::DenseMap<std::uint32_t, std::uint64_t> hashes;
+            for(auto& dep: context.dep_hashes) {
+                hashes.try_emplace(dep.path_id, dep.content_hash);
             }
-            // A dep the table does not cover cannot be validated: rebuild.
-            if(location.path_id >= paths.size()) {
-                return true;
+            llvm::DenseMap<std::uint32_t, const DepStamp*> stamps;
+            for(auto& stamp: context.dep_stamps) {
+                stamps.try_emplace(stamp.path_id, &stamp);
             }
-            auto it = hashes.find(location.path_id);
-            if(dep_stale(paths[location.path_id],
-                         context.build_at,
-                         it != hashes.end() ? std::optional(it->second) : std::nullopt)) {
-                return true;
+
+            llvm::DenseSet<std::uint32_t> deps;
+            for(auto& location: context.include_locations) {
+                if(!deps.insert(location.path_id).second) {
+                    continue;
+                }
+                // A dep the table does not cover cannot be validated: rebuild.
+                if(location.path_id >= paths.size()) {
+                    return true;
+                }
+                auto stamp_it = stamps.find(location.path_id);
+                auto it = hashes.find(location.path_id);
+                if(dep_stale(paths[location.path_id],
+                             stamp_it != stamps.end() ? stamp_it->second : nullptr,
+                             it != hashes.end() ? std::optional(it->second) : std::nullopt)) {
+                    return true;
+                }
             }
         }
 
@@ -707,30 +745,39 @@ bool MergedIndex::need_update(this const Self& self) {
             return true;
         }
 
-        auto context = *index->compilation_contexts()->begin();
         auto* paths = index->paths();
 
-        llvm::DenseMap<std::uint32_t, std::uint64_t> hashes;
-        if(context->dep_hashes()) {
-            for(auto dep: *context->dep_hashes()) {
-                hashes.try_emplace(dep->path_id(), dep->content_hash());
+        for(auto context: *index->compilation_contexts()) {
+            llvm::DenseMap<std::uint32_t, std::uint64_t> hashes;
+            if(context->dep_hashes()) {
+                for(auto dep: *context->dep_hashes()) {
+                    hashes.try_emplace(dep->path_id(), dep->content_hash());
+                }
             }
-        }
+            llvm::DenseMap<std::uint32_t, const binary::DepStamp*> stamps;
+            if(context->dep_stamps()) {
+                for(auto stamp: *context->dep_stamps()) {
+                    stamps.try_emplace(stamp->path_id(), stamp);
+                }
+            }
 
-        llvm::DenseSet<std::uint32_t> deps;
-        for(auto location: *context->include_locations()) {
-            if(!deps.insert(location->path_id()).second) {
-                continue;
-            }
-            // A dep the table does not cover cannot be validated: rebuild.
-            if(!paths || location->path_id() >= paths->size()) {
-                return true;
-            }
-            auto it = hashes.find(location->path_id());
-            if(dep_stale(paths->Get(location->path_id())->string_view(),
-                         context->build_at(),
-                         it != hashes.end() ? std::optional(it->second) : std::nullopt)) {
-                return true;
+            llvm::DenseSet<std::uint32_t> deps;
+            for(auto location: *context->include_locations()) {
+                if(!deps.insert(location->path_id()).second) {
+                    continue;
+                }
+                // A dep the table does not cover cannot be validated: rebuild.
+                if(!paths || location->path_id() >= paths->size()) {
+                    return true;
+                }
+                auto stamp_it = stamps.find(location->path_id());
+                auto it = hashes.find(location->path_id());
+                if(dep_stale(paths->Get(location->path_id())->string_view(),
+                             stamp_it != stamps.end() ? safe_cast<DepStamp>(stamp_it->second)
+                                                      : nullptr,
+                             it != hashes.end() ? std::optional(it->second) : std::nullopt)) {
+                    return true;
+                }
             }
         }
 
@@ -869,37 +916,42 @@ void MergedIndex::merge(this Self& self,
     self.impl->content = content.str();
     self.impl->line_starts = kota::ipc::lsp::build_line_starts(self.impl->content);
 
-    // Intern the dependencies into the shard's own path table, and capture a
-    // content hash for each distinct one so a later staleness check can tell
-    // a real edit apart from a mere touch (mtime bumped, bytes unchanged).
-    // Only re-hashing at check time can prove that, so the baseline is
-    // recorded here.
-    // TODO: this re-reads every dependency on the event-loop thread even
-    // though the indexer worker already read them; if it shows up on large
-    // cold-start profiles, have the worker ship the hashes in the TUIndex.
+    // Intern the dependencies into the shard's own path table. The staleness
+    // baseline per distinct dep is two-part: the consumed-content hash the
+    // worker computed from the compiler's own buffers (describing exactly
+    // what the rows were built from), and a stat fast path recorded only for
+    // files that provably did not change since before the build started —
+    // for the rest the stat could describe content the rows were never built
+    // from, so they re-earn their fast path through a hash check instead.
     std::vector<IncludeLocation> include_locations;
     llvm::SmallVector<DepHash> dep_hashes;
+    llvm::SmallVector<DepStamp> dep_stamps;
     llvm::DenseSet<std::uint32_t> seen;
     include_locations.reserve(deps.size());
+    auto baseline_before_ns = fs::stat_baseline_before_ns(build_at.count());
     for(auto& dep: deps) {
         auto local_id = self.impl->paths.path_id(dep.path);
         include_locations.push_back({local_id, dep.line, dep.include_id});
         if(!seen.insert(local_id).second) {
             continue;
         }
-        // A dep modified after the indexed snapshot was built must not
-        // contribute a baseline: hashing it now would bless content the
-        // rows were never built from, hiding the edit forever. With no
-        // stored hash the staleness check stays conservative and the TU
-        // simply reindexes once more.
+
         fs::file_status status;
-        if(auto err = fs::status(dep.path, status)) {
-            continue;
+        bool stat_ok = !fs::status(dep.path, status);
+        bool untouched = stat_ok && fs::mtime_ns(status) <= baseline_before_ns;
+
+        auto hash = dep.content_hash;
+        if(hash == 0 && untouched) {
+            // The worker had no buffer to hash (e.g. behind a PCH); the
+            // unchanged mtime proves the disk still holds the consumed
+            // bytes, so hash it here.
+            hash = hash_file(dep.path);
         }
-        auto mtime = std::chrono::duration_cast<std::chrono::milliseconds>(
-            status.getLastModificationTime().time_since_epoch());
-        if(mtime <= build_at) {
-            dep_hashes.emplace_back(local_id, hash_file(dep.path));
+        if(hash != 0) {
+            dep_hashes.emplace_back(local_id, hash);
+        }
+        if(untouched) {
+            dep_stamps.push_back({local_id, status.getSize(), fs::mtime_ns(status)});
         }
     }
 
@@ -917,6 +969,7 @@ void MergedIndex::merge(this Self& self,
         context.build_at = build_at.count();
         context.include_locations = std::move(include_locations);
         context.dep_hashes = std::move(dep_hashes);
+        context.dep_stamps = std::move(dep_stamps);
     });
     self.impl->occurrences_cache.clear();
 }

--- a/src/index/merged_index.h
+++ b/src/index/merged_index.h
@@ -14,11 +14,14 @@
 namespace clice::index {
 
 /// A dependency of a compilation context: where it was included and the
-/// file's path, interned into the shard's own path table on merge.
+/// file's path, interned into the shard's own path table on merge, plus the
+/// hash of the bytes the indexing compile consumed for it (0 = unavailable;
+/// the staleness baseline then stays conservative for this file).
 struct DepLocation {
     llvm::StringRef path;
     std::uint32_t line = 0;
     std::uint32_t include_id = 0;
+    std::uint64_t content_hash = 0;
 };
 
 class MergedIndex {

--- a/src/index/schema.fbs
+++ b/src/index/schema.fbs
@@ -49,6 +49,15 @@ struct DepHash {
     content_hash : ulong;
 }
 
+// Stat fast path for one dependency: recorded only when the file provably
+// did not change since before the indexed build started, so an equal stat
+// proves the disk still holds the content the rows were built from.
+struct DepStamp {
+    path_id : uint;
+    size : ulong;
+    mtime_ns : long;
+}
+
 table CompilationContextEntry {
 path_id:
     uint;
@@ -62,6 +71,12 @@ include_locations:
     [IncludeLocation];
 dep_hashes:
     [DepHash];
+
+// Added fields read back as absent from older shards — validation then has
+// no fast path and goes by dep_hashes alone, which stays correct. That is
+// why this addition does not bump index_format_version.
+dep_stamps:
+    [DepStamp];
 }
 
 table OccurrenceEntry {
@@ -251,6 +266,13 @@ file_indices:
     [TUFileIndexEntry];
 main_file_index:
     TUFileIndexEntry;
+
+// Parallel to `paths`: hash of the bytes the indexing compile actually
+// consumed per file (0 = unavailable). The master validates its own disk
+// reads against these before pairing rows with content, and stores them
+// as the shards' staleness baselines.
+path_hashes:
+    [ulong];
 }
 
 // The blob's path table is compact: only paths referenced by the symbol

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -475,7 +475,8 @@ void TUIndex::serialize(llvm::raw_ostream& os) const {
                               CreateStructVector<binary::IncludeLocation>(builder, graph.locations),
                               CreateVector(builder, syms),
                               builder.CreateVector(file_idx_vec.data(), file_idx_vec.size()),
-                              main_idx);
+                              main_idx,
+                              CreateVector(builder, graph.path_hashes));
 
     builder.Finish(tu_index);
     os.write(safe_cast<const char>(builder.GetBufferPointer()), builder.GetSize());
@@ -494,6 +495,11 @@ TUIndex TUIndex::from(const void* data) {
     for(auto loc: *root->locations()) {
         index.graph.locations.emplace_back(*safe_cast<IncludeLocation>(loc));
     }
+
+    if(root->path_hashes()) {
+        index.graph.path_hashes.assign(root->path_hashes()->begin(), root->path_hashes()->end());
+    }
+    index.graph.path_hashes.resize(index.graph.paths.size(), 0);
 
     for(auto entry: *root->symbols()) {
         auto& symbol = index.symbols[entry->symbol_id()];

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -252,10 +252,11 @@ void Compiler::init_compile_graph() {
 
         auto pcm_path = std::move(committed.value().value());
         workspace.pcm_paths[path_id] = pcm_path;
-        workspace.pcm_cache[path_id] = {
-            pcm_path,
-            pcm_key,
-            capture_deps_snapshot(workspace.path_pool, result.value().deps)};
+        workspace.pcm_cache[path_id] = {pcm_path,
+                                        pcm_key,
+                                        capture_deps_snapshot(workspace.path_pool,
+                                                              result.value().deps,
+                                                              result.value().build_at)};
         LOG_INFO("Built PCM for module {}: {}", module_name, pcm_path);
 
         // Persist cache metadata after successful build.
@@ -505,7 +506,8 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
     auto& st = workspace.pch_cache[pch_key];
     st.path = *committed.value().pch_path;
     st.bound = bound;
-    st.deps = capture_deps_snapshot(workspace.path_pool, result.value().deps);
+    st.deps =
+        capture_deps_snapshot(workspace.path_pool, result.value().deps, result.value().build_at);
     st.index_path = *committed.value().index_path;
     // Replace the previous blob's mapping (same key, rebuilt content);
     // in-flight holders of the old shared_ptr stay valid.
@@ -644,7 +646,7 @@ kota::task<bool> Compiler::ensure_deps(Session& session,
     co_return true;
 }
 
-bool Compiler::is_stale(const Session& session) {
+bool Compiler::is_stale(Session& session) {
     if(session.ast_deps.has_value() && deps_changed(workspace.path_pool, *session.ast_deps))
         return true;
 
@@ -665,8 +667,8 @@ bool Compiler::is_stale(const Session& session) {
     return false;
 }
 
-void Compiler::record_deps(Session& session, llvm::ArrayRef<std::string> deps) {
-    session.ast_deps = capture_deps_snapshot(workspace.path_pool, deps);
+void Compiler::record_deps(Session& session, llvm::ArrayRef<DepFile> deps, std::int64_t build_at) {
+    session.ast_deps = capture_deps_snapshot(workspace.path_pool, deps, build_at);
 }
 
 /// Pull-based compilation entry point for user-opened files.
@@ -852,7 +854,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // not declare it fresh; the next request recompiles.
         session->settle_compile(epoch);
         pc->succeeded = true;
-        record_deps(*session, result.value().deps);
+        record_deps(*session, result.value().deps, result.value().build_at);
 
         if(!result.value().tu_index_data.empty()) {
             auto tu_index = index::TUIndex::from(result.value().tu_index_data.data());

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -144,8 +144,10 @@ private:
                                 const std::string& directory,
                                 const std::vector<std::string>& arguments);
 
-    bool is_stale(const Session& session);
-    void record_deps(Session& session, llvm::ArrayRef<std::string> deps);
+    /// Non-const: a passing staleness check may repair the snapshots'
+    /// stat fast paths in place (see deps_changed).
+    bool is_stale(Session& session);
+    void record_deps(Session& session, llvm::ArrayRef<DepFile> deps, std::int64_t build_at);
 
     kota::event_loop& loop;
     Workspace& workspace;

--- a/src/server/compiler/context_resolver.cpp
+++ b/src/server/compiler/context_resolver.cpp
@@ -545,16 +545,29 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
 
     // Read the chain files (all but the target) from disk. The synthesized
     // preamble deliberately reflects disk state, never open-document buffers:
-    // open files must not be depended upon by other files. The staleness
-    // snapshot timestamp is taken before the reads so a concurrent write
-    // lands past build_at and triggers re-validation.
-    auto build_at = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    // open files must not be depended upon by other files. Each file is
+    // stat'ed before it is read: if a write slips in between, the recorded
+    // stat no longer matches the disk and the next check re-validates the
+    // file by hash. Stats within the mtime guard of the read get no fast
+    // path at all — a coarse-granularity filesystem could stamp a slightly
+    // later write with the same mtime.
+    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
+    auto baseline_before_ns = fs::stat_baseline_before_ns(now_ms);
     std::vector<std::string> chain_contents;
     llvm::SmallVector<ChainEntry> chain_entries;
+    DepsSnapshot deps;
     chain_contents.reserve(chain.size() - 1);
     chain_entries.reserve(chain.size() - 1);
+    deps.deps.reserve(chain.size());
     for(std::size_t i = 0; i + 1 < chain.size(); ++i) {
         auto cur_path = workspace.path_pool.resolve(chain[i]);
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(cur_path, status)) {
+            LOG_WARN("resolve_header_context: cannot stat {}", cur_path);
+            return std::nullopt;
+        }
         auto buf = llvm::MemoryBuffer::getFile(cur_path);
         if(!buf) {
             LOG_WARN("resolve_header_context: cannot read {}", cur_path);
@@ -562,6 +575,14 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         }
         chain_contents.emplace_back((*buf)->getBuffer());
         chain_entries.push_back({cur_path, chain_contents.back()});
+        // The hash covers the buffer just read — the bytes the synthesized
+        // preamble embeds — never a re-read that could be newer.
+        auto mtime_ns = fs::mtime_ns(status);
+        bool untouched = mtime_ns <= baseline_before_ns;
+        deps.deps.push_back({.path_id = chain[i],
+                             .size = untouched ? status.getSize() : 0,
+                             .mtime_ns = untouched ? mtime_ns : 0,
+                             .hash = llvm::xxh3_64bits(chain_contents.back())});
     }
 
     // Snapshot the header itself for other occurrences along the chain:
@@ -570,6 +591,8 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     auto target_path = workspace.path_pool.resolve(chain.back());
     std::string self_snapshot_path;
     std::uint64_t target_hash = 0;
+    llvm::sys::fs::file_status target_status;
+    bool target_stat_ok = !llvm::sys::fs::status(target_path, target_status);
     auto preamble_dir = path::join(workspace.config.project.cache_dir, "header_context");
     if(auto target_buf = llvm::MemoryBuffer::getFile(target_path)) {
         auto content = (*target_buf)->getBuffer();
@@ -649,23 +672,20 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         synthesized_hosts[suffix_path] = host_path_id;
     }
 
-    // Snapshot the chain files for staleness detection: their content lives
-    // inside the synthesized preamble, so clang's own dependency tracking
-    // never sees them. Hash the buffers already read above — re-reading from
-    // disk could capture content newer than what the preamble embeds.
-    DepsSnapshot deps;
-    deps.build_at = build_at;
+    // The chain files' snapshot (`deps`) was recorded as they were read:
+    // their content lives inside the synthesized preamble, so clang's own
+    // dependency tracking never sees them.
     llvm::SmallVector<std::uint32_t> chain_ids(chain.begin(), chain.end() - 1);
-    deps.path_ids.assign(chain_ids.begin(), chain_ids.end());
-    deps.hashes.reserve(chain_contents.size() + 1);
-    for(auto& content: chain_contents) {
-        deps.hashes.push_back(llvm::xxh3_64bits(content));
-    }
     if(!self_snapshot_path.empty()) {
         // The self-snapshot mirrors the header's disk state; re-synthesize
-        // when it changes so other-occurrence expansions stay current.
-        deps.path_ids.push_back(chain.back());
-        deps.hashes.push_back(target_hash);
+        // when it changes so other-occurrence expansions stay current. A
+        // failed or too-recent stat leaves no fast path — the next check
+        // goes by hash.
+        bool target_untouched = target_stat_ok && fs::mtime_ns(target_status) <= baseline_before_ns;
+        deps.deps.push_back({.path_id = chain.back(),
+                             .size = target_untouched ? target_status.getSize() : 0,
+                             .mtime_ns = target_untouched ? fs::mtime_ns(target_status) : 0,
+                             .hash = target_hash});
     }
 
     return HeaderContext{host_path_id,

--- a/src/server/compiler/context_resolver.cpp
+++ b/src/server/compiler/context_resolver.cpp
@@ -546,11 +546,10 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     // Read the chain files (all but the target) from disk. The synthesized
     // preamble deliberately reflects disk state, never open-document buffers:
     // open files must not be depended upon by other files. Each file is
-    // stat'ed before it is read: if a write slips in between, the recorded
-    // stat no longer matches the disk and the next check re-validates the
-    // file by hash. Stats within the mtime guard of the read get no fast
-    // path at all — a coarse-granularity filesystem could stamp a slightly
-    // later write with the same mtime.
+    // stat'ed AFTER it is read, and only a stat older than the mtime guard
+    // becomes a fast path: a write racing the read stamps an mtime inside
+    // the guard, so such a file keeps only its hash and the next check
+    // compares the disk against the embedded bytes.
     auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                       std::chrono::system_clock::now().time_since_epoch())
                       .count();
@@ -563,11 +562,6 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     deps.deps.reserve(chain.size());
     for(std::size_t i = 0; i + 1 < chain.size(); ++i) {
         auto cur_path = workspace.path_pool.resolve(chain[i]);
-        llvm::sys::fs::file_status status;
-        if(llvm::sys::fs::status(cur_path, status)) {
-            LOG_WARN("resolve_header_context: cannot stat {}", cur_path);
-            return std::nullopt;
-        }
         auto buf = llvm::MemoryBuffer::getFile(cur_path);
         if(!buf) {
             LOG_WARN("resolve_header_context: cannot read {}", cur_path);
@@ -575,6 +569,11 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
         }
         chain_contents.emplace_back((*buf)->getBuffer());
         chain_entries.push_back({cur_path, chain_contents.back()});
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(cur_path, status)) {
+            LOG_WARN("resolve_header_context: cannot stat {}", cur_path);
+            return std::nullopt;
+        }
         // The hash covers the buffer just read — the bytes the synthesized
         // preamble embeds — never a re-read that could be newer.
         auto mtime_ns = fs::mtime_ns(status);
@@ -592,11 +591,13 @@ std::optional<HeaderContext> ContextResolver::resolve_header_context(std::uint32
     std::string self_snapshot_path;
     std::uint64_t target_hash = 0;
     llvm::sys::fs::file_status target_status;
-    bool target_stat_ok = !llvm::sys::fs::status(target_path, target_status);
+    bool target_stat_ok = false;
     auto preamble_dir = path::join(workspace.config.project.cache_dir, "header_context");
     if(auto target_buf = llvm::MemoryBuffer::getFile(target_path)) {
         auto content = (*target_buf)->getBuffer();
         target_hash = llvm::xxh3_64bits(content);
+        // Stat after the read, same discipline as the chain files above.
+        target_stat_ok = !llvm::sys::fs::status(target_path, target_status);
         self_snapshot_path = path::join(preamble_dir, std::format("{:016x}.self.h", target_hash));
         if(!llvm::sys::fs::exists(self_snapshot_path)) {
             auto ec = llvm::sys::fs::create_directories(preamble_dir);

--- a/src/server/compiler/context_resolver.h
+++ b/src/server/compiler/context_resolver.h
@@ -112,23 +112,23 @@ public:
         header_contexts.erase(path_id);
     }
 
-    /// Zero the header context's dependency baseline so the next use
+    /// Drop the header context's dependency fast paths so the next use
     /// re-validates every chain file by content hash. The context itself is
     /// kept: an in-flight compile can clobber ast_dirty when it finishes,
     /// and the surviving snapshot is what lets is_stale() recover. A
-    /// self-contained borrow tracks no chain deps, so zeroing its baseline
-    /// could never force anything — drop it instead and let the next use
-    /// re-resolve against the updated include graph (cheap: no synthesis
-    /// on that route).
+    /// self-contained borrow tracks no chain deps, so forcing its
+    /// re-validation could never trigger anything — drop it instead and let
+    /// the next use re-resolve against the updated include graph (cheap: no
+    /// synthesis on that route).
     void invalidate_header_deps(std::uint32_t path_id) {
         auto* context = header_context(path_id);
         if(!context) {
             return;
         }
-        if(context->deps.path_ids.empty()) {
+        if(context->deps.empty()) {
             drop_header_context(path_id);
         } else {
-            context->deps.build_at = 0;
+            context->deps.force_revalidate();
         }
     }
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -32,9 +32,40 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
         LOG_WARN("Ignoring TUIndex with empty path graph");
         return;
     }
-    auto file_ids_map = workspace.project_index.merge(tu_index, workspace.path_pool);
     auto main_tu_path_id = static_cast<std::uint32_t>(tu_index.graph.paths.size() - 1);
     llvm::StringRef main_tu_path = tu_index.graph.paths[main_tu_path_id];
+
+    // Shards pair the worker's rows with content read from disk here; if the
+    // disk moved on since the worker read it, the rows' offsets describe
+    // bytes that no longer exist and merging would misplace every position
+    // until the next reindex. The worker's consumed-content hash arbitrates.
+    // A missing hash (0) proceeds as before.
+    auto content_matches = [&](std::uint32_t tu_path_id, llvm::StringRef disk_content) {
+        auto consumed = tu_index.graph.path_hashes[tu_path_id];
+        return consumed == 0 || llvm::xxh3_64bits(disk_content) == consumed;
+    };
+
+    // The main file's verdict gates the WHOLE result: its per-header shards
+    // and the trailing sweep all describe this one compile, so applying any
+    // of it against a moved-on main file would mix two generations (and the
+    // sweep would strip contributions the stale result merely no longer
+    // mentions). Skipping everything keeps the last-known state consistent;
+    // the changed file fails the next staleness check (or is already
+    // pending), and a follow-up pass redoes the merge against settled
+    // content.
+    auto main_buf = llvm::MemoryBuffer::getFile(main_tu_path);
+    if(!main_buf) {
+        LOG_WARN("Skip merge for {}: cannot read content: {}",
+                 main_tu_path,
+                 main_buf.getError().message());
+        return;
+    }
+    if(!content_matches(main_tu_path_id, (*main_buf)->getBuffer())) {
+        LOG_INFO("Skip merge for {}: disk moved on since it was indexed", main_tu_path);
+        return;
+    }
+
+    auto file_ids_map = workspace.project_index.merge(tu_index, workspace.path_pool);
 
     // Collect non-External symbols referenced in a FileIndex.  Each file's
     // MergedIndex shard stores exactly the local symbols its occurrences
@@ -55,18 +86,6 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
     // must be swept below like a dropped one.
     llvm::DenseSet<std::uint32_t> touched;
 
-    // The shard pairs the worker's rows with content read from disk here; if
-    // the disk moved on since the worker read it, the rows' offsets describe
-    // bytes that no longer exist and merging would misplace every position
-    // until the next reindex. The worker's consumed-content hash arbitrates:
-    // on a mismatch the merge is skipped — the changed file fails the next
-    // staleness check (or is already pending), so a follow-up pass redoes it
-    // against the settled content. A missing hash (0) proceeds as before.
-    auto content_matches = [&](std::uint32_t tu_path_id, llvm::StringRef disk_content) {
-        auto consumed = tu_index.graph.path_hashes[tu_path_id];
-        return consumed == 0 || llvm::xxh3_64bits(disk_content) == consumed;
-    };
-
     auto merge_file_index = [&](std::uint32_t tu_path_id, index::FileIndex& file_idx) {
         auto global_path_id = file_ids_map[tu_path_id];
         auto& shard = workspace.merged_indices[global_path_id];
@@ -85,26 +104,10 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
                                 loc.include,
                                 path_hashes[loc.path_id]});
             }
-            auto file_path = workspace.path_pool.resolve(global_path_id);
-            auto buf = llvm::MemoryBuffer::getFile(file_path);
-            if(!buf) {
-                // Overwriting the shard's stored content with nothing would
-                // silently break every position mapping for this TU; keep the
-                // old snapshot, the staleness check re-enqueues it later.
-                // `touched` shields it from the sweep below — a skip must
-                // not strip the last-known rows.
-                LOG_WARN("Skip merge for {}: cannot read content: {}",
-                         file_path,
-                         buf.getError().message());
-                touched.insert(global_path_id);
-                return;
-            }
-            if(!content_matches(main_tu_path_id, (*buf)->getBuffer())) {
-                LOG_INFO("Skip merge for {}: disk moved on since it was indexed", file_path);
-                touched.insert(global_path_id);
-                return;
-            }
-            shard.merge(main_tu_path, tu_index.built_at, deps, file_idx, (*buf)->getBuffer());
+            // Read and verified against the consumed hash before anything
+            // was merged: an unreadable or moved-on main file skips this
+            // whole result up front.
+            shard.merge(main_tu_path, tu_index.built_at, deps, file_idx, (*main_buf)->getBuffer());
             shard.merge_symbols(collect_local_symbols(file_idx));
             touched.insert(global_path_id);
         } else {

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -55,19 +55,35 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
     // must be swept below like a dropped one.
     llvm::DenseSet<std::uint32_t> touched;
 
+    // The shard pairs the worker's rows with content read from disk here; if
+    // the disk moved on since the worker read it, the rows' offsets describe
+    // bytes that no longer exist and merging would misplace every position
+    // until the next reindex. The worker's consumed-content hash arbitrates:
+    // on a mismatch the merge is skipped — the changed file fails the next
+    // staleness check (or is already pending), so a follow-up pass redoes it
+    // against the settled content. A missing hash (0) proceeds as before.
+    auto content_matches = [&](std::uint32_t tu_path_id, llvm::StringRef disk_content) {
+        auto consumed = tu_index.graph.path_hashes[tu_path_id];
+        return consumed == 0 || llvm::xxh3_64bits(disk_content) == consumed;
+    };
+
     auto merge_file_index = [&](std::uint32_t tu_path_id, index::FileIndex& file_idx) {
         auto global_path_id = file_ids_map[tu_path_id];
         auto& shard = workspace.merged_indices[global_path_id];
 
         if(tu_path_id == main_tu_path_id) {
+            auto& path_hashes = tu_index.graph.path_hashes;
             llvm::SmallVector<index::DepLocation> deps;
             deps.reserve(tu_index.graph.locations.size() + 1);
             // The TU's own content is a dependency of its shard too: without
             // it, a closed TU edited on disk with unchanged includes would
             // never look stale.
-            deps.push_back({main_tu_path, 0, 0});
+            deps.push_back({main_tu_path, 0, 0, path_hashes[main_tu_path_id]});
             for(auto& loc: tu_index.graph.locations) {
-                deps.push_back({tu_index.graph.paths[loc.path_id], loc.line, loc.include});
+                deps.push_back({tu_index.graph.paths[loc.path_id],
+                                loc.line,
+                                loc.include,
+                                path_hashes[loc.path_id]});
             }
             auto file_path = workspace.path_pool.resolve(global_path_id);
             auto buf = llvm::MemoryBuffer::getFile(file_path);
@@ -75,9 +91,17 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
                 // Overwriting the shard's stored content with nothing would
                 // silently break every position mapping for this TU; keep the
                 // old snapshot, the staleness check re-enqueues it later.
+                // `touched` shields it from the sweep below — a skip must
+                // not strip the last-known rows.
                 LOG_WARN("Skip merge for {}: cannot read content: {}",
                          file_path,
                          buf.getError().message());
+                touched.insert(global_path_id);
+                return;
+            }
+            if(!content_matches(main_tu_path_id, (*buf)->getBuffer())) {
+                LOG_INFO("Skip merge for {}: disk moved on since it was indexed", file_path);
+                touched.insert(global_path_id);
                 return;
             }
             shard.merge(main_tu_path, tu_index.built_at, deps, file_idx, (*buf)->getBuffer());
@@ -102,6 +126,14 @@ void Indexer::merge(const void* tu_index_data, std::size_t size) {
             if(header_buf) {
                 header_content_storage = (*header_buf)->getBuffer().str();
                 header_content = header_content_storage;
+            }
+            // Unconditional, unlike the read above: an unreadable or
+            // truncated-to-empty header must not slip past the arbitration
+            // and pair the rows with content they were not built from.
+            if(!content_matches(tu_path_id, header_content)) {
+                LOG_INFO("Skip merge for {}: disk moved on since it was indexed", header_path);
+                touched.insert(global_path_id);
+                return;
             }
             // Keyed by the including TU so a reindex of that TU replaces its
             // prior contribution to this header's shard.

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "compile/dep_file.h"
 #include "feature/document_link.h"
 #include "syntax/token.h"
 
@@ -80,7 +81,10 @@ struct CompileResult {
     /// Diagnostics serialized as JSON (RawValue) to avoid bincode/serde annotation conflicts.
     kota::codec::RawValue diagnostics;
     std::size_t memory_usage;
-    std::vector<std::string> deps;
+    /// Milliseconds since epoch, sampled before the compile started. Files
+    /// whose mtime is past this moment may differ from what the build read.
+    std::int64_t build_at = 0;
+    std::vector<DepFile> deps;
     /// Serialized TUIndex for the main file (interested_only=true).
     std::string tu_index_data;
 
@@ -152,7 +156,10 @@ struct BuildResult {
     /// without user errors indicates clice infrastructure breakage (anomaly).
     bool has_user_errors = false;
     std::string output_path;  ///< PCH or PCM path
-    std::vector<std::string> deps;
+    /// Milliseconds since epoch, sampled before the build started. Files
+    /// whose mtime is past this moment may differ from what the build read.
+    std::int64_t build_at = 0;
+    std::vector<DepFile> deps;
     std::string tu_index_data;          ///< Index: serialized TUIndex, merged by the master
     kota::codec::RawValue result_json;  ///< Completion/SignatureHelp result
 };

--- a/src/server/state/file_tracker.cpp
+++ b/src/server/state/file_tracker.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <utility>
 
+#include "support/filesystem.h"
 #include "support/logging.h"
 #include "support/timer.h"
 
@@ -13,10 +14,6 @@
 #include "llvm/Support/FileSystem.h"
 
 namespace clice {
-
-static std::int64_t to_nanoseconds(const llvm::sys::TimePoint<>& time) {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count();
-}
 
 FileTracker::FileTracker(Workspace& workspace,
                          const SessionStore& store,
@@ -40,7 +37,7 @@ FileTracker::CDBStamp FileTracker::stat_cdb() const {
     }
     stamp.exists = true;
     stamp.size = status.getSize();
-    stamp.mtime_ns = to_nanoseconds(status.getLastModificationTime());
+    stamp.mtime_ns = fs::mtime_ns(status);
     return stamp;
 }
 
@@ -185,7 +182,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
                 state.missing = !exists;
                 if(exists) {
                     state.size = status.getSize();
-                    state.mtime_ns = to_nanoseconds(status.getLastModificationTime());
+                    state.mtime_ns = fs::mtime_ns(status);
                     state.hash = hash_file(path);
                     if(state.hash == 0) {
                         // Read failure (hash_file's sentinel): don't seed a
@@ -209,7 +206,7 @@ kota::task<llvm::SmallVector<FileEvent>> FileTracker::tick_workspace() {
             }
 
             auto size = status.getSize();
-            auto mtime_ns = to_nanoseconds(status.getLastModificationTime());
+            auto mtime_ns = fs::mtime_ns(status);
             if(!state.missing && state.size == size && state.mtime_ns == mtime_ns) {
                 continue;
             }

--- a/src/server/state/invalidator.h
+++ b/src/server/state/invalidator.h
@@ -135,8 +135,8 @@ struct DirtySet {
     /// Executed by the context resolver, which owns the verdicts.
     llvm::SmallVector<std::uint32_t> reset_header_mode;
     /// Header sessions whose synthesized preamble embeds changed content:
-    /// zero deps.build_at so every chain file is re-validated by hash, plus
-    /// the mark_ast_dirty treatment.
+    /// drop the chain snapshot's fast paths so every chain file is
+    /// re-validated by hash, plus the mark_ast_dirty treatment.
     llvm::SmallVector<std::uint32_t> force_revalidate;
     /// Closed files whose own content changed: their index rows describe
     /// text that no longer exists. Enqueue for background reindexing as

--- a/src/server/state/workspace.cpp
+++ b/src/server/state/workspace.cpp
@@ -247,7 +247,11 @@ DepsSnapshot capture_deps_snapshot(PathPool& pool,
         llvm::sys::fs::file_status status;
         if(llvm::sys::fs::status(file.path, status)) {
             // The build read it, but it is gone already: record the absence,
-            // reappearing counts as a change.
+            // reappearing counts as a change. Still-missing deliberately
+            // counts as unchanged — flagging it would rebuild on every
+            // check without ever converging, while the artifact is the
+            // last remaining truth for the file (and dependents' recovery
+            // is the DiskRemoved cascade's job, not this snapshot's).
             dep.missing = true;
             dep.hash = 0;
             continue;
@@ -444,6 +448,16 @@ void Workspace::load_cache(ContextResolver& contexts) {
         auto source = resolve(entry.source_file);
         if(!pcm_path || source.empty())
             continue;
+
+        // PCM builds now always record at least the module source itself as
+        // a dependency, so an empty list marks an entry from before deps
+        // were populated — an unvalidatable snapshot that would blindly
+        // serve a stale PCM (the key embeds no content). Drop it and let
+        // the module rebuild once.
+        if(entry.deps.empty()) {
+            LOG_INFO("Dropping dep-less cached PCM for {} (pre-upgrade entry)", source);
+            continue;
+        }
 
         auto path_id = path_pool.intern(source);
         pcm_cache[path_id] = {*pcm_path, entry.key, load_deps(entry.deps)};

--- a/src/server/state/workspace.cpp
+++ b/src/server/state/workspace.cpp
@@ -229,40 +229,89 @@ std::uint64_t hash_file(llvm::StringRef path) {
     return llvm::xxh3_64bits((*buf)->getBuffer());
 }
 
-DepsSnapshot capture_deps_snapshot(PathPool& pool, llvm::ArrayRef<std::string> deps) {
+DepsSnapshot capture_deps_snapshot(PathPool& pool,
+                                   llvm::ArrayRef<DepFile> deps,
+                                   std::int64_t build_at) {
+    // Files whose mtime falls within the guard of the build start count as
+    // "possibly modified during the build" and get no fast-path baseline;
+    // one passing hash comparison repairs them (see deps_changed).
+    auto baseline_before_ns = fs::stat_baseline_before_ns(build_at);
+
     DepsSnapshot snap;
-    // Capture timestamp BEFORE hashing to avoid TOCTOU: if a file is modified
-    // during hashing, its mtime will be > build_at, triggering Layer 2 re-hash.
-    snap.build_at = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    snap.path_ids.reserve(deps.size());
-    snap.hashes.reserve(deps.size());
+    snap.deps.reserve(deps.size());
     for(const auto& file: deps) {
-        snap.path_ids.push_back(pool.intern(file));
-        snap.hashes.push_back(hash_file(file));
+        auto& dep = snap.deps.emplace_back();
+        dep.path_id = pool.intern(file.path);
+        dep.hash = file.hash;
+
+        llvm::sys::fs::file_status status;
+        if(llvm::sys::fs::status(file.path, status)) {
+            // The build read it, but it is gone already: record the absence,
+            // reappearing counts as a change.
+            dep.missing = true;
+            dep.hash = 0;
+            continue;
+        }
+
+        auto mtime_ns = fs::mtime_ns(status);
+        if(mtime_ns > baseline_before_ns) {
+            // Possibly modified during or after the build: this stat may
+            // describe content the build never saw, so it must not become a
+            // fast-path baseline. The consumed hash stays; the next check
+            // compares the disk against it and repairs the fast path on a
+            // match.
+            continue;
+        }
+
+        // Untouched since before the build started — the disk still holds
+        // the consumed bytes, so the stat is a trustworthy fast path.
+        dep.size = status.getSize();
+        dep.mtime_ns = mtime_ns;
+        if(dep.hash == 0) {
+            // The worker could not hash the consumed bytes; the unchanged
+            // mtime proves the disk still holds them, so hash it here.
+            dep.hash = hash_file(file.path);
+        }
     }
     return snap;
 }
 
-bool deps_changed(const PathPool& pool, const DepsSnapshot& snap) {
-    for(std::size_t i = 0; i < snap.path_ids.size(); ++i) {
-        auto path = pool.resolve(snap.path_ids[i]);
+bool deps_changed(const PathPool& pool, DepsSnapshot& snap) {
+    for(auto& dep: snap.deps) {
+        auto path = pool.resolve(dep.path_id);
         llvm::sys::fs::file_status status;
         if(auto ec = llvm::sys::fs::status(path, status)) {
-            // File disappeared — definitely changed.
-            if(snap.hashes[i] != 0)
+            // Gone now: a change unless it was already missing at build time.
+            if(!dep.missing)
                 return true;
             continue;
         }
+        if(dep.missing) {
+            // Missing at build time, present now.
+            return true;
+        }
 
-        // Layer 1: mtime check (cheap, stat only).
-        auto current_mtime = llvm::sys::toTimeT(status.getLastModificationTime());
-        if(current_mtime <= snap.build_at)
+        // Layer 1: an unchanged stat proves unchanged content — the baseline
+        // is only ever recorded or repaired against the consumed hash.
+        auto size = status.getSize();
+        auto mtime_ns = fs::mtime_ns(status);
+        if(dep.mtime_ns != 0 && dep.size == size && dep.mtime_ns == mtime_ns)
             continue;
 
-        // Layer 2: mtime is newer — re-hash content to confirm actual change.
-        auto current_hash = hash_file(path);
-        if(current_hash != snap.hashes[i])
+        // No trusted hash to compare against: rebuild once to converge.
+        if(dep.hash == 0)
             return true;
+
+        // Layer 2: compare the disk against the consumed bytes. hash_file's
+        // 0 sentinel (unreadable right now) cannot match and counts as
+        // changed — conservative, retried by the next check.
+        if(hash_file(path) != dep.hash)
+            return true;
+
+        // Touched but not modified — repair the fast path so the next check
+        // is a single stat again.
+        dep.size = size;
+        dep.mtime_ns = mtime_ns;
     }
     return false;
 }
@@ -272,12 +321,18 @@ namespace {
 struct CacheDepEntry {
     std::uint32_t path;  // index into CacheData::paths
     std::uint64_t hash;
+    // Defaulted so cache.json files written before the per-dep stat baseline
+    // still load: the fields read back zeroed ("no fast path") and the first
+    // staleness check re-earns them by hash. Their old entry-level build_at
+    // is skipped as an unknown field.
+    kota::meta::defaulted<std::uint64_t> size;
+    kota::meta::defaulted<std::int64_t> mtime_ns;
+    kota::meta::defaulted<bool> missing;
 };
 
 struct CachePCHEntry {
     std::string key;  // CacheStore key in the "pch" namespace
     std::uint32_t bound;
-    std::int64_t build_at;
     std::vector<CacheDepEntry> deps;
 };
 
@@ -285,7 +340,6 @@ struct CachePCMEntry {
     std::string key;  // CacheStore key in the "pcm" namespace
     std::uint32_t source_file;
     std::string module_name;
-    std::int64_t build_at;
     std::vector<CacheDepEntry> deps;
 };
 
@@ -344,15 +398,17 @@ void Workspace::load_cache(ContextResolver& contexts) {
         return idx < data.paths.size() ? llvm::StringRef(data.paths[idx]) : "";
     };
 
-    auto load_deps = [&](std::int64_t build_at, const auto& dep_entries) -> DepsSnapshot {
+    auto load_deps = [&](const auto& dep_entries) -> DepsSnapshot {
         DepsSnapshot deps;
-        deps.build_at = build_at;
         for(auto& dep: dep_entries) {
             auto dep_path = resolve(dep.path);
             if(dep_path.empty())
                 continue;
-            deps.path_ids.push_back(path_pool.intern(dep_path));
-            deps.hashes.push_back(dep.hash);
+            deps.deps.push_back({.path_id = path_pool.intern(dep_path),
+                                 .size = dep.size,
+                                 .mtime_ns = dep.mtime_ns,
+                                 .hash = dep.hash,
+                                 .missing = dep.missing});
         }
         return deps;
     };
@@ -377,7 +433,7 @@ void Workspace::load_cache(ContextResolver& contexts) {
         auto& st = pch_cache[entry.key];
         st.path = *pch_path;
         st.bound = entry.bound;
-        st.deps = load_deps(entry.build_at, entry.deps);
+        st.deps = load_deps(entry.deps);
         st.index_path = *index_path;
 
         LOG_DEBUG("Loaded cached PCH: {} -> {}", entry.key, *pch_path);
@@ -390,7 +446,7 @@ void Workspace::load_cache(ContextResolver& contexts) {
             continue;
 
         auto path_id = path_pool.intern(source);
-        pcm_cache[path_id] = {*pcm_path, entry.key, load_deps(entry.build_at, entry.deps)};
+        pcm_cache[path_id] = {*pcm_path, entry.key, load_deps(entry.deps)};
         pcm_paths[path_id] = *pcm_path;
 
         LOG_DEBUG("Loaded cached PCM: {} (module {}) -> {}", source, entry.module_name, *pcm_path);
@@ -430,9 +486,9 @@ void Workspace::save_cache(const ContextResolver& contexts) {
         CachePCHEntry entry;
         entry.key = e.getKey().str();
         entry.bound = st.bound;
-        entry.build_at = st.deps.build_at;
-        for(std::size_t i = 0; i < st.deps.path_ids.size(); ++i) {
-            entry.deps.push_back({intern(st.deps.path_ids[i]), st.deps.hashes[i]});
+        for(auto& dep: st.deps.deps) {
+            entry.deps.push_back(
+                {intern(dep.path_id), dep.hash, dep.size, dep.mtime_ns, dep.missing});
         }
         data.pch.push_back(std::move(entry));
     }
@@ -446,9 +502,9 @@ void Workspace::save_cache(const ContextResolver& contexts) {
         entry.source_file = intern(path_id);
         auto mod_it = path_to_module.find(path_id);
         entry.module_name = mod_it != path_to_module.end() ? mod_it->second : "";
-        entry.build_at = st.deps.build_at;
-        for(std::size_t i = 0; i < st.deps.path_ids.size(); ++i) {
-            entry.deps.push_back({intern(st.deps.path_ids[i]), st.deps.hashes[i]});
+        for(auto& dep: st.deps.deps) {
+            entry.deps.push_back(
+                {intern(dep.path_id), dep.hash, dep.size, dep.mtime_ns, dep.missing});
         }
         data.pcm.push_back(std::move(entry));
     }

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -10,6 +10,7 @@
 
 #include "command/command.h"
 #include "command/toolchain.h"
+#include "compile/dep_file.h"
 #include "feature/document_link.h"
 #include "index/merged_index.h"
 #include "index/preamble_state.h"
@@ -35,22 +36,55 @@ class ContextResolver;
 /// Bump to discard all cached artifacts after incompatible format changes.
 constexpr inline std::uint32_t cache_format_version = 4;
 
-/// Two-layer staleness snapshot for compilation artifacts (PCH, AST, etc.).
-///
-/// Layer 1 (fast): compare each file's current mtime against build_at.
-///   If all mtimes <= build_at, the artifact is fresh (zero I/O beyond stat).
-///
-/// Layer 2 (precise): for files whose mtime changed, re-hash their content
-///   and compare against the stored hash.  If the hash matches, the file was
-///   "touched" but not actually modified — skip the rebuild.
-struct DepsSnapshot {
-    llvm::SmallVector<std::uint32_t> path_ids;
-    llvm::SmallVector<std::uint64_t> hashes;
-    std::int64_t build_at = 0;
-};
-
 /// Sentinel for "no path": path pool ids start at 0, so 0 is a real file.
 constexpr inline std::uint32_t no_path_id = ~0u;
+
+/// One dependency's freshness record inside a DepsSnapshot.
+///
+/// `hash` describes the bytes the build actually consumed (reported by the
+/// worker from the compiler's own buffers). `size`/`mtime_ns` are a stat
+/// fast path: they are only recorded when the file provably did not change
+/// since before the build started, so matching them proves the disk still
+/// holds the consumed content. mtime_ns == 0 means "no fast path" — the
+/// check falls through to the hash comparison and, on a match, repairs the
+/// fast path in place. The index shard's immutable, non-repairing form of
+/// the same fast path is `DepStamp` (merged_index.cpp).
+struct DepState {
+    std::uint32_t path_id = no_path_id;
+    std::uint64_t size = 0;
+    std::int64_t mtime_ns = 0;
+    std::uint64_t hash = 0;
+    /// The file did not exist when the artifact was built (hash is 0 then).
+    bool missing = false;
+};
+
+/// Two-layer staleness snapshot for compilation artifacts (PCH, PCM, AST,
+/// synthesized header preambles). Same vocabulary as FileTracker::FileState.
+///
+/// Layer 1 (fast): stat each dep; size and mtime_ns EQUAL to the record
+///   means unchanged (zero I/O beyond stat). Equality — not a watermark —
+///   so backdated or preserved mtimes cannot masquerade as fresh.
+///
+/// Layer 2 (precise): otherwise hash the disk content and compare against
+///   the consumed-content hash. A match means the file was touched but not
+///   modified: the record's fast path is repaired and no rebuild happens.
+struct DepsSnapshot {
+    llvm::SmallVector<DepState> deps;
+
+    bool empty() const {
+        return deps.empty();
+    }
+
+    /// Drop every fast-path baseline so the next check re-validates each
+    /// dependency by content hash (the hashes stay: they describe what the
+    /// artifact was built from). Used when embedded copies of dependency
+    /// content may disagree with the files themselves.
+    void force_revalidate() {
+        for(auto& dep: deps) {
+            dep.mtime_ns = 0;
+        }
+    }
+};
 
 /// Context for compiling a header file that lacks its own CDB entry.
 struct HeaderContext {
@@ -270,13 +304,20 @@ std::string discover_compile_commands(const Config& config, llvm::StringRef work
 /// Hash a file's content using xxh3_64bits. Returns 0 on read failure.
 std::uint64_t hash_file(llvm::StringRef path);
 
-/// Capture a two-layer staleness snapshot after a successful compilation.
-/// Interns dependency paths into the PathPool and hashes each file's content.
-DepsSnapshot capture_deps_snapshot(PathPool& pool, llvm::ArrayRef<std::string> deps);
+/// Capture a staleness snapshot from a build's reported inputs.
+///
+/// `deps` carries the consumed-content hashes the worker computed at build
+/// time; `build_at` is milliseconds since epoch, sampled before the build
+/// started. Each dependency is stat'ed once: a file untouched since
+/// `build_at` gets a {size, mtime_ns} fast-path baseline, a file modified
+/// during or after the build gets none — the next check must prove the disk
+/// still matches the consumed hash before trusting (and repairing) the stat.
+DepsSnapshot capture_deps_snapshot(PathPool& pool,
+                                   llvm::ArrayRef<DepFile> deps,
+                                   std::int64_t build_at);
 
-/// Two-layer staleness check.
-/// Layer 1 (fast): stat each dep file, compare mtime against build_at.
-/// Layer 2 (precise): for files with mtime > build_at, re-hash content.
-bool deps_changed(const PathPool& pool, const DepsSnapshot& snap);
+/// Two-layer staleness check; see DepsSnapshot. Repairs fast-path baselines
+/// in place when a hash comparison proves a touched file unchanged.
+bool deps_changed(const PathPool& pool, DepsSnapshot& snap);
 
 }  // namespace clice

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -63,7 +63,10 @@ struct DepState {
 ///
 /// Layer 1 (fast): stat each dep; size and mtime_ns EQUAL to the record
 ///   means unchanged (zero I/O beyond stat). Equality — not a watermark —
-///   so backdated or preserved mtimes cannot masquerade as fresh.
+///   so backdated or preserved mtimes cannot masquerade as fresh. The one
+///   deliberate residual: different bytes behind an identical size AND
+///   identical nanosecond mtime are invisible, the universal limit of any
+///   stat-based fast path (FileTracker, ccache and clangd accept the same).
 ///
 /// Layer 2 (precise): otherwise hash the disk content and compare against
 ///   the consumed-content hash. A match means the file was touched but not

--- a/src/server/transport/master_server.cpp
+++ b/src/server/transport/master_server.cpp
@@ -302,8 +302,9 @@ void MasterServer::dispatch(llvm::ArrayRef<FileEvent> events) {
     }
 
     // Headers whose synthesized preamble embeds changed chain content:
-    // zeroing build_at forces deps_changed() to re-validate every chain
-    // file by content hash; open sessions also recompile and re-trial.
+    // dropping the snapshot's fast paths forces deps_changed() to re-validate
+    // every chain file by content hash; open sessions also recompile and
+    // re-trial.
     for(auto path_id: dirty.force_revalidate) {
         contexts.invalidate_header_deps(path_id);
         if(auto session = sessions.find(path_id)) {

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -191,6 +191,7 @@ void StatefulWorker::register_handlers() {
                 result.inactive_regions =
                     feature::inactive_regions(doc->unit, params.open_conditionals, doc->pch.second)
                         .regions;
+                result.build_at = doc->unit.build_at().count();
                 result.deps = doc->unit.deps();
 
                 // Build index for main file only (interested_only=true).

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -126,6 +126,7 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
     PCHInfo pch_info;
     auto unit = compile(cp, pch_info);
     bool success = unit.completed();
+    auto build_at = unit.build_at().count();
 
     std::string errors;
     if(!success)
@@ -160,6 +161,7 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
+        result.build_at = build_at;
         result.deps = pch_info.deps;
         return result;
     } else {
@@ -200,6 +202,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
     PCMInfo pcm_info;
     auto unit = compile(cp, pcm_info);
     bool success = unit.completed();
+    auto build_at = unit.build_at().count();
 
     std::string errors;
     if(!success)
@@ -216,6 +219,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
         worker::BuildResult result;
         result.success = true;
         result.output_path = tmp_path;
+        result.build_at = build_at;
         result.deps = pcm_info.deps;
         return result;
     } else {

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <expected>
 #include <memory>
@@ -53,6 +55,30 @@ inline std::expected<std::string, std::error_code> createTemporaryFile(llvm::Str
         return std::unexpected(error);
     }
     return path.str().str();
+}
+
+/// A file's mtime as nanoseconds since epoch — the resolution every
+/// freshness baseline in the project stores.
+inline std::int64_t mtime_ns(const llvm::sys::fs::file_status& status) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               status.getLastModificationTime().time_since_epoch())
+        .count();
+}
+
+/// Filesystem mtime-granularity guard for freshness baselines: a stat fast
+/// path is only recorded for a file whose mtime precedes the reference
+/// moment by at least this much. Closer to it, a coarse-granularity
+/// filesystem (FAT stores 2s mtimes, several network filesystems whole
+/// seconds) could stamp a write the reference never saw with a timestamp
+/// from before it — so those files re-earn their fast path through one
+/// hash comparison instead.
+constexpr inline std::int64_t mtime_guard_ns = 2'000'000'000;
+
+/// The newest mtime (ns) a file may carry and still be provably untouched
+/// since the reference moment `at_ms` (a build start, or "now" for
+/// content read on the spot).
+constexpr std::int64_t stat_baseline_before_ns(std::int64_t at_ms) {
+    return at_ms * 1'000'000 - mtime_guard_ns;
 }
 
 inline std::expected<void, std::error_code> write(llvm::StringRef path, llvm::StringRef content) {

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -7,6 +7,7 @@ server restarts via cache.json, and are properly reused across sessions.
 
 import asyncio
 import json
+import os
 
 import pytest
 from lsprotocol.types import (
@@ -257,8 +258,10 @@ async def test_pcm_cache_entry_has_deps(client, test_data_dir, tmp_path):
     for entry in cache["pcm"]:
         deps = entry.get("deps", [])
         assert deps, f"PCM entry {entry.get('module_name')} has no deps"
-        source = paths[entry["source_file"]]
-        dep_paths = {paths[d["path"]] for d in deps}
+        # Deps are canonicalized through real_path; compare resolved forms
+        # (on macOS the pytest tmp dir sits behind the /var symlink).
+        source = os.path.realpath(paths[entry["source_file"]])
+        dep_paths = {os.path.realpath(paths[d["path"]]) for d in deps}
         assert source in dep_paths, "Module source must be its own dependency"
         assert all(d["hash"] != 0 for d in deps)
 

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -75,9 +75,11 @@ async def test_cache_json_persisted(client, tmp_path):
     # Verify the entry has expected fields.
     entry = cache["pch"][0]
     assert "key" in entry
-    assert "build_at" in entry
     assert "deps" in entry
     assert "bound" in entry
+    for dep in entry["deps"]:
+        assert dep["hash"] != 0
+        assert "mtime_ns" in dep and "size" in dep
 
 
 async def test_pch_reused_on_close_reopen(client, tmp_path):
@@ -158,6 +160,107 @@ async def test_pch_survives_server_restart(executable, tmp_path):
 
     assert_no_anomaly(c2, tmp_path)
     await shutdown_client(c2)
+
+
+async def test_old_cache_json_upgrades(executable, tmp_path):
+    """A cache.json written before the per-dep stat baselines (entry-level
+    build_at, deps as bare {path, hash}) must still load: unknown fields are
+    skipped, absent ones read back zeroed, and the entry revalidates by hash
+    instead of being dropped."""
+    pin_cache_to_workspace(tmp_path)
+    (tmp_path / "header.h").write_text("#pragma once\nstruct Old { int v; };\n")
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { Old o; return o.v; }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+
+    c1 = await make_client(executable, tmp_path)
+    uri, _ = await c1.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(c1, uri)
+    pch_mtime_s1 = list_pch_files(tmp_path)[0].stat().st_mtime
+    await shutdown_client(c1)
+
+    # Rewrite cache.json into the pre-baseline shape.
+    cache_path = cache_root(tmp_path) / "cache.json"
+    cache = json.loads(cache_path.read_text())
+    for entry in cache["pch"] + cache.get("pcm", []):
+        entry["build_at"] = 0
+        entry["deps"] = [{"path": d["path"], "hash": d["hash"]} for d in entry["deps"]]
+    cache_path.write_text(json.dumps(cache))
+
+    c2 = await make_client(executable, tmp_path)
+    uri2, _ = await c2.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(c2, uri2)
+    # Loaded, hash-validated, reused — not rebuilt.
+    assert list_pch_files(tmp_path)[0].stat().st_mtime == pch_mtime_s1
+    await shutdown_client(c2)
+
+
+async def test_pcm_offline_edit_invalidates(executable, test_data_dir, tmp_path):
+    """Editing a module interface while the server is down must invalidate
+    the cached PCM on restart: the PCM key embeds no content, so only its
+    deps snapshot can see the change."""
+    import shutil
+
+    from tests.tools.compile_commands import generate_cdb
+    from tests.tools.checks import assert_has_errors
+
+    src = test_data_dir / "modules" / "save_recompile"
+    for f in src.iterdir():
+        if f.is_file():
+            shutil.copy2(f, tmp_path / f.name)
+    pin_cache_to_workspace(tmp_path)
+    generate_cdb(tmp_path)
+
+    # Session 1: importer compiles clean, PCM cached.
+    c1 = await make_client(executable, tmp_path)
+    mid_uri, _ = await c1.open_and_wait(tmp_path / "mid.cppm")
+    assert_clean_compile(c1, mid_uri)
+    assert len(list_pcm_files(tmp_path)) >= 1
+    assert_no_anomaly(c1, tmp_path)
+    await shutdown_client(c1)
+
+    # Offline: rename the export the importer calls.
+    (tmp_path / "leaf.cppm").write_text(
+        "export module Leaf;\n\nexport int renamed_leaf() {\n    return 1;\n}\n"
+    )
+
+    # Session 2: mid.cppm calls leaf(), which no longer exists — a stale
+    # PCM would compile it clean.
+    c2 = await make_client(executable, tmp_path)
+    mid_uri2, _ = await c2.open_and_wait(tmp_path / "mid.cppm")
+    assert_has_errors(c2, mid_uri2, "Expected errors after offline interface edit")
+    await shutdown_client(c2)
+
+
+async def test_pcm_cache_entry_has_deps(client, test_data_dir, tmp_path):
+    """cache.json PCM entries must record dependencies, including the module
+    source file itself — an empty list is permanently blind."""
+    import shutil
+
+    from tests.tools.compile_commands import generate_cdb
+
+    src = test_data_dir / "modules" / "save_recompile"
+    for f in src.iterdir():
+        if f.is_file():
+            shutil.copy2(f, tmp_path / f.name)
+    pin_cache_to_workspace(tmp_path)
+    generate_cdb(tmp_path)
+    await client.initialize(tmp_path)
+
+    mid_uri, _ = await client.open_and_wait(tmp_path / "mid.cppm")
+    assert_clean_compile(client, mid_uri)
+
+    cache = read_cache_json(tmp_path)
+    assert cache is not None and cache.get("pcm"), "Expected PCM cache entries"
+    paths = cache["paths"]
+    for entry in cache["pcm"]:
+        deps = entry.get("deps", [])
+        assert deps, f"PCM entry {entry.get('module_name')} has no deps"
+        source = paths[entry["source_file"]]
+        dep_paths = {paths[d["path"]] for d in deps}
+        assert source in dep_paths, "Module source must be its own dependency"
+        assert all(d["hash"] != 0 for d in deps)
 
 
 async def test_shared_preamble_shares_pch(client, tmp_path):

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -234,6 +234,43 @@ async def test_pcm_offline_edit_invalidates(executable, test_data_dir, tmp_path)
     await shutdown_client(c2)
 
 
+async def test_depless_pcm_entry_dropped(executable, test_data_dir, tmp_path):
+    """A PCM cache entry with an empty deps list (written before deps were
+    populated) is unvalidatable and must be dropped at load, not trusted."""
+    import shutil
+
+    from tests.tools.compile_commands import generate_cdb
+    from tests.tools.checks import assert_has_errors
+
+    src = test_data_dir / "modules" / "save_recompile"
+    for f in src.iterdir():
+        if f.is_file():
+            shutil.copy2(f, tmp_path / f.name)
+    pin_cache_to_workspace(tmp_path)
+    generate_cdb(tmp_path)
+
+    c1 = await make_client(executable, tmp_path)
+    mid_uri, _ = await c1.open_and_wait(tmp_path / "mid.cppm")
+    assert_clean_compile(c1, mid_uri)
+    await shutdown_client(c1)
+
+    # Simulate a pre-upgrade cache: strip the PCM deps, then break the
+    # interface offline. A trusted dep-less entry would compile mid clean.
+    cache_path = cache_root(tmp_path) / "cache.json"
+    cache = json.loads(cache_path.read_text())
+    for entry in cache["pcm"]:
+        entry["deps"] = []
+    cache_path.write_text(json.dumps(cache))
+    (tmp_path / "leaf.cppm").write_text(
+        "export module Leaf;\n\nexport int renamed_leaf() {\n    return 1;\n}\n"
+    )
+
+    c2 = await make_client(executable, tmp_path)
+    mid_uri2, _ = await c2.open_and_wait(tmp_path / "mid.cppm")
+    assert_has_errors(c2, mid_uri2, "Expected errors after offline interface edit")
+    await shutdown_client(c2)
+
+
 async def test_pcm_cache_entry_has_deps(client, test_data_dir, tmp_path):
     """cache.json PCM entries must record dependencies, including the module
     source file itself — an empty list is permanently blind."""

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -544,6 +544,59 @@ async def test_saved_host_reinvalidates_header(client, tmp_path):
     )
 
 
+async def test_same_second_save_detected(client, tmp_path):
+    """A header saved immediately after the dependent's compile — within the
+    same second — must still invalidate the PCH. Deliberately no mtime sleep:
+    a watermark-based freshness check is blind exactly here."""
+    (tmp_path / "header.h").write_text(
+        "#pragma once\ninline int value() { return 1; }\n"
+    )
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { return value(); }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(client, uri)
+
+    (tmp_path / "header.h").write_text(
+        "#pragma once\ninline int renamed() { return 1; }\n"
+    )
+    client.text_document_did_save(
+        DidSaveTextDocumentParams(
+            text_document=TextDocumentIdentifier(uri=(tmp_path / "header.h").as_uri())
+        )
+    )
+
+    # main.cpp still calls value(): a reused stale PCH would compile clean.
+    await wait_for_recompile(client, uri)
+    assert_has_errors(client, uri, "Expected errors after same-second header save")
+
+
+async def test_backdated_header_change_detected(client, tmp_path):
+    """A header whose content changes while its mtime moves backwards
+    (rsync -t, git-restore-mtime) must be caught by the pull-side check
+    alone — no didSave is sent."""
+    header = tmp_path / "header.h"
+    header.write_text("#pragma once\ninline int value() { return 1; }\n")
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { return value(); }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(client, uri)
+
+    stat = header.stat()
+    header.write_text("#pragma once\ninline int renamed() { return 1; }\n")
+    os.utime(header, (stat.st_atime, stat.st_mtime - 100))
+
+    await wait_for_recompile(client, uri)
+    assert_has_errors(client, uri, "Expected errors after backdated header change")
+
+
 async def test_orphan_header_default_command(client, tmp_path):
     """A header with no CDB entry and no including source falls back to the
     synthesized default command and still compiles."""

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -100,14 +100,19 @@ int main() { return 0; }
     // PCHInfo.path should match the output file.
     ASSERT_EQ(info.path, *pch_path);
 
-    // PCHInfo.mtime should be a reasonable timestamp (non-zero, recent).
-    ASSERT_TRUE(info.mtime > 0);
+    // build_at is sampled before the compile runs (non-zero, recent).
+    ASSERT_TRUE(preamble_unit.build_at().count() > 0);
 
     // PCHInfo.preamble should be non-empty (contains the #include directives).
     ASSERT_FALSE(info.preamble.empty());
 
-    // PCHInfo.deps should list files involved in building the PCH.
+    // PCHInfo.deps should list files involved in building the PCH, each with
+    // the hash of the consumed bytes.
     ASSERT_FALSE(info.deps.empty());
+    for(auto& dep: info.deps) {
+        ASSERT_FALSE(dep.path.empty());
+        ASSERT_TRUE(dep.hash != 0);
+    }
 
     // PCHInfo.arguments should match what was passed in.
     ASSERT_EQ(info.arguments.size(), params.arguments.size());

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -304,10 +304,12 @@ const char e[] = {
     bool data_found = false;
     bool probe_found = false;
     for(auto& dep: deps) {
-        ASSERT_TRUE(path::is_absolute(dep));
-        header_found |= dep == TestVFS::path("data.h");
-        data_found |= dep == TestVFS::path("data.bin");
-        probe_found |= dep == TestVFS::path("probe.bin");
+        ASSERT_TRUE(path::is_absolute(dep.path));
+        // Every readable dep ships the consumed-content hash.
+        ASSERT_TRUE(dep.hash != 0);
+        header_found |= dep.path == TestVFS::path("data.h");
+        data_found |= dep.path == TestVFS::path("data.bin");
+        probe_found |= dep.path == TestVFS::path("probe.bin");
     }
     ASSERT_TRUE(header_found);
     ASSERT_TRUE(data_found);
@@ -329,7 +331,8 @@ TEST_CASE(FailedIncludeDeps) {
 
     auto deps = built.deps();
     ASSERT_EQ(deps.size(), 1U);
-    ASSERT_EQ(deps[0], TestVFS::path("test.h"));
+    ASSERT_EQ(deps[0].path, TestVFS::path("test.h"));
+    ASSERT_TRUE(deps[0].hash != 0);
 };
 
 };  // TEST_SUITE(Directive)

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -7,6 +7,7 @@
 #include "index/merged_index.h"
 
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/xxhash.h"
 
 namespace clice::testing {
 
@@ -676,6 +677,119 @@ TEST_CASE(OldShardDiscarded) {
         ASSERT_TRUE(loaded.content().empty());
         ASSERT_TRUE(loaded.need_update());
     }
+}
+
+std::uint64_t file_hash(llvm::StringRef path) {
+    auto buf = llvm::MemoryBuffer::getFile(path);
+    return buf ? llvm::xxh3_64bits((*buf)->getBuffer()) : 0;
+}
+
+/// A build_at far enough in the future that every existing file clears the
+/// mtime guard and earns a stat fast path at merge.
+std::chrono::milliseconds generous_build_at() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch()) +
+           std::chrono::milliseconds(10'000);
+}
+
+TEST_CASE(NeedUpdateChecksAllContexts) {
+    TempDir tmp;
+    tmp.touch("a.h", "int a();\n");
+    tmp.touch("b.h", "int b();\n");
+    auto a = tmp.path("a.h");
+    auto b = tmp.path("b.h");
+
+    index::MergedIndex shard;
+    index::FileIndex fi_a, fi_b;
+    auto dep_of = [&](const std::string& path) {
+        return llvm::SmallVector<index::DepLocation>{
+            {path, 1, 0, file_hash(path)}
+        };
+    };
+    shard.merge("tuA", generous_build_at(), dep_of(a), fi_a, "int a();\n");
+    shard.merge("tuB", generous_build_at(), dep_of(b), fi_b, "int b();\n");
+
+    ASSERT_FALSE(shard.need_update());
+
+    // Only one contribution's dependency goes stale at a time; a check that
+    // stops at a single context would miss whichever the iteration order
+    // hides, so exercise both.
+    tmp.touch("b.h", "int b2();\n");
+    ASSERT_TRUE(shard.need_update());
+
+    shard.merge("tuB", generous_build_at(), dep_of(b), fi_b, "int b2();\n");
+    ASSERT_FALSE(shard.need_update());
+    tmp.touch("a.h", "int a2();\n");
+    ASSERT_TRUE(shard.need_update());
+
+    // The serialized reader shares the loop: both contexts again through a
+    // reloaded view.
+    shard.merge("tuA", generous_build_at(), dep_of(a), fi_a, "int a2();\n");
+    llvm::SmallString<1024> s;
+    llvm::raw_svector_ostream os(s);
+    shard.serialize(os);
+    auto view = index::MergedIndex(s);
+    ASSERT_FALSE(view.need_update());
+
+    tmp.touch("b.h", "int b3();\n");
+    ASSERT_TRUE(view.need_update());
+
+    // Restore b (fresh again via the hash layer), then break a: the verdict
+    // now hinges on the second context alone.
+    tmp.touch("b.h", "int b2();\n");
+    ASSERT_FALSE(view.need_update());
+    tmp.touch("a.h", "int a3();\n");
+    ASSERT_TRUE(view.need_update());
+}
+
+TEST_CASE(NeedUpdateBackdatedEdit) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int old_name();\n");
+    auto dep = tmp.path("dep.h");
+
+    index::MergedIndex shard;
+    index::FileIndex fi;
+    llvm::SmallVector<index::DepLocation> deps{
+        {dep, 1, 0, file_hash(dep)}
+    };
+    shard.merge("tu", generous_build_at(), deps, fi, "content");
+    ASSERT_FALSE(shard.need_update());
+
+    // Same length, mtime rolled back: a watermark would call this fresh;
+    // stamp equality sends it to the hash layer.
+    auto recorded = file_mtime_ns(dep);
+    tmp.touch("dep.h", "int new_name();\n");
+    set_file_mtime(dep, recorded - 5'000'000'000);
+    ASSERT_TRUE(shard.need_update());
+}
+
+TEST_CASE(SerializedStampsValidate) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+
+    index::MergedIndex shard;
+    index::FileIndex fi;
+    llvm::SmallVector<index::DepLocation> deps{
+        {dep, 1, 0, file_hash(dep)}
+    };
+    shard.merge("tu", generous_build_at(), deps, fi, "content");
+
+    llvm::SmallString<1024> s;
+    llvm::raw_svector_ostream os(s);
+    shard.serialize(os);
+    auto view = index::MergedIndex(s);
+
+    ASSERT_FALSE(view.need_update());
+
+    // Touched, not modified: the immutable stamp mismatches, the hash
+    // proves the content unchanged.
+    set_file_mtime(dep, file_mtime_ns(dep) + 5'000'000'000);
+    ASSERT_FALSE(view.need_update());
+
+    // A real edit is caught by the hash layer.
+    tmp.touch("dep.h", "int g();\n");
+    ASSERT_TRUE(view.need_update());
 }
 
 };  // TEST_SUITE(MergedIndex)

--- a/tests/unit/server/context_resolver_tests.cpp
+++ b/tests/unit/server/context_resolver_tests.cpp
@@ -106,20 +106,21 @@ TEST_CASE(InvalidateDropsBorrowed) {
     auto borrowed = workspace.path_pool.intern("/proj/borrowed.h");
     auto synthesized = workspace.path_pool.intern("/proj/synthesized.h");
 
-    // A self-contained borrow tracks no chain deps: zeroing its baseline
-    // could never force re-validation, so invalidation drops it outright.
+    // A self-contained borrow tracks no chain deps: forcing re-validation
+    // could never trigger anything, so invalidation drops it outright.
     resolver.header_contexts[borrowed] = HeaderContext{};
     resolver.invalidate_header_deps(borrowed);
     ASSERT_FALSE(resolver.header_contexts.contains(borrowed));
 
-    // A synthesized context re-validates its chain by content hash.
+    // A synthesized context re-validates its chain by content hash: the
+    // fast paths are dropped, the consumed hash stays.
     auto& context = resolver.header_contexts[synthesized];
-    context.deps.path_ids = {borrowed};
-    context.deps.hashes = {7};
-    context.deps.build_at = 123;
+    context.deps.deps.push_back({.path_id = borrowed, .size = 42, .mtime_ns = 123, .hash = 7});
     resolver.invalidate_header_deps(synthesized);
     ASSERT_TRUE(resolver.header_contexts.contains(synthesized));
-    ASSERT_EQ(resolver.header_contexts[synthesized].deps.build_at, 0);
+    auto& dep = resolver.header_contexts[synthesized].deps.deps[0];
+    ASSERT_EQ(dep.mtime_ns, 0);
+    ASSERT_EQ(dep.hash, 7u);
 }
 
 };  // TEST_SUITE(ContextResolver)

--- a/tests/unit/server/deps_snapshot_tests.cpp
+++ b/tests/unit/server/deps_snapshot_tests.cpp
@@ -1,0 +1,198 @@
+#include "test/temp_dir.h"
+#include "test/test.h"
+#include "server/state/workspace.h"
+
+#include "llvm/Support/FileSystem.h"
+
+namespace clice::testing {
+namespace {
+
+/// A build_at (milliseconds since epoch, like the worker's `unit.build_at()`)
+/// far enough in the future that every existing file clears the mtime guard
+/// and earns a stat fast path at capture.
+std::int64_t generous_build_at() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+               .count() +
+           10'000;
+}
+
+TEST_SUITE(DepsSnapshot) {
+
+TEST_CASE(FreshWhenUntouched) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+    ASSERT_EQ(snap.deps.size(), 1u);
+    ASSERT_TRUE(snap.deps[0].mtime_ns != 0);
+    ASSERT_FALSE(deps_changed(pool, snap));
+}
+
+TEST_CASE(ImmediateEditDetected) {
+    // The F44 shape: the dependency is saved right after the artifact's
+    // freshness was captured — no watermark may bless it.
+    TempDir tmp;
+    tmp.touch("dep.h", "int value();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+    tmp.touch("dep.h", "int renamed();\n");
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+TEST_CASE(BackdatedEditDetected) {
+    // The F04 shape: the edit lands with an mtime that does not move
+    // forward (rsync -t, git-restore-mtime). Equality comparison sends it
+    // to the hash layer regardless of the timestamp's direction.
+    TempDir tmp;
+    tmp.touch("dep.h", "int old_name();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+
+    tmp.touch("dep.h", "int new_name();\n");  // same length
+    set_file_mtime(dep, snap.deps[0].mtime_ns - 5'000'000'000);
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+TEST_CASE(TouchRepairsFastPath) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+
+    // Rewrite identical bytes: the stat moves, the content does not.
+    tmp.touch("dep.h", "int f();\n");
+    set_file_mtime(dep, snap.deps[0].mtime_ns + 5'000'000'000);
+    ASSERT_FALSE(deps_changed(pool, snap));
+
+    // The passing hash comparison repaired the fast path in place.
+    ASSERT_EQ(snap.deps[0].mtime_ns, file_mtime_ns(dep));
+}
+
+TEST_CASE(PoisonedCaptureDetected) {
+    // The F01 shape: the dependency changed between the build reading it
+    // and the snapshot being captured. The consumed hash describes v1, the
+    // disk holds v2, and the capture-time stat must not bless v2.
+    TempDir tmp;
+    tmp.touch("dep.h", "int v1();\n");
+    auto dep = tmp.path("dep.h");
+    auto consumed = hash_file(dep);
+
+    tmp.touch("dep.h", "int v2();\n");
+    // build_at in the past: the file's mtime falls inside "modified during
+    // or after the build", so no fast path is recorded.
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, consumed}
+    },
+                                      /*build_at=*/1);
+    ASSERT_EQ(snap.deps[0].mtime_ns, 0);
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+TEST_CASE(NoBaselineConverges) {
+    // Same capture shape as above, but the disk still holds the consumed
+    // bytes: one hash comparison proves it and re-earns the fast path.
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      /*build_at=*/1);
+    ASSERT_EQ(snap.deps[0].mtime_ns, 0);
+
+    ASSERT_FALSE(deps_changed(pool, snap));
+    ASSERT_EQ(snap.deps[0].mtime_ns, file_mtime_ns(dep));
+}
+
+TEST_CASE(MissingTransitions) {
+    TempDir tmp;
+    auto dep = tmp.path("ghost.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, 0}
+    },
+                                      generous_build_at());
+    ASSERT_TRUE(snap.deps[0].missing);
+
+    // Still missing: unchanged.
+    ASSERT_FALSE(deps_changed(pool, snap));
+
+    // Appearing is a change.
+    tmp.touch("ghost.h", "int f();\n");
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+TEST_CASE(RemovedAfterBuild) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int f();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+
+    fs::remove(dep);
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+TEST_CASE(ForceRevalidateGoesByHash) {
+    TempDir tmp;
+    tmp.touch("dep.h", "int old_name();\n");
+    auto dep = tmp.path("dep.h");
+
+    PathPool pool;
+    auto snap = capture_deps_snapshot(pool,
+                                      {
+                                          DepFile{dep, hash_file(dep)}
+    },
+                                      generous_build_at());
+    auto recorded_mtime = snap.deps[0].mtime_ns;
+
+    // An edit that restores the recorded stat exactly would pass the fast
+    // path; force_revalidate drops it, so the hash still catches the edit.
+    tmp.touch("dep.h", "int new_name();\n");  // same length
+    set_file_mtime(dep, recorded_mtime);
+
+    snap.force_revalidate();
+    ASSERT_TRUE(deps_changed(pool, snap));
+}
+
+};  // TEST_SUITE(DepsSnapshot)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -1,0 +1,88 @@
+#include "test/temp_dir.h"
+#include "test/test.h"
+#include "command/argument_parser.h"
+#include "compile/compilation.h"
+#include "index/tu_index.h"
+#include "server/compiler/context_resolver.h"
+#include "server/compiler/indexer.h"
+#include "server/state/session_store.h"
+#include "server/state/workspace.h"
+#include "server/worker/worker_pool.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace clice::testing {
+namespace {
+
+TEST_SUITE(IndexerMerge) {
+
+kota::event_loop loop;
+Workspace workspace;
+SessionStore store;
+WorkerPool pool{loop};
+ContextResolver resolver{workspace};
+Indexer indexer{loop, workspace, pool, resolver, store};
+
+struct IndexedTU {
+    std::string data;     ///< Serialized TUIndex, as a worker would ship it.
+    std::string tu_path;  ///< The TU's canonical path inside the index.
+};
+
+/// Index a real on-disk file in-process and serialize its TUIndex.
+IndexedTU index_file(TempDir& tmp, llvm::StringRef file) {
+    std::string resource = std::string(resource_dir());
+    std::vector<std::string> args =
+        {"clang++", "-fsyntax-only", "-resource-dir", resource, "-c", std::string(file)};
+
+    CompilationParams cp;
+    cp.kind = CompilationKind::Indexing;
+    cp.directory = std::string(tmp.root);
+    for(auto& arg: args) {
+        cp.arguments.push_back(arg.c_str());
+    }
+
+    auto unit = compile(cp);
+    if(!unit.completed()) {
+        return {};
+    }
+    auto tu_index = index::TUIndex::build(unit);
+    IndexedTU result;
+    result.tu_path = tu_index.graph.paths.back();
+    llvm::raw_string_ostream os(result.data);
+    tu_index.serialize(os);
+    return result;
+}
+
+TEST_CASE(MergeSkipsMovedDisk) {
+    TempDir tmp;
+    tmp.touch("main.cpp", "int value() { return 1; }\n");
+    auto src = tmp.path("main.cpp");
+
+    auto indexed = index_file(tmp, src);
+    ASSERT_FALSE(indexed.data.empty());
+
+    indexer.merge(indexed.data.data(), indexed.data.size());
+    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    auto it = workspace.merged_indices.find(path_id);
+    ASSERT_TRUE(it != workspace.merged_indices.end());
+    ASSERT_EQ(it->second.content(), "int value() { return 1; }\n");
+
+    // The disk moved on since the rows were indexed: merging them would
+    // pair offsets with bytes they were not built from, so the merge must
+    // be skipped and the last-known snapshot kept serving.
+    tmp.touch("main.cpp", "int renamed() { return 2; }\n");
+    indexer.merge(indexed.data.data(), indexed.data.size());
+    ASSERT_EQ(it->second.content(), "int value() { return 1; }\n");
+    ASSERT_TRUE(it->second.has_contribution(indexed.tu_path));
+
+    // Once the rows describe the settled content again, the merge lands.
+    auto fresh = index_file(tmp, src);
+    ASSERT_FALSE(fresh.data.empty());
+    indexer.merge(fresh.data.data(), fresh.data.size());
+    ASSERT_EQ(it->second.content(), "int renamed() { return 2; }\n");
+}
+
+};  // TEST_SUITE(IndexerMerge)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/server/stateless_worker_tests.cpp
+++ b/tests/unit/server/stateless_worker_tests.cpp
@@ -184,10 +184,17 @@ TEST_CASE(BuildPCMRequest) {
             EXPECT_TRUE(build.build_at > 0);
             // The module source itself must be a hashed dependency: the PCM
             // cache key embeds no content, so the deps snapshot is the only
-            // thing that can see an offline edit of the interface.
+            // thing that can see an offline edit of the interface. Deps are
+            // canonicalized through real_path (on macOS the temp dir sits
+            // behind the /var -> /private/var symlink), so compare against
+            // the canonical spelling.
+            llvm::SmallString<256> canonical;
+            if(llvm::sys::fs::real_path(src, canonical)) {
+                canonical = src;
+            }
             bool source_dep = false;
             for(auto& dep: build.deps) {
-                if(dep.path == src) {
+                if(dep.path == canonical) {
                     source_dep = dep.hash != 0;
                 }
             }

--- a/tests/unit/server/stateless_worker_tests.cpp
+++ b/tests/unit/server/stateless_worker_tests.cpp
@@ -178,6 +178,21 @@ TEST_CASE(BuildPCMRequest) {
 
         auto result = co_await w.peer->send_request(params);
         EXPECT_TRUE(result.has_value());
+        if(result.has_value()) {
+            auto& build = result.value();
+            EXPECT_TRUE(build.success);
+            EXPECT_TRUE(build.build_at > 0);
+            // The module source itself must be a hashed dependency: the PCM
+            // cache key embeds no content, so the deps snapshot is the only
+            // thing that can see an offline edit of the interface.
+            bool source_dep = false;
+            for(auto& dep: build.deps) {
+                if(dep.path == src) {
+                    source_dep = dep.hash != 0;
+                }
+            }
+            EXPECT_TRUE(source_dep);
+        }
         test_done = true;
         w.peer->close_output();
     });

--- a/tests/unit/test/temp_dir.h
+++ b/tests/unit/test/temp_dir.h
@@ -9,6 +9,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace clice::testing {
@@ -73,5 +74,31 @@ private:
     /// existing elements are not moved when new ones are appended.
     std::deque<std::string> pool;
 };
+
+/// Rewrite a file's mtime, for freshness tests that simulate backdated or
+/// preserved timestamps (rsync -t, git-restore-mtime). Returns false on
+/// failure so callers can assert.
+inline bool set_file_mtime(llvm::StringRef path, std::int64_t mtime_ns) {
+    int fd = -1;
+    if(llvm::sys::fs::openFileForWrite(path,
+                                       fd,
+                                       llvm::sys::fs::CD_OpenExisting,
+                                       llvm::sys::fs::OF_Append)) {
+        return false;
+    }
+    auto time = llvm::sys::TimePoint<>(std::chrono::nanoseconds(mtime_ns));
+    bool ok = !llvm::sys::fs::setLastAccessAndModificationTime(fd, time, time);
+    llvm::sys::Process::SafelyCloseFileDescriptor(fd);
+    return ok;
+}
+
+/// A file's current mtime in nanoseconds, or -1 when it cannot be stat'ed.
+inline std::int64_t file_mtime_ns(llvm::StringRef path) {
+    llvm::sys::fs::file_status status;
+    if(llvm::sys::fs::status(path, status)) {
+        return -1;
+    }
+    return fs::mtime_ns(status);
+}
 
 }  // namespace clice::testing


### PR DESCRIPTION
## Problem

Compilation artifacts (PCH / PCM / AST / synthesized header preambles) shared one freshness snapshot whose two layers were both unsound, and the index shards carried their own, subtly different copy of the same check. Audited failure modes (bughunt F44 / F01 / F04 / F33):

- **Same-second save is permanently invisible** (F44, Critical). Layer 1 compared each dep's mtime against a single `build_at` watermark, both truncated to whole seconds, with `<=`. A header saved in the same second the dependent's compile finished satisfies `mtime <= build_at` forever — the hash layer never runs, and the dependent keeps compiling against a stale PCH until the header changes again. Reproduced with a natural type-then-save rhythm; no adversarial timing needed.
- **The snapshot describes the wrong bytes** (F01, High). `capture_deps_snapshot` ran on the master *after* the build and hashed the *current* disk. A header saved while the build was running yields a snapshot that blesses content the build never read; the poisoned entry persists via cache.json across restarts.
- **Backdated / preserved mtimes are invisible** (F04). Any content change whose mtime does not advance past the watermark (rsync -t, git-restore-mtime, clock steps) never reaches the hash layer.
- **PCM deps were never populated** (F33, High). The PCM `compile()` overload never filled `out.deps`, so every PCM snapshot was empty — and the PCM cache key embeds no content, so "graceful exit → edit a module interface offline → restart" deterministically serves a stale PCM. The module source itself also has to be a dep, which it never was.
- **Index-side gaps**: `need_update` validated only the *first* compilation context of a shard (a header shard has one per including TU); merge paired the worker's rows with content re-read from disk at merge time (position misalignment when the file changed in between); the same watermark blindness applied to shard staleness.

## Design

One freshness vocabulary everywhere, aligned with the one implementation that was already right (FileTracker):

- **Per-dep records instead of a watermark.** `DepsSnapshot` is now a list of `DepState { path_id, size, mtime_ns, hash, missing }`. Layer 1 passes only when size and nanosecond mtime are **equal** to the record — backdated or preserved mtimes can no longer masquerade as fresh. Layer 2 hashes the disk against the recorded hash; a match is a touch, not an edit, and repairs the fast path in place.
- **Hashes describe consumed bytes.** Workers hash each dependency from the compiler's own in-memory buffers (`SourceManager`) and ship `{path, hash}` pairs plus `build_at` (sampled *before* the compile) in `CompileResult` / `BuildResult`. A later disk read can no longer impersonate what the build saw.
- **Stat baselines are gated by the build start.** The master records a `{size, mtime_ns}` fast path only for deps whose mtime precedes `build_at` by a 2s filesystem-granularity guard (`fs::stat_baseline_before_ns`). Anything newer keeps only the consumed hash and re-earns its fast path through one hash comparison. The synthesized header-preamble chain (a third producer of these records) applies the same guard.
- **PCM deps populated** (`out.deps = unit.deps()` + the canonicalized module source with its content hash).
- **Index shards use the same scheme.** `TUIndex` ships per-path consumed hashes; `MergedIndex::merge` records `DepStamp` fast paths under the same guard (new, backward-compatible flatbuffer field); `need_update` validates **every** compilation context, in-memory and serialized; the indexer skips a merge whose rows no longer hash to the disk content and keeps the last-known snapshot serving instead of stripping it.
- **Formats migrate in place.** Old cache.json entries load with zeroed baselines (unknown `build_at` skipped, missing fields defaulted) and revalidate by hash once; old shards without `dep_stamps` do the same. No cache or index version bump, nothing is rebuilt on upgrade.

`force_revalidate` (previously `build_at = 0`) now zeroes the per-dep fast paths while keeping the hashes, which is the same semantics expressed per record.

## Testing

- New `DepsSnapshot` unit suite: the full freshness truth table — same-second edit, backdated edit, touch-repairs-fast-path, poisoned-capture detection, no-baseline convergence, missing-file transitions, force_revalidate.
- New `IndexerMerge` unit suite: a merge whose rows describe outdated disk content is skipped and the last-known snapshot (rows included) keeps serving; the settled reindex lands.
- `MergedIndex`: multi-context `need_update` exercised for both contexts and through a serialized view; backdated edits; stamp round-trip.
- Integration: same-second save (deliberately no mtime sleep), backdated header change (no didSave), PCM offline-interface-edit across restart, cache.json PCM entries contain the module source with non-zero hashes, old-format cache.json upgrade path.
- Existing suites adapted where the schema changed (assertions strengthened, none weakened).
- Local runs: Debug (ASAN) 909 unit / 271 integration / 3 smoke, RelWithDebInfo 927 unit — all green.
- Pre-PR review: 3 independent reviewers (correctness / style / tests); all findings addressed in this branch (notably: the chain-snapshot mtime guard, merge-skip sweep protection, deterministic multi-context regression tests).