### PR TITLE
fix(semantic tokens): fix delta underflow after multiline tokens

### DIFF
--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -504,62 +504,62 @@ public:
         auto end_char = static_cast<std::uint32_t>(end_position->character);
 
         if(begin_line == end_line) [[likely]] {
-            auto delta_line = begin_line - last_line;
-            auto delta_start = delta_line == 0 ? begin_char - last_start_character : begin_char;
-            auto token_length = end_char - begin_char;
-            emit_relative(delta_line, delta_start, token_length, token.kind, token.modifiers);
-        } else {
-            auto chunk = content.substr(begin, end - begin);
-            bool first_piece = true;
-            std::uint32_t chunk_offset = 0;
-            std::uint32_t piece_size = 0;
-
-            for(char c: chunk) {
-                piece_size += 1;
-                if(c != '\n') {
-                    continue;
-                }
-
-                std::uint32_t delta_line = 1;
-                std::uint32_t delta_start = 0;
-                if(first_piece) {
-                    delta_line = begin_line - last_line;
-                    delta_start = delta_line == 0 ? begin_char - last_start_character : begin_char;
-                    first_piece = false;
-                }
-
-                auto length = lsp::encoded_length(chunk.substr(chunk_offset, piece_size), encoding);
-                emit_relative(delta_line, delta_start, length, token.kind, token.modifiers);
-
-                chunk_offset += piece_size;
-                piece_size = 0;
-            }
-
-            if(piece_size > 0) {
-                auto length = lsp::encoded_length(chunk.substr(chunk_offset), encoding);
-                emit_relative(1, 0, length, token.kind, token.modifiers);
-            }
+            emit(begin_line, begin_char, end_char - begin_char, token.kind, token.modifiers);
+            return;
         }
 
-        last_line = end_line;
-        last_start_character = begin_char;
+        // LSP semantic tokens have no multiline support (unless the client
+        // negotiates the capability), so split the token into per-line pieces.
+        auto chunk = content.substr(begin, end - begin);
+        std::uint32_t line = begin_line;
+        std::uint32_t character = begin_char;
+        std::uint32_t chunk_offset = 0;
+        std::uint32_t piece_size = 0;
+
+        for(char c: chunk) {
+            piece_size += 1;
+            if(c != '\n') {
+                continue;
+            }
+
+            auto length = lsp::encoded_length(chunk.substr(chunk_offset, piece_size), encoding);
+            emit(line, character, length, token.kind, token.modifiers);
+
+            line += 1;
+            character = 0;
+            chunk_offset += piece_size;
+            piece_size = 0;
+        }
+
+        if(piece_size > 0) {
+            auto length = lsp::encoded_length(chunk.substr(chunk_offset), encoding);
+            emit(line, character, length, token.kind, token.modifiers);
+        }
     }
 
 private:
