### PR TITLE
fix(tests): keep same-size edits out of the stamp time tick

### DIFF
--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -731,7 +731,13 @@ TEST_CASE(NeedUpdateChecksAllContexts) {
     auto view = index::MergedIndex(s);
     ASSERT_FALSE(view.need_update());
 
+    // Same-size rewrites move the mtime explicitly: Windows file times
+    // advance in ~16ms ticks, so a rewrite landing in the stamp's tick
+    // reproduces size AND mtime exactly and the stat fast path rightly
+    // trusts it. A real edit arrives long after the stamp; the bump
+    // models that and pins these verdicts on the hash layer.
     tmp.touch("b.h", "int b3();\n");
+    set_file_mtime(b, file_mtime_ns(b) + 5'000'000'000);
     ASSERT_TRUE(view.need_update());
 
     // Restore b (fresh again via the hash layer), then break a: the verdict
@@ -739,6 +745,7 @@ TEST_CASE(NeedUpdateChecksAllContexts) {
     tmp.touch("b.h", "int b2();\n");
     ASSERT_FALSE(view.need_update());
     tmp.touch("a.h", "int a3();\n");
+    set_file_mtime(a, file_mtime_ns(a) + 5'000'000'000);
     ASSERT_TRUE(view.need_update());
 }
 
@@ -787,8 +794,11 @@ TEST_CASE(SerializedStampsValidate) {
     set_file_mtime(dep, file_mtime_ns(dep) + 5'000'000'000);
     ASSERT_FALSE(view.need_update());
 
-    // A real edit is caught by the hash layer.
+    // A real edit is caught by the hash layer. The explicit mtime bump
+    // keeps the same-size rewrite out of the stamp's Windows time tick
+    // (see NeedUpdateChecksAllContexts).
     tmp.touch("dep.h", "int g();\n");
+    set_file_mtime(dep, file_mtime_ns(dep) + 5'000'000'000);
     ASSERT_TRUE(view.need_update());
 }
 


### PR DESCRIPTION
Both Windows CI jobs are red on main since #507 (its own merge run 29258064794 failed): `MergedIndex.NeedUpdateChecksAllContexts` and `MergedIndex.SerializedStampsValidate` fail deterministically with `need_update() expected true, got false`.

## Root cause

Windows file times advance in ~16ms clock ticks. The failing assertions perform **same-size** rewrites (`int b2();` → `int b3();`, `int f();` → `int g();`) moments after the stamp was recorded; when the rewrite lands in the same tick, the file reproduces the stamp's size **and** mtime exactly, so the stat fast path — equality-based by design — rightly reports fresh, and the hash layer the assertions meant to exercise is never consulted. On Linux/macOS nanosecond timestamps always move, which is why only Windows fails.

**Production is immune**: `merge` only records a stamp for files untouched since two seconds before the build (`stat_baseline_before_ns`), so a stamped file's later edit can never share its tick. The tests defeat that guard deliberately (`generous_build_at()` = now + 10s) to earn the fast path, which is what exposes them to the tick.

## Fix

After each same-size rewrite, bump the file's mtime explicitly (`set_file_mtime`, +5s) — modelling the reality that a genuine edit arrives long after the stamp, and pinning those verdicts on the hash layer as intended. Test-only change; no product code touched.