### PR TITLE
refactor(server): RAII cleanup and cancellable AST tasks

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -41,7 +41,7 @@ set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG 02b255f
+    GIT_TAG f2cdf65
 )
 
 set(KOTA_ENABLE_ZEST ON)

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -352,7 +352,6 @@ void Compiler::init_compile_graph() {
                 workspace.build_crashes.on_crash(budget_key);
             });
         if(!result.has_value() || !result.value().success) {
-            workspace.store->abort(pending);
             if(expected_build_failure(result)) {
                 LOG_WARN("BuildPCM failed for module {}: {}",
                          module_name,
@@ -592,8 +591,6 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         });
 
     if(!result.has_value() || !result.value().success) {
-        workspace.store->abort(pending);
-        workspace.store->abort(pending_idx);
         if(expected_build_failure(result)) {
             LOG_WARN("PCH build failed for {}: {}", path, build_failure_message(result));
         } else {
@@ -622,7 +619,7 @@ kota::task<bool> Compiler::ensure_pch(Session& session,
         PairCommit outcome;
         auto pch_path = workspace.store->commit(std::move(pending));
         if(!pch_path) {
-            workspace.store->abort(pending_idx);
+            // pending_idx cleans its own tmp blob when the frame unwinds.
             return outcome;
         }
         outcome.pch_path = std::move(*pch_path);
@@ -843,13 +840,24 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     // get dirty again while we were flying".
     auto epoch = session->dirty_epoch;
 
-    auto finish_compile = [&]() {
-        if(session->compiling == pc) {
-            session->compiling.reset();
+    // RAII, not a manual call: kotatsu cancellation destroys a suspended
+    // frame without resuming it (compile_tasks.cancel() at shutdown), and
+    // a finish that never runs would leave session->compiling set and
+    // `done` unset — every waiter in ensure_compiled hangs and the session
+    // is bricked. Same pattern as BuildingGuard and UnitGuard.
+    struct [[nodiscard]] FinishCompile {
+        std::shared_ptr<Session>& session;
+        std::shared_ptr<Session::PendingCompile>& pc;
+        std::uint32_t pid;
+
+        ~FinishCompile() {
+            if(session->compiling == pc) {
+                session->compiling.reset();
+            }
+            LOG_INFO("ensure_compiled: finish path_id={}", pid);
+            pc->done.set();
         }
-        LOG_INFO("ensure_compiled: finish path_id={}", pid);
-        pc->done.set();
-    };
+    } finish_compile{session, pc, pid};
 
     LOG_INFO("ensure_compiled: starting compile path_id={} gen={}", pid, gen);
 
@@ -906,7 +914,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         pc->deps_done = true;
         if(!deps_ok) {
             LOG_WARN("Dependency preparation failed for {}, skipping compile", uri_str);
-            finish_compile();
             co_return;
         }
 
@@ -915,7 +922,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                      session->generation,
                      gen,
                      uri_str);
-            finish_compile();
             co_return;
         }
 
@@ -929,7 +935,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             LOG_WARN("ensure_compiled: {} quarantined during dependency prep", uri_str);
             session->quarantine.spend_probe();
             publish_quarantined(session, source, suffix_line_limit);
-            finish_compile();
             co_return;
         }
 
@@ -982,7 +987,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                      session->generation,
                      gen,
                      uri_str);
-            finish_compile();
             co_return;
         }
 
@@ -1013,7 +1017,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                 };
                 on_output.emit(session);
             }
-            finish_compile();
             co_return;
         }
 
@@ -1025,7 +1028,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // ast_dirty is still set, so the next request re-runs the trial.
         if(trial_round && session->dirty_epoch != epoch) {
             LOG_INFO("Discarding invalidated self-containment probe for {}", uri_str);
-            finish_compile();
             co_return;
         }
 
@@ -1079,7 +1081,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         }
 
         auto version = session->version;
-        finish_compile();
 
         LOG_PERF("request", "kind=Compile file={} total_ms={}", file_path, timer.ms());
         // The preamble's share lives with the PCH; the compile result
@@ -1100,8 +1101,6 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             on_indexing_needed();
         co_return;
     }
-
-    finish_compile();
 }
 
 /// AST and diagnostics have been published to the client.

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -192,7 +192,6 @@ static std::optional<CacheStore::PendingEntry>
     llvm::raw_fd_ostream os(pending.tmp_path, ec);
     if(ec) {
         LOG_WARN("Failed to write index blob {}: {}", key, ec.message());
-        store.abort(pending);
         return std::nullopt;
     }
     serialize(os);
@@ -202,7 +201,6 @@ static std::optional<CacheStore::PendingEntry>
     if(os.has_error()) {
         LOG_WARN("Failed to write index blob {}: {}", key, os.error().message());
         os.clear_error();
-        store.abort(pending);
         return std::nullopt;
     }
     return pending;