-    void emit_relative(std::uint32_t delta_line,
-                       std::uint32_t delta_start,
-                       std::uint32_t token_length,
-                       SymbolKind kind,
-                       std::uint32_t modifiers) {
+    /// Emits one LSP entry at the absolute (line, character), computing the
+    /// delta against the previously emitted entry. This is the single place
+    /// that reads and updates the previous-position bookkeeping.
+    void emit(std::uint32_t line,
+              std::uint32_t character,
+              std::uint32_t token_length,
+              SymbolKind kind,
+              std::uint32_t modifiers) {
         if(token_length == 0) {
             return;
         }
 
+        auto delta_line = line - last_line;
+        auto delta_start = delta_line == 0 ? character - last_start_character : character;
         output.data.push_back(delta_line);
         output.data.push_back(delta_start);
         output.data.push_back(token_length);
         output.data.push_back(type_index(kind));
         output.data.push_back(encode_modifiers(modifiers));
+
+        last_line = line;
+        last_start_character = character;
     }
 
 private:

--- a/tests/unit/feature/semantic_tokens_tests.cpp
+++ b/tests/unit/feature/semantic_tokens_tests.cpp
@@ -20,8 +20,11 @@ namespace protocol = kota::ipc::protocol;
 
 struct DecodedToken {
     LocalSourceRange range;
-    std::uint32_t line = 0;
-    std::uint32_t start = 0;
+    /// Absolute positions are accumulated in 64 bits so that a broken delta
+    /// stream (e.g. an underflowed deltaStart) stays visible instead of
+    /// wrapping back to a plausible value.
+    std::uint64_t line = 0;
+    std::uint64_t start = 0;
     std::uint32_t length = 0;
     std::uint32_t type = 0;
     std::uint32_t modifiers = 0;
@@ -45,8 +48,8 @@ auto decode_utf8_tokens(llvm::StringRef content, const protocol::SemanticTokens&
     std::vector<DecodedToken> result;
     result.reserve(tokens.data.size() / 5);
 
-    std::uint32_t line = 0;
-    std::uint32_t character = 0;
+    std::uint64_t line = 0;
+    std::uint64_t character = 0;
     for(std::size_t i = 0; i < tokens.data.size(); i += 5) {
         auto delta_line = tokens.data[i + 0];
         auto delta_char = tokens.data[i + 1];
@@ -56,18 +59,27 @@ auto decode_utf8_tokens(llvm::StringRef content, const protocol::SemanticTokens&
 
         line += delta_line;
         character = delta_line == 0 ? character + delta_char : delta_char;
-        assert(line < starts.size() && "line index out of range");
 
-        auto begin = starts[line] + character;
-        auto end = begin + length;
-        result.push_back({
-            .range = LocalSourceRange(begin, end),
+        DecodedToken token{
             .line = line,
             .start = character,
             .length = length,
             .type = type,
             .modifiers = modifiers,
-        });
+        };
+
+        // Only map in-bounds positions back to a byte range; out-of-range
+        // tokens keep an invalid range so lookups by annotation fail loudly.
+        if(line < starts.size()) {
+            auto begin = starts[line] + character;
+            auto end = begin + length;
+            if(end <= content.size()) {
+                token.range = LocalSourceRange(static_cast<std::uint32_t>(begin),
+                                               static_cast<std::uint32_t>(end));
+            }
+        }
+
+        result.push_back(token);
     }
 
     return result;
@@ -79,8 +91,8 @@ auto decode_relative_tokens(const protocol::SemanticTokens& tokens) -> std::vect
     std::vector<DecodedToken> result;
     result.reserve(tokens.data.size() / 5);
 
-    std::uint32_t line = 0;
-    std::uint32_t character = 0;
+    std::uint64_t line = 0;
+    std::uint64_t character = 0;
     for(std::size_t i = 0; i < tokens.data.size(); i += 5) {
         auto delta_line = tokens.data[i + 0];
         auto delta_char = tokens.data[i + 1];
@@ -143,6 +155,23 @@ void EXPECT_TOKEN(llvm::StringRef name,
 
 void EXPECT_NO_TOKEN(llvm::StringRef name) {
     ASSERT_TRUE(find_by_range(name) == nullptr);
+}
+
+void EXPECT_TOKENS_WITHIN_LINES() {
+    auto content = unit->interested_content();
+    auto starts = compute_line_starts(content);
+    for(const auto& token: decoded) {
+        ASSERT_TRUE(token.line < starts.size());
+        auto line_end = token.line + 1 < starts.size() ? starts[token.line + 1] : content.size();
+        ASSERT_TRUE(token.start <= line_end - starts[token.line]);
+    }
+}
+
+void EXPECT_TOKEN_AT(llvm::StringRef name, std::uint64_t line, std::uint64_t start) {
+    auto* token = find_by_range(name);
+    ASSERT_TRUE(token != nullptr);
+    ASSERT_EQ(token->line, line);
+    ASSERT_EQ(token->start, start);
 }
 
 TEST_CASE(BasicLexicalKinds) {
@@ -466,6 +495,31 @@ cd*/
     ASSERT_EQ(comments[1].line, comments[0].line + 1);
     ASSERT_EQ(comments[1].start, 0);
     ASSERT_EQ(comments[1].length, 4);
+}
+
+TEST_CASE(CodeAfterRawString) {
+    run_utf8(R"cpp(
+const char* s = R"(line1
+line2
+)"; @k0[int] @x[x] = 1;
+)cpp");
+
+    EXPECT_TOKENS_WITHIN_LINES();
+    EXPECT_TOKEN_AT("k0", 3, 4);
+    EXPECT_TOKEN_AT("x", 3, 8);
+    EXPECT_TOKEN("k0", SymbolKind::Keyword);
+}
+
+TEST_CASE(CodeAfterMultilineComment) {
+    run_utf8(R"cpp(
+    /* first
+second */ @k0[int] @x[x] = 1;
+)cpp");
+
+    EXPECT_TOKENS_WITHIN_LINES();
+    EXPECT_TOKEN_AT("k0", 2, 10);
+    EXPECT_TOKEN_AT("x", 2, 14);
+    EXPECT_TOKEN("k0", SymbolKind::Keyword);
 }
 
 TEST_CASE(ModuleDeclaration) {


### PR DESCRIPTION
## Problem

When a line contains tokens after a multiline token ends on it (code following the closing quote of a raw string literal, or after a `*/` of a multiline block comment), the semantic-tokens delta encoding is corrupted. `SemanticTokenEncoder::append` splits a multiline token into per-line entries whose last piece starts at column 0 of the end line, but `last_start_character` was unconditionally set to the token's start column on its FIRST line. The next token's `deltaStart = char - last_start_character` then either underflows u32 (runtime-measured `char=4294967292`, destroying highlighting for the whole line) or silently shifts columns when it stays positive. A secondary flaw: `last_line` advanced to the token's end line even when nothing was emitted there (token ending exactly at a newline).

## Fix

Delta computation and prev-position bookkeeping fold into a single `emit(line, character, ...)` taking absolute positions — the only reader/writer of `last_line`/`last_start_character`, updated only when an entry is actually emitted. The split loop tracks each piece's absolute position; piece lengths and the splitting itself are unchanged.

## Testing

- Tests written FIRST and confirmed failing on the old code: `CodeAfterRawString` and `CodeAfterMultilineComment` decode the delta stream and assert exact absolute columns; the test decoders accumulate in 64-bit so an underflow can never wrap back into plausible values (which had masked this bug). Before the fix the raw-string case decoded a token start beyond the line end and the comment case landed at columns 6/10 instead of 10/14; both now decode exactly.
- 3-agent pre-PR review (correctness / style / tests) passed with no blocking findings; the correctness pass traced same-end-line, later-line, consecutive-multiline, newline-terminated, CRLF and zero-length-piece paths, and notes the fix also repairs the `last_line` update when nothing is emitted on the end line.
- Full local gates: format clean, unit 987, integration 283, smoke 3/3 — all green (RelWithDebInfo).
