### PR TITLE
fix(server): clamp out-of-bounds didChange ranges per LSP 3.17

### DIFF
--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -12,6 +12,7 @@
 #include "index/tu_index.h"
 #include "server/compiler/context_resolver.h"
 #include "server/protocol/extension.h"
+#include "server/protocol/position.h"
 #include "server/protocol/worker.h"
 #include "support/anomaly.h"
 #include "support/filesystem.h"
@@ -196,21 +197,6 @@ constexpr std::uint8_t evidence_kind(worker::BuildKind kind) {
 }
 
 constexpr inline std::uint8_t document_link_evidence = 0x20;
-
-/// Clamp a client-supplied position to the document, following LSP
-/// semantics: a character beyond the line length defaults to the line end,
-/// a line beyond the document defaults to the end of the content.
-static lsp::LineMap::Offset clamped_offset(const lsp::LineMap& map,
-                                           const protocol::Position& position) {
-    if(auto offset = map.to_offset(position)) {
-        return *offset;
-    }
-    auto starts = map.line_starts();
-    if(position.line >= starts.size()) {
-        return static_cast<lsp::LineMap::Offset>(map.content().size());
-    }
-    return map.line_bounds(starts[position.line]).end;
-}
 
 Compiler::Compiler(kota::event_loop& loop,
                    Workspace& workspace,

--- a/src/server/protocol/position.h
+++ b/src/server/protocol/position.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/// Shared LSP position clamping for master-side buffer access.
+
+#include "kota/ipc/lsp/position.h"
+
+namespace clice {
+
+namespace protocol = kota::ipc::protocol;
+
+/// Clamp a client-supplied position to the document, following LSP
+/// semantics: a character beyond the line length defaults to the line end
+/// (also when it lands mid-codepoint), a line beyond the document defaults
+/// to the end of the content.
+inline kota::ipc::lsp::LineMap::Offset clamped_offset(const kota::ipc::lsp::LineMap& map,
+                                                      const protocol::Position& position) {
+    if(auto offset = map.to_offset(position)) {
+        return *offset;
+    }
+    auto starts = map.line_starts();
+    if(position.line >= starts.size()) {
+        return static_cast<kota::ipc::lsp::LineMap::Offset>(map.content().size());
+    }
+    return map.line_bounds(starts[position.line]).end;
+}
+
+}  // namespace clice

--- a/src/server/state/session_store.cpp
+++ b/src/server/state/session_store.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <variant>
 
+#include "server/protocol/position.h"
 #include "support/logging.h"
 
 #include "kota/ipc/lsp/position.h"
@@ -73,23 +74,31 @@ void SessionStore::apply_change(Session& session,
                     auto map = session.line_map();
                     auto start = map.to_offset(range.start);
                     auto end = map.to_offset(range.end);
-                    if(start && end && *start <= *end) {
-                        if(llvm::StringRef(session.text).substr(*start, *end - *start) != c.text) {
-                            session.text.replace(*start, *end - *start, c.text);
-                            applied = true;
-                        }
-                    } else {
+                    if(!start || !end || *start > *end) {
                         // The client's view has drifted from ours (or the
-                        // client is buggy). Drop the edit but keep serving:
-                        // a full-document change or reopen resynchronizes.
-                        LOG_ERROR(
-                            "didChange range {}:{}-{}:{} does not fit the buffer " "(path_id={} version={}); edit dropped",
+                        // client is buggy). LSP 3.17 requires clamping
+                        // positions past the document instead of dropping
+                        // the edit, which would silently desync every
+                        // subsequent position until a full sync or reopen.
+                        LOG_INFO(
+                            "didChange range {}:{}-{}:{} does not fit the buffer " "(path_id={} version={}); clamped",
                             range.start.line,
                             range.start.character,
                             range.end.line,
                             range.end.character,
                             session.path_id,
                             version);
+                        start = clamped_offset(map, range.start);
+                        end = clamped_offset(map, range.end);
+                        if(*start > *end) {
+                            // Inverted even after clamping: treat it as an
+                            // empty range at the clamped start.
+                            end = start;
+                        }
+                    }
+                    if(llvm::StringRef(session.text).substr(*start, *end - *start) != c.text) {
+                        session.text.replace(*start, *end - *start, c.text);
+                        applied = true;
                     }
                 }
                 session.line_starts = lsp::build_line_starts(session.text);
@@ -98,7 +107,7 @@ void SessionStore::apply_change(Session& session,
     }
 
     // A real content change re-arms a quarantined document with one probe
-    // attempt; dropped or no-op edits grant none (see Quarantine::on_edit).
+    // attempt; no-op edits grant none (see Quarantine::on_edit).
     session.quarantine.on_edit(applied);
 
     session.generation++;

--- a/src/server/state/session_store.h
+++ b/src/server/state/session_store.h
@@ -38,10 +38,10 @@ enum class ResetDepth : std::uint8_t {
 /// this store hands out.
 ///
 /// Buffer desync (client and server drifting out of sync) is tolerated: an
-/// incremental edit whose range does not fit the buffer is dropped with an
-/// ERROR log, and requests keep being served — a full-document change or a
-/// reopen resynchronizes. Non-monotonic document versions are warned about
-/// at the transport edge, where the protocol context lives.
+/// incremental edit whose range does not fit the buffer is clamped to the
+/// document per LSP 3.17 (logged at info), and requests keep being served.
+/// Non-monotonic document versions are warned about at the transport edge,
+/// where the protocol context lives.
 ///
 /// Future work: this store does not yet bound the number of concurrently
 /// open sessions.
@@ -69,9 +69,9 @@ struct SessionStore {
 
     /// Apply a didChange: fold the content changes into the buffer (range →
     /// offset mapping, in-place text replacement, line-start rebuild), then
-    /// bump version, generation and mark the AST dirty. Changes whose range
-    /// cannot be mapped to a valid offset span are dropped with an ERROR
-    /// log (see the struct comment on desync tolerance).
+    /// bump version, generation and mark the AST dirty. Ranges that do not
+    /// fit the buffer are clamped per LSP 3.17 (see the struct comment on
+    /// desync tolerance).
     void apply_change(Session& session,
                       llvm::ArrayRef<protocol::TextDocumentContentChangeEvent> changes,
                       int version);

--- a/tests/integration/lifecycle/test_protocol_edges.py
+++ b/tests/integration/lifecycle/test_protocol_edges.py
@@ -85,14 +85,16 @@ async def test_change_without_open(client, workspace):
     assert get_errors(client.diagnostics[uri]) == []
 
 
-async def test_desync_range_tolerated(client, tmp_path):
+async def test_desync_range_clamped(client, tmp_path):
     write_source(tmp_path, "main.cpp", "int foo() { return 1; }\n")
     write_cdb(tmp_path, ["main.cpp"])
     await client.initialize(tmp_path)
     uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
 
     # An incremental edit whose range lies outside the buffer: the views
-    # have drifted. The edit is dropped with an ERROR log; no refusal.
+    # have drifted. The range is clamped per LSP 3.17, so "oops" lands at
+    # the true end of the document instead of being dropped.
+    event = client.wait_for_diagnostics(uri)
     client.text_document_did_change(
         DidChangeTextDocumentParams(
             text_document=VersionedTextDocumentIdentifier(uri=uri, version=2),
@@ -108,18 +110,23 @@ async def test_desync_range_tolerated(client, tmp_path):
         )
     )
 
-    # Requests keep being served from the retained buffer.
+    # Requests keep being served, now against the clamped buffer.
     hover = await client.hover_at(uri, 0, 4)
     assert hover is not None
+
+    # The appended "oops" makes the TU ill-formed: errors prove the edit
+    # was applied rather than dropped.
+    await asyncio.wait_for(event.wait(), timeout=60.0)
+    assert get_errors(client.diagnostics[uri])
 
     logs_dir = tmp_path / ".clice" / "logs"
     for _ in range(50):
         logs = "".join(f.read_text(errors="replace") for f in logs_dir.rglob("*.log"))
-        if "didChange range" in logs:
+        if any("didChange range" in ln and "clamped" in ln for ln in logs.splitlines()):
             break
         await asyncio.sleep(0.1)
     else:
-        pytest.fail("dropped out-of-sync edit never produced an error log")
+        pytest.fail("clamped out-of-sync edit never produced a clamp log")
 
 
 @pytest.mark.workspace("hello_world")

--- a/tests/unit/server/session_store_tests.cpp
+++ b/tests/unit/server/session_store_tests.cpp
@@ -83,20 +83,105 @@ TEST_CASE(WholeDocumentReplace) {
     ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
 }
 
-TEST_CASE(InvalidRangeDropped) {
+TEST_CASE(InvertedRangeCollapsed) {
     SessionStore store;
     auto session = store.open(1);
-    store.apply_open(*session, "short\n", 1);
+    store.apply_open(*session, "ab\ncd\n", 1);
 
-    // A range past the end of the document cannot be mapped to offsets;
-    // the change is silently dropped but version bookkeeping still runs.
-    auto change = partial_change(99, 0, 99, 1, "junk");
+    // A range whose start lies after its end deletes nothing; the text is
+    // inserted at the start position.
+    auto change = partial_change(1, 0, 0, 0, "X");
     store.apply_change(*session, change, 2);
 
-    ASSERT_EQ(session->text, "short\n");
+    ASSERT_EQ(session->text, "ab\nXcd\n");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
+}
+
+TEST_CASE(SelectAllDeleteClamped) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "int foo() { return 1; }\n", 1);
+
+    // Several clients emit select-all-delete as an oversized range; per
+    // LSP 3.17 positions past the document clamp to the document end.
+    auto change = partial_change(0, 0, 99999, 0, "");
+    store.apply_change(*session, change, 2);
+
+    ASSERT_EQ(session->text, "");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
     ASSERT_EQ(session->version, 2);
     ASSERT_TRUE(session->ast_dirty);
     ASSERT_EQ(session->generation, 2u);
+}
+
+TEST_CASE(InsertPastLastLine) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "int a;\n", 1);
+
+    // Line 1 (after the trailing newline) is the last line; line 2 clamps
+    // to the true end of the document.
+    auto change = partial_change(2, 0, 2, 0, "int b;\n");
+    store.apply_change(*session, change, 2);
+
+    ASSERT_EQ(session->text, "int a;\nint b;\n");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
+}
+
+TEST_CASE(InsertPastLineEnd) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "ab\ncd\n", 1);
+
+    // A character beyond the line length clamps to the line end.
+    auto change = partial_change(0, 9999, 0, 9999, "X");
+    store.apply_change(*session, change, 2);
+
+    ASSERT_EQ(session->text, "abX\ncd\n");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
+}
+
+TEST_CASE(ClampedChangeFolds) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "ab\ncd\n", 1);
+
+    // The clamp for the second change must resolve against the buffer as
+    // left by the first one (EOF has moved from 6 to 8).
+    protocol::TextDocumentContentChangeEvent changes[] = {
+        partial_change(0, 1, 0, 2, "xyz"),  // "ab" -> "axyz"
+        partial_change(99, 0, 99, 0, "!"),  // clamps to the new EOF
+    };
+    store.apply_change(*session, changes, 2);
+
+    ASSERT_EQ(session->text, "axyz\ncd\n!");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
+}
+
+TEST_CASE(EmptyDocumentClamped) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "", 1);
+
+    auto change = partial_change(5, 3, 8, 0, "int x;");
+    store.apply_change(*session, change, 2);
+
+    ASSERT_EQ(session->text, "int x;");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
+}
+
+TEST_CASE(RangeEndPastEof) {
+    SessionStore store;
+    auto session = store.open(1);
+    store.apply_open(*session, "int a;\nint b;\n", 1);
+
+    // The end position sits on the last (empty) line but one character
+    // past its length: it clamps to the end of the document.
+    auto change = partial_change(1, 0, 2, 1, "");
+    store.apply_change(*session, change, 2);
+
+    ASSERT_EQ(session->text, "int a;\n");
+    ASSERT_EQ(session->line_starts, lsp::build_line_starts(session->text));
 }
 
 TEST_CASE(ReopenBumpsGeneration) {
@@ -220,7 +305,7 @@ TEST_CASE(QuarantineProbeOnEdit) {
     ASSERT_FALSE(session->quarantine.blocked());
 }
 
-TEST_CASE(DroppedEditNoProbe) {
+TEST_CASE(NoopEditNoProbe) {
     SessionStore store;
     auto session = store.open(1);
     store.apply_open(*session, "int a;\n", 1);
@@ -228,11 +313,11 @@ TEST_CASE(DroppedEditNoProbe) {
     session->quarantine.on_crash();
     ASSERT_TRUE(session->quarantine.blocked());
 
-    // The probe license is one attempt per real content change: an edit
-    // whose range does not fit the buffer is dropped, an empty change list
-    // and a no-op replacement change nothing — none may re-arm a compile
-    // of the unchanged poison bytes.
-    store.apply_change(*session, partial_change(99, 0, 99, 1, "junk"), 2);
+    // The probe license is one attempt per real content change: an
+    // out-of-range deletion clamps to an empty range at the end of the
+    // document, an empty change list and a no-op replacement change
+    // nothing — none may re-arm a compile of the unchanged poison bytes.
+    store.apply_change(*session, partial_change(99, 0, 99, 1, ""), 2);
     ASSERT_TRUE(session->quarantine.blocked());
 
     store.apply_change(*session, {}, 3);


### PR DESCRIPTION
## Problem

LSP 3.17 requires positions beyond the document to be clamped (line past the end → last line; character past the line → line length). `SessionStore::apply_change` instead dropped the whole edit whenever an endpoint fell outside the buffer — kota's `LineMap::to_offset` returns nullopt there and the handler bailed with only a server-side ERROR log.

The client's buffer and the server's then silently diverge until a full sync or reopen: a `{0,0}-{99999,0} → ""` select-all-delete (as emitted by several non-VSCode clients) leaves the server answering semanticTokens for text the client already deleted, and every subsequent position is shifted. Runtime-verified in four forms: select-all-delete, insert past the last line, insert past a line's end, and a delete range ending past EOF.

## Fix

- The compiler already clamped query positions with a local static helper; that helper is hoisted verbatim into `src/server/protocol/position.h` (`clamped_offset`) and now serves both the compiler's four call sites and `apply_change` — one clamping semantic everywhere, kota's nullopt contract untouched.
- `apply_change` clamps per spec before applying: line beyond → document end, character beyond → line end, range still inverted after clamping → empty range at the clamped start. The drop ERROR log becomes an info clamp log.
- Version/generation/ast_dirty/quarantine bookkeeping unchanged: a clamped edit that changes content counts as a real edit for the quarantine probe; a clamped no-op grants none.

## Testing

- New unit tests written FIRST and confirmed failing on the old code: the four forms above, plus inverted-range collapse, clamped-no-op probe semantics, clamp-against-folded-buffer, and empty-document edits.
- `test_desync_range_tolerated` strengthened into `test_desync_range_clamped`: keeps the original liveness assertions and now also asserts the clamped application really happened (the out-of-range text lands at EOF and produces the expected error diagnostics — the old drop behavior kept diagnostics clean, so this pins the new semantics).
- 3-agent pre-PR review (correctness / style / tests) passed; all findings addressed.
- Full local gates: format clean, unit 991, integration 283, smoke 3/3 — all green (RelWithDebInfo).