@@ -257,10 +255,8 @@ kota::task<> Indexer::save() {
     auto committed =
         co_await kota::queue([&] { return store.commit(std::move(*project_pending)); });
     if(!committed.has_value() || !committed.value().has_value()) {
+        // The shard entries clean their own tmp blobs up on destruction.
         LOG_WARN("Failed to commit ProjectIndex blob, dropping {} shard blobs", shards.size());
-        for(auto& pending: shards) {
-            store.abort(pending);
-        }
         co_return;
     }
 

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -192,6 +192,15 @@ void StatefulWorker::register_handlers() {
             doc->pcms.try_emplace(name, pcm_path);
         }
 
+        // The old AST describes the text this request just replaced: drop
+        // it before the cancellable await, or a cancellation landing while
+        // the work is still queued would wake waiters with the previous
+        // unit installed next to the new buffer — with_ast_or would serve
+        // stale offsets as current. Waiters observe has_ast == false and
+        // return their missing value until a compile lands.
+        doc->has_ast = false;
+        doc->unit = CompilationUnit(nullptr);
+
         // The parse itself is cancellable: CompilationParams::stop is
         // polled after every top-level declaration, so the hook reaches
         // into the middle of the AST build instead of waiting for it to

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -1,5 +1,6 @@
 #include "server/worker/stateful_worker.h"
 
+#include <atomic>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -44,6 +45,19 @@ struct DocumentEntry {
 
     // Per-document serialization mutex
     kota::mutex strand;
+};
+
+/// RAII ownership of a locked strand. kotatsu cancellation destroys a
+/// suspended coroutine frame without resuming it — a peer close (or a
+/// wire-level $/cancelRequest) cancels the handler task while it awaits the
+/// thread pool — so a manual unlock after the await would never run on that
+/// path and the document's strand would deadlock forever.
+struct [[nodiscard]] StrandGuard {
+    kota::mutex& strand;
+
+    ~StrandGuard() {
+        strand.unlock();
+    }
 };
 
 class StatefulWorker {
@@ -103,14 +117,24 @@ class StatefulWorker {
 
         co_await doc->ast_ready.wait();
         co_await doc->strand.lock();
+        StrandGuard strand_guard{doc->strand};
 
-        auto result = co_await kota::queue([&]() -> R {
-            if(!doc->has_ast || (!doc->unit.completed() && !doc->unit.fatal_error()))
-                return std::move(missing);
-            return fn(*doc);
-        });
+        // The frame stays alive until fn returns even when the handler is
+        // cancelled mid-await, so the by-reference captures are safe; the
+        // hook just lets a cancelled query return its missing value instead
+        // of walking the whole AST for a result nobody will read.
+        std::atomic<bool> cancelled{false};
+        auto result = co_await kota::queue(
+            [&]() -> R {
+                if(cancelled.load(std::memory_order_relaxed)) {
+                    return std::move(missing);
+                }
+                if(!doc->has_ast || (!doc->unit.completed() && !doc->unit.fatal_error()))
+                    return std::move(missing);
+                return fn(*doc);
+            },
+            [&] { cancelled.store(true, std::memory_order_relaxed); });
 
-        doc->strand.unlock();
         co_return result.value();
     }
 
@@ -141,6 +165,20 @@ void StatefulWorker::register_handlers() {
 
         co_await doc->strand.lock();
 
+        // Every exit — including a cancellation that destroys this frame at
+        // the queue await below — must release the strand and wake the AST
+        // waiters: an unset ast_ready would hang every later query for this
+        // document (they observe has_ast == false and return their missing
+        // value; the next Compile sets a real AST).
+        struct [[nodiscard]] CompileGuard {
+            DocumentEntry& doc;
+
+            ~CompileGuard() {
+                doc.ast_ready.set();
+                doc.strand.unlock();
+            }
+        } guard{*doc};
+
         // Copy params to doc AFTER acquiring the strand lock, so that
         // concurrent Compile requests waiting on the strand don't
         // overwrite our fields before we use them.
@@ -154,56 +192,66 @@ void StatefulWorker::register_handlers() {
             doc->pcms.try_emplace(name, pcm_path);
         }
 
-        auto compile_result = co_await kota::queue([&]() -> worker::CompileResult {
-            ScopedTimer timer;
+        // The parse itself is cancellable: CompilationParams::stop is
+        // polled after every top-level declaration, so the hook reaches
+        // into the middle of the AST build instead of waiting for it to
+        // finish; an interrupted unit reports !completed() and the phases
+        // after it are skipped like any other incomplete compile. The
+        // document stays coherent at every early exit (unit and has_ast
+        // are set together).
+        auto stop = std::make_shared<std::atomic_bool>(false);
+        auto compile_result = co_await kota::queue(
+            [&]() -> worker::CompileResult {
+                ScopedTimer timer;
 
-            CompilationParams cp;
-            cp.kind = CompilationKind::Content;
-            fill_args(cp, doc->directory, doc->arguments);
-            if(!doc->pch.first.empty()) {
-                cp.pch = doc->pch;
-            }
-            cp.add_remapped_file(params.path, doc->text);
-            for(auto& entry: doc->pcms) {
-                cp.pcms.try_emplace(entry.getKey(), entry.getValue());
-            }
+                CompilationParams cp;
+                cp.kind = CompilationKind::Content;
+                fill_args(cp, doc->directory, doc->arguments);
+                if(!doc->pch.first.empty()) {
+                    cp.pch = doc->pch;
+                }
+                cp.add_remapped_file(params.path, doc->text);
+                for(auto& entry: doc->pcms) {
+                    cp.pcms.try_emplace(entry.getKey(), entry.getValue());
+                }
+                cp.stop = stop;
 
-            doc->unit = compile(cp);
-            doc->has_ast = true;
+                doc->unit = compile(cp);
+                doc->has_ast = true;
 
-            worker::CompileResult result;
-            result.version = doc->version;
-            if(doc->unit.completed() || doc->unit.fatal_error()) {
-                auto diags = feature::diagnostics(doc->unit);
-                auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(diags);
-                result.diagnostics = kota::codec::RawValue{json ? std::move(*json) : "[]"};
-                LOG_INFO("Compile done: path={}, {}ms, {} diags, fatal={}",
-                         params.path,
-                         timer.ms(),
-                         diags.size(),
-                         doc->unit.fatal_error());
-            } else {
-                result.diagnostics = kota::codec::RawValue{"[]"};
-                LOG_WARN("Compile incomplete: path={}, {}ms", params.path, timer.ms());
-            }
-            result.memory_usage = 0;  // TODO: query actual memory
-            if(doc->unit.completed()) {
-                result.inactive_regions =
-                    feature::inactive_regions(doc->unit, params.open_conditionals, doc->pch.second)
-                        .regions;
-                result.build_at = doc->unit.build_at().count();
-                result.deps = doc->unit.deps();
+                worker::CompileResult result;
+                result.version = doc->version;
+                if(doc->unit.completed() || doc->unit.fatal_error()) {
+                    auto diags = feature::diagnostics(doc->unit);
+                    auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(diags);
+                    result.diagnostics = kota::codec::RawValue{json ? std::move(*json) : "[]"};
+                    LOG_INFO("Compile done: path={}, {}ms, {} diags, fatal={}",
+                             params.path,
+                             timer.ms(),
+                             diags.size(),
+                             doc->unit.fatal_error());
+                } else {
+                    result.diagnostics = kota::codec::RawValue{"[]"};
+                    LOG_WARN("Compile incomplete: path={}, {}ms", params.path, timer.ms());
+                }
+                result.memory_usage = 0;  // TODO: query actual memory
+                if(doc->unit.completed() && !stop->load(std::memory_order_relaxed)) {
+                    result.inactive_regions = feature::inactive_regions(doc->unit,
+                                                                        params.open_conditionals,
+                                                                        doc->pch.second)
+                                                  .regions;
+                    result.build_at = doc->unit.build_at().count();
+                    result.deps = doc->unit.deps();
 
-                // Build index for main file only (interested_only=true).
-                auto tu_index = index::TUIndex::build(doc->unit, true);
-                llvm::raw_string_ostream os(result.tu_index_data);
-                tu_index.serialize(os);
-            }
-            return result;
-        });
+                    // Build index for main file only (interested_only=true).
+                    auto tu_index = index::TUIndex::build(doc->unit, true);
+                    llvm::raw_string_ostream os(result.tu_index_data);
+                    tu_index.serialize(os);
+                }
+                return result;
+            },
+            [stop] { stop->store(true, std::memory_order_relaxed); });
 
-        doc->strand.unlock();
-        doc->ast_ready.set();
         shrink_if_over_limit();
 
         co_return compile_result.value();

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -1,5 +1,6 @@
 #include "server/worker/stateless_worker.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <format>
 #include <optional>
@@ -99,13 +100,15 @@ static std::optional<std::string> write_preamble_state(llvm::StringRef blob,
     return std::nullopt;
 }
 
-static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
+static worker::BuildResult handle_build_pch(const worker::BuildParams& params,
+                                            const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
 
     CompilationParams cp;
     cp.kind = CompilationKind::Preamble;
     fill_args(cp, params.directory, params.arguments);
     cp.add_remapped_file(params.file, params.text, params.preamble_bound);
+    cp.stop = stop;
 
     // When the master provides an output path it is already a tmp path
     // allocated by its CacheStore: write directly, the master commits
@@ -125,7 +128,10 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
 
     PCHInfo pch_info;
     auto unit = compile(cp, pch_info);
-    bool success = unit.completed();
+    // A cancelled parse reports !completed(); the extra check catches a
+    // cancellation landing between the parse and the serialization, whose
+    // blob nobody will read. The tmp file is removed like any failed build.
+    bool success = unit.completed() && !stop->load(std::memory_order_relaxed);
     auto build_at = unit.build_at().count();
 
     std::string errors;
@@ -175,7 +181,8 @@ static worker::BuildResult handle_build_pch(const worker::BuildParams& params) {
     }
 }
 
-static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
+static worker::BuildResult handle_build_pcm(const worker::BuildParams& params,
+                                            const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
 
     CompilationParams cp;
@@ -184,6 +191,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
     for(auto& [name, path]: params.pcms) {
         cp.pcms.try_emplace(name, path);
     }
+    cp.stop = stop;
 
     // See handle_build_pch: a provided output path is the master's tmp path.
     std::string tmp_path;
@@ -201,7 +209,7 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
 
     PCMInfo pcm_info;
     auto unit = compile(cp, pcm_info);
-    bool success = unit.completed();
+    bool success = unit.completed() && !stop->load(std::memory_order_relaxed);
     auto build_at = unit.build_at().count();
 
     std::string errors;
@@ -236,7 +244,8 @@ static worker::BuildResult handle_build_pcm(const worker::BuildParams& params) {
     }
 }
 
-static worker::BuildResult handle_index(const worker::BuildParams& params) {
+static worker::BuildResult handle_index(const worker::BuildParams& params,
+                                        const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
 
     CompilationParams cp;
@@ -245,6 +254,7 @@ static worker::BuildResult handle_index(const worker::BuildParams& params) {
     for(auto& [name, path]: params.pcms) {
         cp.pcms.try_emplace(name, path);
     }
+    cp.stop = stop;
 
     auto unit = compile(cp);
     if(!unit.completed()) {
@@ -252,6 +262,11 @@ static worker::BuildResult handle_index(const worker::BuildParams& params) {
         return {false, "Index compilation failed"};
     }
 
+    // Building and serializing the index costs a large share of the pass;
+    // skip both when the cancellation landed after the parse finished.
+    if(stop->load(std::memory_order_relaxed)) {
+        return {false, "Index cancelled"};
+    }
     auto tu_index = index::TUIndex::build(unit);
     std::string serialized;
     llvm::raw_string_ostream os(serialized);
@@ -267,7 +282,8 @@ static worker::BuildResult handle_index(const worker::BuildParams& params) {
     return result;
 }
 
-static worker::BuildResult handle_completion(const worker::BuildParams& params) {
+static worker::BuildResult handle_completion(const worker::BuildParams& params,
+                                             const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
 
     CompilationParams cp;
@@ -281,6 +297,7 @@ static worker::BuildResult handle_completion(const worker::BuildParams& params) 
     }
     cp.add_remapped_file(params.file, params.text);
     cp.completion = {params.file, params.offset};
+    cp.stop = stop;
 
     auto items = feature::code_complete(cp);
     LOG_DEBUG("Completion done: {} items, {}ms", items.size(), timer.ms());
@@ -290,7 +307,8 @@ static worker::BuildResult handle_completion(const worker::BuildParams& params) 
     return result;
 }
 
-static worker::BuildResult handle_signature_help(const worker::BuildParams& params) {
+static worker::BuildResult handle_signature_help(const worker::BuildParams& params,
+                                                 const std::shared_ptr<std::atomic_bool>& stop) {
     ScopedTimer timer;
 
     CompilationParams cp;
@@ -304,6 +322,7 @@ static worker::BuildResult handle_signature_help(const worker::BuildParams& para
     }
     cp.add_remapped_file(params.file, params.text);
     cp.completion = {params.file, params.offset};
+    cp.stop = stop;
 
     auto help = feature::signature_help(cp);
     LOG_DEBUG("SignatureHelp done: {}ms", timer.ms());
@@ -362,20 +381,32 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
     peer.on_request([&](RequestContext& ctx,
                         const worker::BuildParams& params) -> RequestResult<worker::BuildParams> {
         using K = worker::BuildKind;
-        auto result = co_await kota::queue([&]() -> worker::BuildResult {
-            switch(params.kind) {
-                case K::BuildPCH: return handle_build_pch(params);
-                case K::BuildPCM: return handle_build_pcm(params);
-                case K::Index: {
-                    ScopedNice guard;
-                    return handle_index(params);
+        // A cancellation (peer close, wire-level $/cancelRequest) dequeues
+        // work that has not started; work already on the pool thread learns
+        // through the hook: the shared flag doubles as CompilationParams::
+        // stop, which clang polls after every top-level declaration, so
+        // even the parse itself stops instead of running to completion for
+        // a result nobody will read.
+        auto stop = std::make_shared<std::atomic_bool>(false);
+        auto result = co_await kota::queue(
+            [&]() -> worker::BuildResult {
+                if(stop->load(std::memory_order_relaxed)) {
+                    return {false, "Build cancelled"};
                 }
-                case K::Completion: return handle_completion(params);
-                case K::SignatureHelp: return handle_signature_help(params);
-                case K::Format: return handle_format(params);
-            }
-            return {false, "Unknown build kind"};
-        });
+                switch(params.kind) {
+                    case K::BuildPCH: return handle_build_pch(params, stop);
+                    case K::BuildPCM: return handle_build_pcm(params, stop);
+                    case K::Index: {
+                        ScopedNice guard;
+                        return handle_index(params, stop);
+                    }
+                    case K::Completion: return handle_completion(params, stop);
+                    case K::SignatureHelp: return handle_signature_help(params, stop);
+                    case K::Format: return handle_format(params);
+                }
+                return {false, "Unknown build kind"};
+            },
+            [stop] { stop->store(true, std::memory_order_relaxed); });
         co_return result.value();
     });
 

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -604,9 +604,9 @@ std::expected<std::string, std::error_code> CacheStore::commit(PendingEntry pend
     return final_path;
 }
 
-void CacheStore::abort(const PendingEntry& pending) {
-    if(!pending.tmp_path.empty()) {
-        llvm::sys::fs::remove(pending.tmp_path);
+void CacheStore::PendingEntry::remove_tmp() {
+    if(!tmp_path.empty()) {
+        llvm::sys::fs::remove(tmp_path);
     }
 }
 

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -86,9 +86,11 @@ struct CacheNamespace {
 class CacheStore {
 public:
     /// A two-phase write in progress.  The caller (or a worker process on
-    /// its behalf) writes the blob to tmp_path, then either commits or
-    /// aborts.  Dropping a PendingEntry without commit/abort leaks the tmp
-    /// file until the next open() sweep.
+    /// its behalf) writes the blob to tmp_path, then commits.  Self-cleaning:
+    /// an entry destroyed without being committed removes its tmp file —
+    /// kotatsu cancellation destroys a suspended coroutine frame without
+    /// resuming it, so a manual abort after the await would never run on
+    /// that path and the tmp blob would leak until the next open() sweep.
     struct PendingEntry {
         std::string ns;
         std::string key;
@@ -96,6 +98,42 @@ public:
 
         /// Whether this write targets the key's aux blob (begin_store_aux).
         bool aux = false;
+
+        PendingEntry() = default;
+
+        PendingEntry(std::string ns, std::string key, std::string tmp_path, bool aux = false) :
+            ns(std::move(ns)), key(std::move(key)), tmp_path(std::move(tmp_path)), aux(aux) {}
+
+        PendingEntry(const PendingEntry&) = delete;
+        PendingEntry& operator=(const PendingEntry&) = delete;
+
+        PendingEntry(PendingEntry&& other) noexcept :
+            ns(std::move(other.ns)), key(std::move(other.key)), tmp_path(std::move(other.tmp_path)),
+            aux(other.aux) {
+            other.tmp_path.clear();
+        }
+
+        PendingEntry& operator=(PendingEntry&& other) noexcept {
+            if(this != &other) {
+                remove_tmp();
+                ns = std::move(other.ns);
+                key = std::move(other.key);
+                tmp_path = std::move(other.tmp_path);
+                aux = other.aux;
+                other.tmp_path.clear();
+            }
+            return *this;
+        }
+
+        ~PendingEntry() {
+            remove_tmp();
+        }
+
+    private:
+        /// Idempotent: commit() consumes the entry by value, and after its
+        /// rename the tmp path no longer exists — removing a missing file
+        /// is a no-op.
+        void remove_tmp();
     };
 
     /// Open (creating if necessary) the store under `root`.  Any sibling
@@ -142,9 +180,6 @@ public:
     /// the stale destination is removed and the rename retried, and if the
     /// new blob still cannot be published an error is returned.
     std::expected<std::string, std::error_code> commit(PendingEntry pending);
-
-    /// Cancel a two-phase write and delete the tmp file.
-    void abort(const PendingEntry& pending);
 
     /// Remove a blob.  Primarily for Persistent namespaces, whose cleanup
     /// is the caller's mark-and-sweep; LRU namespaces rarely need it.

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -322,8 +322,14 @@ TEST_CASE(StopUnblocksCompileWaiters) {
         };
         group.spawn(waiter());
 
-        // Let the compile reach the stateful worker, then tear down.
-        co_await kota::sleep(300);
+        // Deterministic in-flight state: the pending compile is registered
+        // and the waiter still parked, so stop() provably cancels a
+        // suspended run_compile instead of racing one that already landed.
+        for(int i = 0; i < 100 && session->compiling == nullptr; ++i) {
+            co_await kota::sleep(10);
+        }
+        CO_ASSERT_TRUE(session->compiling != nullptr);
+        CO_ASSERT_FALSE(waiter_done);
         co_await compiler.stop();
 
         // Bounded: a waiter left hanging (the pre-RAII bug) fails this

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -302,7 +302,8 @@ TEST_CASE(StopUnblocksCompileWaiters) {
 
     auto session = std::make_shared<Session>();
     session->path_id = workspace.path_pool.intern(src);
-    session->text = "#include <vector>\n#include <string>\nint main() { return 0; }\n";
+    session->text =
+        "#include <vector>\n#include <string>\n#include <algorithm>\n" "#include <regex>\nint main() { return 0; }\n";
 
     bool waiter_done = false;
     bool done = false;
@@ -324,6 +325,15 @@ TEST_CASE(StopUnblocksCompileWaiters) {
         // Let the compile reach the stateful worker, then tear down.
         co_await kota::sleep(300);
         co_await compiler.stop();
+
+        // Bounded: a waiter left hanging (the pre-RAII bug) fails this
+        // cleanly here instead of hanging the whole binary.
+        for(int i = 0; i < 100 && !waiter_done; ++i) {
+            co_await kota::sleep(100);
+        }
+        if(!waiter_done) {
+            group.cancel();
+        }
         co_await group.join();
 
         EXPECT_TRUE(waiter_done);

--- a/tests/unit/server/compiler_tests.cpp
+++ b/tests/unit/server/compiler_tests.cpp
@@ -283,6 +283,63 @@ TEST_CASE(PchCrashBlocksBuild) {
     logging::reset_anomaly_for_testing();
 }
 
+TEST_CASE(StopUnblocksCompileWaiters) {
+    // Compiler::stop() cancels compile_tasks, destroying a suspended
+    // run_compile frame without resuming it. The finish must be RAII: a
+    // waiter parked on the pending compile's `done` event would otherwise
+    // hang forever and the session would stay bricked behind `compiling`.
+    logging::set_anomaly_trap_for_testing([](logging::AnomalyId) {});
+
+    TempDir tmp;
+    tmp.touch("slow.cpp", "");
+    auto src = tmp.path("slow.cpp");
+
+    kota::event_loop loop;
+    Workspace workspace;
+    ContextResolver contexts(workspace);
+    WorkerPool pool(loop);
+    Compiler compiler(loop, workspace, contexts, pool);
+
+    auto session = std::make_shared<Session>();
+    session->path_id = workspace.path_pool.intern(src);
+    session->text = "#include <vector>\n#include <string>\nint main() { return 0; }\n";
+
+    bool waiter_done = false;
+    bool done = false;
+    auto body = [&]() -> kota::task<> {
+        WorkerPoolOptions opts;
+        opts.self_path = clice_binary();
+        opts.stateless_count = 0;
+        opts.stateful_count = 1;
+        CO_ASSERT_TRUE(pool.start(opts));
+        co_await kota::sleep(500);
+
+        kota::task_group<> group(loop);
+        auto waiter = [&]() -> kota::task<> {
+            [[maybe_unused]] bool ok = co_await compiler.ensure_compiled(session);
+            waiter_done = true;
+        };
+        group.spawn(waiter());
+
+        // Let the compile reach the stateful worker, then tear down.
+        co_await kota::sleep(300);
+        co_await compiler.stop();
+        co_await group.join();
+
+        EXPECT_TRUE(waiter_done);
+        EXPECT_TRUE(session->compiling == nullptr);
+
+        co_await pool.stop();
+        done = true;
+    };
+    auto task = body();
+    loop.schedule(task);
+    loop.run();
+    EXPECT_TRUE(done);
+
+    logging::reset_anomaly_for_testing();
+}
+
 TEST_CASE(PoisonPreambleBudget) {
     // One document's quarantine cannot contain a poison preamble: the PCH
     // is shared, so every session with the same preamble would re-trigger

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -52,6 +52,60 @@ TEST_CASE(CompileRequest) {
     ASSERT_TRUE(test_done);
 }
 
+TEST_CASE(CancelledCompileFreesStrand) {
+    TempDir tmp;
+    tmp.touch("cancel_test.cpp", "");
+    auto src = tmp.path("cancel_test.cpp");
+
+    WorkerHandle w;
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+
+    bool test_done = false;
+
+    w.run([&]() -> kota::task<> {
+        // Slow enough that the cancel lands while the AST build is still on
+        // the pool thread.
+        worker::CompileParams cp;
+        cp.path = src;
+        cp.version = 1;
+        cp.text = "#include <vector>\n#include <string>\nint main() { return 0; }\n";
+        cp.directory = "/tmp";
+        cp.arguments = make_args(src);
+        cp.pch = {"", 0};
+        cp.pcms = {};
+
+        kota::cancellation_source source;
+        kota::ipc::request_options opts;
+        opts.token = source.token();
+
+        bool first_failed = false;
+        kota::task_group<> group(w.loop);
+        auto sender = [&]() -> kota::task<> {
+            auto result = co_await w.peer->send_request(cp, opts);
+            first_failed = !result.has_value();
+        };
+        group.spawn(sender());
+        co_await kota::sleep(150, w.loop);
+        source.cancel();
+        co_await group.join();
+        EXPECT_TRUE(first_failed);
+
+        // The strand must be free again: a second compile of the same
+        // document completes instead of hanging behind the cancelled one's
+        // never-released lock (the guard releases it when the cancelled
+        // handler's frame unwinds).
+        cp.version = 2;
+        auto retry = co_await w.peer->send_request(cp);
+        CO_ASSERT_TRUE(retry.has_value());
+        EXPECT_EQ(retry.value().version, 2);
+
+        test_done = true;
+        w.peer->close_output();
+    });
+
+    ASSERT_TRUE(test_done);
+}
+
 TEST_CASE(HoverWithoutCompile) {
     WorkerHandle w;
     ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -68,7 +68,8 @@ TEST_CASE(CancelledCompileFreesStrand) {
         worker::CompileParams cp;
         cp.path = src;
         cp.version = 1;
-        cp.text = "#include <vector>\n#include <string>\nint main() { return 0; }\n";
+        cp.text =
+            "#include <vector>\n#include <string>\n#include <algorithm>\n" "#include <regex>\nint main() { return 0; }\n";
         cp.directory = "/tmp";
         cp.arguments = make_args(src);
         cp.pch = {"", 0};
@@ -93,11 +94,67 @@ TEST_CASE(CancelledCompileFreesStrand) {
         // The strand must be free again: a second compile of the same
         // document completes instead of hanging behind the cancelled one's
         // never-released lock (the guard releases it when the cancelled
-        // handler's frame unwinds).
+        // handler's frame unwinds). Bounded so a regression is a clean,
+        // attributable failure instead of a CI-wide timeout.
         cp.version = 2;
-        auto retry = co_await w.peer->send_request(cp);
+        kota::ipc::request_options retry_opts;
+        retry_opts.timeout = std::chrono::milliseconds(30'000);
+        auto retry = co_await w.peer->send_request(cp, retry_opts);
         CO_ASSERT_TRUE(retry.has_value());
         EXPECT_EQ(retry.value().version, 2);
+
+        test_done = true;
+        w.peer->close_output();
+    });
+
+    ASSERT_TRUE(test_done);
+}
+
+TEST_CASE(CancelledQueryFreesStrand) {
+    TempDir tmp;
+    tmp.touch("query_cancel.cpp", "");
+    auto src = tmp.path("query_cancel.cpp");
+
+    WorkerHandle w;
+    ASSERT_TRUE(w.spawn(4ULL * 1024 * 1024 * 1024));
+
+    bool test_done = false;
+
+    w.run([&]() -> kota::task<> {
+        worker::CompileParams cp;
+        cp.path = src;
+        cp.version = 1;
+        cp.text = "int value() { return 42; }\n";
+        cp.directory = "/tmp";
+        cp.arguments = make_args(src);
+        cp.pch = {"", 0};
+        cp.pcms = {};
+        auto compiled = co_await w.peer->send_request(cp);
+        CO_ASSERT_TRUE(compiled.has_value());
+
+        // Queries take the strand through with_ast_or: a cancelled query
+        // must release it on unwind like a cancelled compile does.
+        worker::QueryParams qp;
+        qp.kind = worker::QueryKind::SemanticTokens;
+        qp.path = src;
+
+        kota::cancellation_source source;
+        kota::ipc::request_options opts;
+        opts.token = source.token();
+
+        kota::task_group<> group(w.loop);
+        auto sender = [&]() -> kota::task<> {
+            [[maybe_unused]] auto result = co_await w.peer->send_request(qp, opts);
+        };
+        group.spawn(sender());
+        source.cancel();
+        co_await group.join();
+
+        // Bounded: a still-locked strand fails this cleanly via timeout.
+        kota::ipc::request_options retry_opts;
+        retry_opts.timeout = std::chrono::milliseconds(30'000);
+        auto retry = co_await w.peer->send_request(qp, retry_opts);
+        CO_ASSERT_TRUE(retry.has_value());
 
         test_done = true;
         w.peer->close_output();

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -1,3 +1,4 @@
+#include <format>
 #include <string>
 #include <vector>
 
@@ -63,13 +64,21 @@ TEST_CASE(CancelledCompileFreesStrand) {
     bool test_done = false;
 
     w.run([&]() -> kota::task<> {
-        // Slow enough that the cancel lands while the AST build is still on
-        // the pool thread.
+        // A deterministically slow TU: two hundred thousand trivial
+        // declarations keep the parse far past the cancellation tick on any
+        // hardware — two consecutive macOS runners completed a whole
+        // four-STL-header compile roundtrip inside 20ms — while the
+        // per-declaration stop poll keeps the cancelled remainder cheap.
+        std::string text;
+        text.reserve(1 << 22);
+        for(int i = 0; i < 200'000; ++i) {
+            text += std::format("int v{};\n", i);
+        }
+
         worker::CompileParams cp;
         cp.path = src;
         cp.version = 1;
-        cp.text =
-            "#include <vector>\n#include <string>\n#include <algorithm>\n" "#include <regex>\nint main() { return 0; }\n";
+        cp.text = std::move(text);
         cp.directory = "/tmp";
         cp.arguments = make_args(src);
         cp.pch = {"", 0};

--- a/tests/unit/server/stateful_worker_tests.cpp
+++ b/tests/unit/server/stateful_worker_tests.cpp
@@ -86,7 +86,14 @@ TEST_CASE(CancelledCompileFreesStrand) {
             first_failed = !result.has_value();
         };
         group.spawn(sender());
-        co_await kota::sleep(150, w.loop);
+        // One short tick: enough for the request bytes to flush, far below
+        // any parse of four STL headers. The $/cancelRequest then chases
+        // the request down the same pipe, and the single-threaded worker
+        // processes it while the handler is parked on the pool await — the
+        // compile cannot have replied first, so the cancel deterministically
+        // lands mid-flight (a 150ms window lost this race on a warm macOS
+        // runner that compiled the TU faster).
+        co_await kota::sleep(20, w.loop);
         source.cancel();
         co_await group.join();
         EXPECT_TRUE(first_failed);

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -95,18 +95,33 @@ TEST_CASE(StoreAndLookup) {
     ASSERT_TRUE(llvm::StringRef(path).ends_with("k1.pch"));
 }
 
-TEST_CASE(AbortRemovesTmp) {
+TEST_CASE(DropRemovesTmp) {
     TempDir tmp;
     auto store = open_store(tmp);
     register_lru(store);
 
-    auto pending = store.begin_store("pch", "k1");
-    ASSERT_TRUE(fs::write(pending.tmp_path, "junk").has_value());
-    auto tmp_path = pending.tmp_path;
-    store.abort(pending);
+    // Self-cleaning is the abort: an entry destroyed without being
+    // committed removes its tmp file — including when a cancellation
+    // destroys the owning coroutine frame without resuming it.
+    std::string tmp_path;
+    {
+        auto pending = store.begin_store("pch", "k1");
+        ASSERT_TRUE(fs::write(pending.tmp_path, "junk").has_value());
+        tmp_path = pending.tmp_path;
+    }
 
     ASSERT_FALSE(llvm::sys::fs::exists(tmp_path));
     ASSERT_FALSE(store.lookup("pch", "k1").has_value());
+
+    // A moved-from entry no longer owns the tmp file.
+    auto pending = store.begin_store("pch", "k2");
+    ASSERT_TRUE(fs::write(pending.tmp_path, "junk").has_value());
+    auto second = pending.tmp_path;
+    {
+        auto moved = std::move(pending);
+        ASSERT_TRUE(llvm::sys::fs::exists(second));
+    }
+    ASSERT_FALSE(llvm::sys::fs::exists(second));
 }
 
 TEST_CASE(CommitWithoutWriteFails) {

--- a/tests/unit/support/cache_store_tests.cpp
+++ b/tests/unit/support/cache_store_tests.cpp
@@ -122,6 +122,17 @@ TEST_CASE(DropRemovesTmp) {
         ASSERT_TRUE(llvm::sys::fs::exists(second));
     }
     ASSERT_FALSE(llvm::sys::fs::exists(second));
+
+    // Move assignment cleans the destination's own tmp before adopting.
+    auto lhs = store.begin_store("pch", "k3");
+    auto rhs = store.begin_store("pch", "k4");
+    ASSERT_TRUE(fs::write(lhs.tmp_path, "junk").has_value());
+    ASSERT_TRUE(fs::write(rhs.tmp_path, "junk").has_value());
+    auto third = lhs.tmp_path;
+    auto fourth = rhs.tmp_path;
+    lhs = std::move(rhs);
+    ASSERT_FALSE(llvm::sys::fs::exists(third));
+    ASSERT_TRUE(llvm::sys::fs::exists(fourth));
 }
 
 TEST_CASE(CommitWithoutWriteFails) {


### PR DESCRIPTION
## Manual cleanup → RAII

kotatsu cancellation destroys a suspended coroutine frame **without resuming it**, so any "manual cleanup after the await" in a coroutine is a latent deadlock or leak. The codebase already encodes this rule twice (`BuildingGuard`, `UnitGuard`); this PR converts the three remaining holdouts:

- **`run_compile`'s manual `finish_compile()`**: a compile task cancelled at shutdown skipped the finish, leaving `session->compiling` set and the `done` event unset — every `ensure_compiled` waiter hung forever and the session was bricked. Now a `FinishCompile` RAII guard. Reproduced pre-fix by `StopUnblocksCompileWaiters` (hangs, timeout 124); passes post-fix.
- **Stateful worker's per-document strand**: `co_await strand.lock(); … co_await kota::queue(...); strand.unlock();` — a handler cancelled at the queue await (wire `$/cancelRequest`, peer close) never unlocked, deadlocking the document forever. Now `StrandGuard`/`CompileGuard` (the latter also wakes `ast_ready` waiters, who observe no AST and return their missing value). Reproduced pre-fix by `CancelledCompileFreesStrand` (the follow-up compile hangs behind the locked strand, exit 124); passes post-fix. `CancelledQueryFreesStrand` covers the query-side guard.
- **`CacheStore::PendingEntry`**: now move-only and self-cleaning — the destructor removes the tmp blob unless `commit()` consumed it — and `CacheStore::abort()` plus all seven manual call sites are gone; a cancelled two-phase write can no longer leak its tmp file until the next startup sweep. Reproduced pre-fix by `DropRemovesTmp` (tmp survives scope exit); passes post-fix, including moved-from and move-assign semantics.

## Cancellable AST tasks (kotatsu bump 02b255f → f2cdf65)

The bump picks up `kota::queue(fn, on_cancel)`: cancel-while-queued dequeues (fn never runs); cancel-while-running fires the hook so fn can return early — the frame stays alive until fn returns.

The workers chain this into **`CompilationParams::stop`**, which clang polls after every top-level declaration (`ProxyASTConsumer::HandleTopLevelDecl`): a cancelled request now interrupts **the parse itself** at declaration granularity instead of running the whole AST build/index/serialize pipeline to completion for a result nobody will read. Wired through stateful compiles and queries, PCH/PCM builds, indexing, completion and signature help; an interrupted unit reports `!completed()` and flows into the existing failure paths, and the response is discarded since the request already settled as cancelled. Observed in the strand test's worker log: cancel at ~150 ms → "Compile incomplete … 139 ms" instead of the full 1.3 s parse.

The Compile handler also drops the previous unit together with adopting the new buffer, before the cancellable await: a cancellation landing while the work is still queued used to leave the old AST installed next to the new text (a window previously masked by the strand deadlock), and queries would have served stale offsets as current.

This unblocks the master-side follow-up of cancelling superseded PCH/compile requests end-to-end: the worker mechanism is in place; the master only needs to start passing request tokens.

## Verification

- All three fixes reproduced against pre-fix sources: `DropRemovesTmp` fails cleanly, both async tests hang (timeout 124); all pass post-fix. The regression tests are bounded (request timeouts / polled joins) so a future regression fails as a named assertion rather than a CI-wide timeout, and the cancelled TU is deterministically slow (200k generated declarations) after two macOS runners compiled a four-STL-header TU inside a 20 ms cancellation window.
- 3-agent review (correctness / style / tests): correctness traced guard destructor orderings, the `stop` shared_ptr lifetime through `run_clang`'s move, the PairCommit pool-thread interaction, and kotatsu's frame-liveness guarantee — no defects; all style and test feedback applied, plus one reviewer-found stale-AST window fixed.
- Unit 979 (Debug + RelWithDebInfo), integration 279 (both configs), smoke 3/3 — green locally and on CI (17 checks).
