### PR TITLE
fix(server): drop stderr lines instead of blocking

### DIFF
--- a/src/server/protocol/extension.h
+++ b/src/server/protocol/extension.h
@@ -96,4 +96,18 @@ struct PollResult {
     std::uint32_t events = 0;
 };
 
+/// Test hook (clice/internal/logFlood): emit `count` info-level log lines
+/// of roughly `size` bytes each, tagged stderr-flood with a running index.
+/// Gives backpressure tests a deterministic volume source — feature log
+/// lines change shape over time and must not be load-bearing for tests.
+/// Absent from capabilities and user docs.
+struct LogFloodParams {
+    std::uint32_t count = 0;
+    std::uint32_t size = 0;
+};
+
+struct LogFloodResult {
+    std::uint32_t emitted = 0;
+};
+
 }  // namespace clice::ext

--- a/src/server/state/config.h
+++ b/src/server/state/config.h
@@ -35,6 +35,10 @@ struct ProjectConfig {
     std::optional<bool> enable_indexing;
     std::optional<int> idle_timeout_ms;
 
+    /// Enables the clice/internal test hooks that can generate load on
+    /// demand (log floods). Off unless the harness asks for them.
+    std::optional<bool> test_hooks;
+
     defaulted<std::uint32_t> stateful_worker_count = {};
     defaulted<std::uint32_t> stateless_worker_count = {};
     defaulted<std::uint32_t> min_stateless_worker_count = {};

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -597,6 +597,17 @@ void LSPClient::register_extensions() {
             }
             co_return to_raw(ext::PollResult{static_cast<std::uint32_t>(events.size())});
         });
+
+    peer.on_request("clice/internal/logFlood",
+                    [](RequestContext& ctx, const ext::LogFloodParams& params) -> RawResult {
+                        auto count = std::min<std::uint32_t>(params.count, 100'000);
+                        auto size = std::clamp<std::uint32_t>(params.size, 16, 4096);
+                        std::string padding(size, 'f');
+                        for(std::uint32_t i = 0; i < count; ++i) {
+                            LOG_INFO("[stderr-flood {}] {}", i, padding);
+                        }
+                        co_return to_raw(ext::LogFloodResult{count});
+                    });
 }
 
 /// Publish clice.toml load problems as diagnostics, each on its own file's

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -599,7 +599,15 @@ void LSPClient::register_extensions() {
         });
 
     peer.on_request("clice/internal/logFlood",
-                    [](RequestContext& ctx, const ext::LogFloodParams& params) -> RawResult {
+                    [this](RequestContext& ctx, const ext::LogFloodParams& params) -> RawResult {
+                        // Load-generating hook: a stray client must not be able to
+                        // bloat the file log, so it only exists when the harness asked
+                        // for it at initialize time.
+                        if(!this->server.workspace.config.project.test_hooks.value_or(false)) {
+                            co_return kota::outcome_error(
+                                kota::ipc::Error{protocol::ErrorCode::InvalidRequest,
+                                                 "test hooks are not enabled"});
+                        }
                         auto count = std::min<std::uint32_t>(params.count, 100'000);
                         auto size = std::clamp<std::uint32_t>(params.size, 16, 4096);
                         std::string padding(size, 'f');

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -14,6 +14,7 @@
 #include "server/protocol/worker.h"
 #include "server/worker/worker_common.h"
 #include "support/logging.h"
+#include "support/stderr_sink.h"
 
 #include "kota/async/async.h"
 #include "kota/ipc/codec/bincode.h"
@@ -366,6 +367,12 @@ int run_stateful_worker_mode(std::uint64_t memory_limit,
                              const std::string& log_dir,
                              std::size_t max_documents) {
     logging::stderr_logger(worker_name, logging::options);
+    // A worker's stderr reader is the master's always-running drain — a
+    // trusted party — and the fd is reserved for third-party crash output
+    // (assertion failures, sanitizer reports) whose writers expect blocking
+    // semantics. Undo the sink's non-blocking switch unconditionally: with
+    // no log directory the file_logger below never runs.
+    logging::restore_pipe_blocking();
     if(!log_dir.empty()) {
         // File only: worker stderr is reserved for crash/unexpected output,
         // which the master relays into its own log (see logging taxonomy).

--- a/src/server/worker/stateless_worker.cpp
+++ b/src/server/worker/stateless_worker.cpp
@@ -13,6 +13,7 @@
 #include "server/protocol/worker.h"
 #include "server/worker/worker_common.h"
 #include "support/logging.h"
+#include "support/stderr_sink.h"
 
 #include "kota/async/async.h"
 #include "kota/ipc/codec/bincode.h"
@@ -360,6 +361,12 @@ int run_stateless_worker_mode(const std::string& worker_name, const std::string&
 #endif
 
     logging::stderr_logger(worker_name, logging::options);
+    // A worker's stderr reader is the master's always-running drain — a
+    // trusted party — and the fd is reserved for third-party crash output
+    // (assertion failures, sanitizer reports) whose writers expect blocking
+    // semantics. Undo the sink's non-blocking switch unconditionally: with
+    // no log directory the file_logger below never runs.
+    logging::restore_pipe_blocking();
     if(!log_dir.empty()) {
         // File only: worker stderr is reserved for crash/unexpected output,
         // which the master relays into its own log (see logging taxonomy).

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -8,9 +8,9 @@
 #include <vector>
 
 #ifdef _WIN32
-// The only direct windows.h include in clice.  The defines keep it from
-// spilling the min/max macros (and other clutter) that break LLVM and
-// standard headers; any future include of windows.h needs the same guards.
+// The defines keep windows.h from spilling the min/max macros (and other
+// clutter) that break LLVM and standard headers; any direct include of
+// windows.h (here and stderr_sink.cpp) needs the same guards.
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -6,11 +6,10 @@
 #include <string>
 
 #include "support/filesystem.h"
+#include "support/stderr_sink.h"
 
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ringbuffer_sink.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
-#include "spdlog/sinks/stdout_sinks.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Signals.h"
 
@@ -25,7 +24,7 @@ constexpr static auto pattern = "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [thread %t] [%s
 void stderr_logger(std::string_view name, const Options& options) {
     std::shared_ptr<spdlog::logger> logger;
 
-    auto console_sink = std::make_shared<spdlog::sinks::stderr_color_sink_mt>(options.color);
+    auto console_sink = std::make_shared<StderrSink>();
     if(options.replay_console) {
         ringbuffer_sink = std::make_shared<spdlog::sinks::ringbuffer_sink_mt>(128);
         std::array<spdlog::sink_ptr, 2> sinks = {console_sink, ringbuffer_sink};
@@ -65,7 +64,7 @@ void file_logger(std::string_view name,
 
     llvm::SmallVector<spdlog::sink_ptr, 2> sinks = {file_sink};
     if(mirror_stderr) {
-        sinks.push_back(std::make_shared<spdlog::sinks::stderr_color_sink_mt>(options.color));
+        sinks.push_back(std::make_shared<StderrSink>());
     }
     auto logger = std::make_shared<spdlog::logger>(std::string(name), sinks.begin(), sinks.end());
     logger->set_level(options.level);
@@ -113,6 +112,10 @@ void install_crash_handler(std::string_view log_path, bool stderr_trace) {
     llvm::sys::AddSignalHandler(crash_handler, nullptr);
     // Workers skip the stderr backtrace: their crash traces belong in their
     // own log file only, not relayed into the master log via the stderr pipe.
+    // Crash-only exception to the never-blocked-by-the-client rule: LLVM's
+    // raw_ostream spins on a full non-blocking pipe, so a crash trace to an
+    // undrained stderr can stall the dying process. The same trace already
+    // reached the log file above, unaffected by fd 2's state.
     if(stderr_trace) {
         llvm::sys::PrintStackTraceOnErrorSignal("clice");
     }

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -63,21 +63,23 @@ void file_logger(std::string_view name,
     auto replay_buffer = ringbuffer_sink;
 
     llvm::SmallVector<spdlog::sink_ptr, 2> sinks = {file_sink};
+    std::shared_ptr<StderrSink> mirror;
     if(mirror_stderr) {
-        sinks.push_back(std::make_shared<StderrSink>());
-    } else {
-        // The startup logger's sink switched fd 2 to non-blocking; without
-        // a mirror nothing owns the drop handling anymore, and the fd is
-        // reserved for third-party crash output (sanitizer reports) whose
-        // writers expect blocking semantics. Its reader is the master's
-        // always-running drain, so blocking is safe here.
-        restore_pipe_blocking();
+        mirror = std::make_shared<StderrSink>();
+        sinks.push_back(mirror);
     }
     auto logger = std::make_shared<spdlog::logger>(std::string(name), sinks.begin(), sinks.end());
     logger->set_level(options.level);
     logger->set_pattern(pattern);
     logger->flush_on(Level::trace);
     spdlog::set_default_logger(std::move(logger));
+
+    if(mirror && mirror->inoperative()) {
+        // The mirror fails closed (drops everything) rather than risk the
+        // caller blocking on an unswitchable pipe; say so where it can be
+        // seen — the file log.
+        LOG_WARN("stderr mirror disabled: pipe could not be switched to non-blocking");
+    }
 
     // Replay buffered logs after swapping the default logger, so no messages
     // emitted between the snapshot and the swap are lost.

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -65,6 +65,13 @@ void file_logger(std::string_view name,
     llvm::SmallVector<spdlog::sink_ptr, 2> sinks = {file_sink};
     if(mirror_stderr) {
         sinks.push_back(std::make_shared<StderrSink>());
+    } else {
+        // The startup logger's sink switched fd 2 to non-blocking; without
+        // a mirror nothing owns the drop handling anymore, and the fd is
+        // reserved for third-party crash output (sanitizer reports) whose
+        // writers expect blocking semantics. Its reader is the master's
+        // always-running drain, so blocking is safe here.
+        restore_pipe_blocking();
     }
     auto logger = std::make_shared<spdlog::logger>(std::string(name), sinks.begin(), sinks.end());
     logger->set_level(options.level);

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -70,7 +70,11 @@
 ///
 /// ## Process ownership
 /// The master logs to <logging_dir>/<session>/master.log and mirrors to
-/// stderr, which editors show in their output panel. Workers log ONLY to
+/// stderr, which editors show in their output panel. The mirror is
+/// best-effort: clients are expected to drain stderr (editors do), and
+/// one that stops reading costs log lines, never liveness — once the
+/// pipe fills, lines are dropped and the gap is reported when the client
+/// drains again (see support/stderr_sink.h). Workers log ONLY to
 /// their own <session>/<worker>.log (mirror_stderr = false): a worker's
 /// stderr is reserved for unexpected third-party output — assertion
 /// failures, sanitizer reports — which the pool relays line-by-line into the
@@ -83,11 +87,9 @@
 namespace clice::logging {
 
 using Level = spdlog::level::level_enum;
-using ColorMode = spdlog::color_mode;
 
 struct Options {
     Level level = Level::info;
-    ColorMode color = ColorMode::automatic;
     bool replay_console = true;
 };
 

--- a/src/support/stderr_sink.cpp
+++ b/src/support/stderr_sink.cpp
@@ -71,45 +71,92 @@ StderrSink::StderrSink(int fd, std::size_t capacity) : fd(fd), capacity(capacity
     }
 }
 
-void StderrSink::write_or_buffer(const char* data, std::size_t size) {
-    while(size > 0) {
+std::size_t StderrSink::write_some(const char* data, std::size_t size) {
+    std::size_t written = 0;
+    while(written < size) {
 #ifdef _WIN32
         // PIPE_NOWAIT: a full pipe reports success with zero (or partial)
         // bytes written instead of blocking.
-        int n = ::_write(fd, data, static_cast<unsigned int>(size));
+        int n = ::_write(fd, data + written, static_cast<unsigned int>(size - written));
         if(n <= 0) {
             break;
         }
 #else
-        ssize_t n = ::write(fd, data, size);
+        ssize_t n = ::write(fd, data + written, size - written);
         if(n <= 0) {
             if(n < 0 && errno == EINTR) {
                 continue;
             }
-            // EAGAIN: pipe full — keep the rest for a later flush. EPIPE
-            // and friends: reader gone; the buffer then just ages out.
+            // EAGAIN: pipe full — the rest waits for a later delivery.
+            // EPIPE and friends: reader gone; the backlog just ages out.
             break;
         }
 #endif
-        data += n;
-        size -= static_cast<std::size_t>(n);
+        written += static_cast<std::size_t>(n);
     }
-    pending.append(data, size);
+    return written;
+}
+
+void StderrSink::stage_note_if_due() {
+    // The gap is older than any survivor, so the report is delivered
+    // ahead of everything and lives outside the backlog: continued
+    // pressure can evict buffered lines but never the count itself.
+    if(dropped_unreported > 0 && active_note.empty()) {
+        active_note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
+                                  dropped_unreported);
+        note_sent = 0;
+        dropped_unreported = 0;
+    }
+}
+
+bool StderrSink::pump() {
+    if(!active_note.empty()) {
+        note_sent += write_some(active_note.data() + note_sent, active_note.size() - note_sent);
+        if(note_sent < active_note.size()) {
+            return false;
+        }
+        active_note.clear();
+        note_sent = 0;
+    }
+    if(!pending.empty()) {
+        auto n = write_some(pending.data(), pending.size());
+        if(n > 0) {
+            front_partial = pending[n - 1] != '\n';
+            pending.erase(0, n);
+        }
+        if(pending.empty()) {
+            front_partial = false;
+        }
+        return pending.empty();
+    }
+    return true;
 }
 
 void StderrSink::shed_over_capacity() {
-    while(pending.size() > capacity) {
+    if(pending.size() <= capacity) {
+        return;
+    }
+    // Never cut the tail of a line whose head already reached the pipe;
+    // the budget is soft by at most that one line.
+    std::size_t start = 0;
+    if(front_partial) {
         auto newline = pending.find('\n');
         if(newline == std::string::npos) {
-            dropped_total.fetch_add(1, std::memory_order_relaxed);
-            dropped_unreported += 1;
-            pending.clear();
             return;
         }
-        pending.erase(0, newline + 1);
+        start = newline + 1;
+    }
+    std::size_t cut = start;
+    while(pending.size() - (cut - start) > capacity) {
+        auto newline = pending.find('\n', cut);
+        if(newline == std::string::npos) {
+            break;
+        }
+        cut = newline + 1;
         dropped_total.fetch_add(1, std::memory_order_relaxed);
         dropped_unreported += 1;
     }
+    pending.erase(start, cut - start);
 }
 
 void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
@@ -118,31 +165,30 @@ void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
         return;
     }
 
-    // The gap precedes everything still buffered — evicted lines were
-    // older than the survivors — so the report goes to the FRONT of the
-    // backlog: the first quantum the pipe accepts after the client
-    // resumes carries it, however small the pipe. Under continued
-    // pressure the note ages out with everything else and a fresh count
-    // is staged later.
-    if(dropped_unreported > 0) {
-        auto note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
-                                dropped_unreported);
-        dropped_unreported = 0;
-        pending.insert(0, note);
-    }
-
-    // Flush what the pipe refused earlier; order is preserved by never
-    // writing fresh content while older bytes are still pending.
-    if(!pending.empty()) {
-        std::string backlog;
-        backlog.swap(pending);
-        write_or_buffer(backlog.data(), backlog.size());
-    }
+    stage_note_if_due();
+    pump();
 
     spdlog::memory_buf_t formatted;
     formatter_->format(msg, formatted);
-    write_or_buffer(formatted.data(), formatted.size());
+    if(active_note.empty() && pending.empty()) {
+        auto n = write_some(formatted.data(), formatted.size());
+        if(n < formatted.size()) {
+            pending.assign(formatted.data() + n, formatted.size() - n);
+            front_partial = n > 0;
+        }
+    } else {
+        // Older bytes go first: fresh content queues behind the backlog.
+        pending.append(formatted.data(), formatted.size());
+    }
     shed_over_capacity();
+}
+
+void StderrSink::flush_() {
+    if(disabled) {
+        return;
+    }
+    stage_note_if_due();
+    pump();
 }
 
 }  // namespace clice::logging

--- a/src/support/stderr_sink.cpp
+++ b/src/support/stderr_sink.cpp
@@ -18,29 +18,57 @@
 
 namespace clice::logging {
 
-/// Switch the fd to non-blocking writes when (and only when) it is a pipe:
-/// that is the one shape whose drain an external party controls.
-static void set_pipe_nonblocking(int fd) {
+/// Whether the fd's drain is controlled by an external party. Pipes and
+/// sockets qualify (editors, supervisors); terminals and files do not — a
+/// tty/pty file description is shared with the parent shell, and neither
+/// can exert client-controlled backpressure.
+static bool externally_drained(int fd) {
 #ifdef _WIN32
     HANDLE handle = reinterpret_cast<HANDLE>(::_get_osfhandle(fd));
-    if(handle == INVALID_HANDLE_VALUE || ::GetFileType(handle) != FILE_TYPE_PIPE) {
-        return;
-    }
-    DWORD mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;
-    ::SetNamedPipeHandleState(handle, &mode, nullptr, nullptr);
+    return handle != INVALID_HANDLE_VALUE && ::GetFileType(handle) == FILE_TYPE_PIPE;
 #else
     struct stat st = {};
-    if(::fstat(fd, &st) != 0 || !S_ISFIFO(st.st_mode)) {
+    return ::fstat(fd, &st) == 0 && (S_ISFIFO(st.st_mode) || S_ISSOCK(st.st_mode));
+#endif
+}
+
+/// Switch such an fd to non-blocking writes. False means the fd needs the
+/// treatment but could not be switched — writing to it could still wedge
+/// the caller, so the sink must not write at all.
+static bool set_pipe_nonblocking(int fd) {
+#ifdef _WIN32
+    HANDLE handle = reinterpret_cast<HANDLE>(::_get_osfhandle(fd));
+    DWORD mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+    return ::SetNamedPipeHandleState(handle, &mode, nullptr, nullptr) != 0;
+#else
+    if(int flags = ::fcntl(fd, F_GETFL); flags >= 0) {
+        return ::fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+    }
+    return false;
+#endif
+}
+
+void restore_pipe_blocking(int fd) {
+    if(!externally_drained(fd)) {
         return;
     }
+#ifdef _WIN32
+    HANDLE handle = reinterpret_cast<HANDLE>(::_get_osfhandle(fd));
+    DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+    ::SetNamedPipeHandleState(handle, &mode, nullptr, nullptr);
+#else
     if(int flags = ::fcntl(fd, F_GETFL); flags >= 0) {
-        ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+        ::fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
     }
 #endif
 }
 
 StderrSink::StderrSink(int fd) : fd(fd) {
-    set_pipe_nonblocking(fd);
+    // A pipe that cannot be switched must never be written: a blocking
+    // write to it is exactly the wedge this sink exists to prevent.
+    if(externally_drained(fd)) {
+        disabled = !set_pipe_nonblocking(fd);
+    }
 }
 
 bool StderrSink::try_write(const char* data, std::size_t size) {
@@ -70,6 +98,11 @@ bool StderrSink::try_write(const char* data, std::size_t size) {
 }
 
 void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
+    if(disabled) {
+        dropped_total.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
     spdlog::memory_buf_t formatted;
     formatter_->format(msg, formatted);
 

--- a/src/support/stderr_sink.cpp
+++ b/src/support/stderr_sink.cpp
@@ -63,7 +63,7 @@ void restore_pipe_blocking(int fd) {
 #endif
 }
 
-StderrSink::StderrSink(int fd) : fd(fd) {
+StderrSink::StderrSink(int fd, std::size_t capacity) : fd(fd), capacity(capacity) {
     // A pipe that cannot be switched must never be written: a blocking
     // write to it is exactly the wedge this sink exists to prevent.
     if(externally_drained(fd)) {
@@ -71,14 +71,14 @@ StderrSink::StderrSink(int fd) : fd(fd) {
     }
 }
 
-bool StderrSink::try_write(const char* data, std::size_t size) {
+void StderrSink::write_or_buffer(const char* data, std::size_t size) {
     while(size > 0) {
 #ifdef _WIN32
         // PIPE_NOWAIT: a full pipe reports success with zero (or partial)
         // bytes written instead of blocking.
         int n = ::_write(fd, data, static_cast<unsigned int>(size));
         if(n <= 0) {
-            return false;
+            break;
         }
 #else
         ssize_t n = ::write(fd, data, size);
@@ -86,15 +86,30 @@ bool StderrSink::try_write(const char* data, std::size_t size) {
             if(n < 0 && errno == EINTR) {
                 continue;
             }
-            // EAGAIN: pipe full. EPIPE and friends: reader gone. Either
-            // way the line is shed, never awaited.
-            return false;
+            // EAGAIN: pipe full — keep the rest for a later flush. EPIPE
+            // and friends: reader gone; the buffer then just ages out.
+            break;
         }
 #endif
         data += n;
         size -= static_cast<std::size_t>(n);
     }
-    return true;
+    pending.append(data, size);
+}
+
+void StderrSink::shed_over_capacity() {
+    while(pending.size() > capacity) {
+        auto newline = pending.find('\n');
+        if(newline == std::string::npos) {
+            dropped_total.fetch_add(1, std::memory_order_relaxed);
+            dropped_unreported += 1;
+            pending.clear();
+            return;
+        }
+        pending.erase(0, newline + 1);
+        dropped_total.fetch_add(1, std::memory_order_relaxed);
+        dropped_unreported += 1;
+    }
 }
 
 void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
@@ -103,27 +118,27 @@ void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
         return;
     }
 
-    spdlog::memory_buf_t formatted;
-    formatter_->format(msg, formatted);
+    // Flush what the pipe refused earlier; order is preserved by never
+    // writing fresh content while older bytes are still pending.
+    if(!pending.empty()) {
+        std::string backlog;
+        backlog.swap(pending);
+        write_or_buffer(backlog.data(), backlog.size());
+    }
 
-    // Report earlier drops before the next line that fits, so the gap is
-    // visible where it happened. If the note itself does not fit, the
-    // pipe is still full and this line joins the count.
-    if(dropped_unreported > 0) {
+    // Report earlier evictions once the backlog cleared: the note lands
+    // where writes resumed, right before the next fresh line.
+    if(pending.empty() && dropped_unreported > 0) {
         auto note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
                                 dropped_unreported);
-        if(!try_write(note.data(), note.size())) {
-            dropped_unreported += 1;
-            dropped_total.fetch_add(1, std::memory_order_relaxed);
-            return;
-        }
         dropped_unreported = 0;
+        write_or_buffer(note.data(), note.size());
     }
 
-    if(!try_write(formatted.data(), formatted.size())) {
-        dropped_unreported += 1;
-        dropped_total.fetch_add(1, std::memory_order_relaxed);
-    }
+    spdlog::memory_buf_t formatted;
+    formatter_->format(msg, formatted);
+    write_or_buffer(formatted.data(), formatted.size());
+    shed_over_capacity();
 }
 
 }  // namespace clice::logging

--- a/src/support/stderr_sink.cpp
+++ b/src/support/stderr_sink.cpp
@@ -1,0 +1,96 @@
+#include "support/stderr_sink.h"
+
+#include <format>
+
+#ifdef _WIN32
+#include <io.h>
+
+// See cache_store.cpp: windows.h must not spill min/max macros.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace clice::logging {
+
+/// Switch the fd to non-blocking writes when (and only when) it is a pipe:
+/// that is the one shape whose drain an external party controls.
+static void set_pipe_nonblocking(int fd) {
+#ifdef _WIN32
+    HANDLE handle = reinterpret_cast<HANDLE>(::_get_osfhandle(fd));
+    if(handle == INVALID_HANDLE_VALUE || ::GetFileType(handle) != FILE_TYPE_PIPE) {
+        return;
+    }
+    DWORD mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+    ::SetNamedPipeHandleState(handle, &mode, nullptr, nullptr);
+#else
+    struct stat st = {};
+    if(::fstat(fd, &st) != 0 || !S_ISFIFO(st.st_mode)) {
+        return;
+    }
+    if(int flags = ::fcntl(fd, F_GETFL); flags >= 0) {
+        ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    }
+#endif
+}
+
+StderrSink::StderrSink(int fd) : fd(fd) {
+    set_pipe_nonblocking(fd);
+}
+
+bool StderrSink::try_write(const char* data, std::size_t size) {
+    while(size > 0) {
+#ifdef _WIN32
+        // PIPE_NOWAIT: a full pipe reports success with zero (or partial)
+        // bytes written instead of blocking.
+        int n = ::_write(fd, data, static_cast<unsigned int>(size));
+        if(n <= 0) {
+            return false;
+        }
+#else
+        ssize_t n = ::write(fd, data, size);
+        if(n <= 0) {
+            if(n < 0 && errno == EINTR) {
+                continue;
+            }
+            // EAGAIN: pipe full. EPIPE and friends: reader gone. Either
+            // way the line is shed, never awaited.
+            return false;
+        }
+#endif
+        data += n;
+        size -= static_cast<std::size_t>(n);
+    }
+    return true;
+}
+
+void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
+    spdlog::memory_buf_t formatted;
+    formatter_->format(msg, formatted);
+
+    // Report earlier drops before the next line that fits, so the gap is
+    // visible where it happened. If the note itself does not fit, the
+    // pipe is still full and this line joins the count.
+    if(dropped_unreported > 0) {
+        auto note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
+                                dropped_unreported);
+        if(!try_write(note.data(), note.size())) {
+            dropped_unreported += 1;
+            dropped_total.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+        dropped_unreported = 0;
+    }
+
+    if(!try_write(formatted.data(), formatted.size())) {
+        dropped_unreported += 1;
+        dropped_total.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+}  // namespace clice::logging

--- a/src/support/stderr_sink.cpp
+++ b/src/support/stderr_sink.cpp
@@ -118,21 +118,25 @@ void StderrSink::sink_it_(const spdlog::details::log_msg& msg) {
         return;
     }
 
+    // The gap precedes everything still buffered — evicted lines were
+    // older than the survivors — so the report goes to the FRONT of the
+    // backlog: the first quantum the pipe accepts after the client
+    // resumes carries it, however small the pipe. Under continued
+    // pressure the note ages out with everything else and a fresh count
+    // is staged later.
+    if(dropped_unreported > 0) {
+        auto note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
+                                dropped_unreported);
+        dropped_unreported = 0;
+        pending.insert(0, note);
+    }
+
     // Flush what the pipe refused earlier; order is preserved by never
     // writing fresh content while older bytes are still pending.
     if(!pending.empty()) {
         std::string backlog;
         backlog.swap(pending);
         write_or_buffer(backlog.data(), backlog.size());
-    }
-
-    // Report earlier evictions once the backlog cleared: the note lands
-    // where writes resumed, right before the next fresh line.
-    if(pending.empty() && dropped_unreported > 0) {
-        auto note = std::format("[logging] dropped {} stderr line(s): client not draining\n",
-                                dropped_unreported);
-        dropped_unreported = 0;
-        write_or_buffer(note.data(), note.size());
     }
 
     spdlog::memory_buf_t formatted;

--- a/src/support/stderr_sink.h
+++ b/src/support/stderr_sink.h
@@ -3,39 +3,45 @@
 #include <atomic>
 #include <cstddef>
 #include <mutex>
+#include <string>
 
 #include "spdlog/sinks/base_sink.h"
 
 namespace clice::logging {
 
-/// A stderr sink that drops instead of blocking.
+/// A stderr sink that buffers, then drops — never blocks.
 ///
 /// fd 2's reader is the editor/client. Every client we support drains it,
 /// but the server's liveness must not depend on that: once the 64KB pipe
 /// fills, a plain write(2) parks the calling thread — the event loop —
-/// until the client feels like reading, wedging the whole server. The
-/// fallback is the simplest possible: when stderr is a pipe it is switched
-/// to non-blocking, a full pipe costs the line instead of the caller, and
-/// a summary line reports the gap once the client drains again. The file
-/// log stays complete regardless — stderr is only a mirror.
+/// until the client feels like reading, wedging the whole server. So when
+/// stderr is a pipe it is switched to non-blocking, and what the pipe
+/// refuses goes into a bounded in-memory buffer flushed by later log
+/// calls: a slow reader loses nothing, torn lines cannot happen. Only a
+/// reader that stays stuck past the buffer budget costs lines — whole
+/// oldest lines are evicted and a summary line reports the gap once
+/// writes flow again. The file log stays complete regardless — stderr is
+/// only a mirror.
 ///
 /// Terminals and regular files are left in blocking mode: they cannot
 /// exert client-controlled backpressure, and O_NONBLOCK on a tty is
 /// shared with the parent shell's own file description.
-/// Undo StderrSink's non-blocking switch on a pipe/socket fd. Workers call
-/// this after dropping their startup mirror: their stderr is reserved for
-/// third-party crash output (assertion failures, sanitizer reports) whose
-/// writers expect blocking semantics, and its reader is the master's
-/// always-running drain — a trusted party, unlike a client.
-void restore_pipe_blocking(int fd = 2);
-
 class StderrSink final : public spdlog::sinks::base_sink<std::mutex> {
 public:
-    explicit StderrSink(int fd = 2);
+    /// `capacity` bounds the backpressure buffer: enough to ride out a
+    /// busy editor's pauses, small enough that a dead reader cannot turn
+    /// the mirror into a leak. Tests shrink it to exercise eviction.
+    explicit StderrSink(int fd = 2, std::size_t capacity = 256 * 1024);
 
     /// Lines dropped so far because the pipe was full (observability).
     std::size_t dropped() const {
         return dropped_total.load(std::memory_order_relaxed);
+    }
+
+    /// The fd needed the non-blocking switch but refused it: the sink
+    /// sheds everything rather than risk blocking the caller.
+    bool inoperative() const {
+        return disabled;
     }
 
 protected:
@@ -44,16 +50,29 @@ protected:
     void flush_() override {}
 
 private:
-    /// Write as much as the pipe accepts; false means it filled up (or the
-    /// reader vanished) and the rest of the line was shed.
-    bool try_write(const char* data, std::size_t size);
+    /// Write as much as the pipe accepts; what it refuses is appended to
+    /// `pending` for later flushes.
+    void write_or_buffer(const char* data, std::size_t size);
+
+    /// Evict whole oldest lines until the buffer fits its budget.
+    void shed_over_capacity();
 
     int fd;
     /// The fd needs non-blocking treatment but could not be switched:
     /// every line is shed without touching the fd.
     bool disabled = false;
+    std::size_t capacity;
+    /// Bytes the pipe refused, flushed ahead of every later write.
+    std::string pending;
     std::atomic<std::size_t> dropped_total = 0;
     std::size_t dropped_unreported = 0;
 };
+
+/// Undo StderrSink's non-blocking switch on a pipe/socket fd. Workers call
+/// this right after their startup logger: their stderr is reserved for
+/// third-party crash output (assertion failures, sanitizer reports) whose
+/// writers expect blocking semantics, and its reader is the master's
+/// always-running drain — a trusted party, unlike a client.
+void restore_pipe_blocking(int fd = 2);
 
 }  // namespace clice::logging

--- a/src/support/stderr_sink.h
+++ b/src/support/stderr_sink.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+
+#include "spdlog/sinks/base_sink.h"
+
+namespace clice::logging {
+
+/// A stderr sink that drops instead of blocking.
+///
+/// fd 2's reader is the editor/client. Every client we support drains it,
+/// but the server's liveness must not depend on that: once the 64KB pipe
+/// fills, a plain write(2) parks the calling thread — the event loop —
+/// until the client feels like reading, wedging the whole server. The
+/// fallback is the simplest possible: when stderr is a pipe it is switched
+/// to non-blocking, a full pipe costs the line instead of the caller, and
+/// a summary line reports the gap once the client drains again. The file
+/// log stays complete regardless — stderr is only a mirror.
+///
+/// Terminals and regular files are left in blocking mode: they cannot
+/// exert client-controlled backpressure, and O_NONBLOCK on a tty is
+/// shared with the parent shell's own file description.
+class StderrSink final : public spdlog::sinks::base_sink<std::mutex> {
+public:
+    explicit StderrSink(int fd = 2);
+
+    /// Lines dropped so far because the pipe was full (observability).
+    std::size_t dropped() const {
+        return dropped_total.load(std::memory_order_relaxed);
+    }
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override;
+
+    void flush_() override {}
+
+private:
+    /// Write as much as the pipe accepts; false means it filled up (or the
+    /// reader vanished) and the rest of the line was shed.
+    bool try_write(const char* data, std::size_t size);
+
+    int fd;
+    std::atomic<std::size_t> dropped_total = 0;
+    std::size_t dropped_unreported = 0;
+};
+
+}  // namespace clice::logging

--- a/src/support/stderr_sink.h
+++ b/src/support/stderr_sink.h
@@ -22,6 +22,13 @@ namespace clice::logging {
 /// Terminals and regular files are left in blocking mode: they cannot
 /// exert client-controlled backpressure, and O_NONBLOCK on a tty is
 /// shared with the parent shell's own file description.
+/// Undo StderrSink's non-blocking switch on a pipe/socket fd. Workers call
+/// this after dropping their startup mirror: their stderr is reserved for
+/// third-party crash output (assertion failures, sanitizer reports) whose
+/// writers expect blocking semantics, and its reader is the master's
+/// always-running drain — a trusted party, unlike a client.
+void restore_pipe_blocking(int fd = 2);
+
 class StderrSink final : public spdlog::sinks::base_sink<std::mutex> {
 public:
     explicit StderrSink(int fd = 2);
@@ -42,6 +49,9 @@ private:
     bool try_write(const char* data, std::size_t size);
 
     int fd;
+    /// The fd needs non-blocking treatment but could not be switched:
+    /// every line is shed without touching the fd.
+    bool disabled = false;
     std::atomic<std::size_t> dropped_total = 0;
     std::size_t dropped_unreported = 0;
 };

--- a/src/support/stderr_sink.h
+++ b/src/support/stderr_sink.h
@@ -47,14 +47,22 @@ public:
 protected:
     void sink_it_(const spdlog::details::log_msg& msg) override;
 
-    void flush_() override {}
+    /// A flush is a delivery opportunity: push the note and backlog as far
+    /// as the pipe allows, still without ever blocking.
+    void flush_() override;
 
 private:
-    /// Write as much as the pipe accepts; what it refuses is appended to
-    /// `pending` for later flushes.
-    void write_or_buffer(const char* data, std::size_t size);
+    /// Write until the pipe refuses; returns how much it took.
+    std::size_t write_some(const char* data, std::size_t size);
 
-    /// Evict whole oldest lines until the buffer fits its budget.
+    /// Materialize the gap report when drops are unreported and no report
+    /// is already in flight.
+    void stage_note_if_due();
+
+    /// Deliver note remainder, then backlog, in place; true when drained.
+    bool pump();
+
+    /// Evict whole oldest lines until the backlog fits its budget.
     void shed_over_capacity();
 
     int fd;
@@ -62,8 +70,17 @@ private:
     /// every line is shed without touching the fd.
     bool disabled = false;
     std::size_t capacity;
-    /// Bytes the pipe refused, flushed ahead of every later write.
+    /// Gap report in flight, held OUTSIDE the backlog: eviction can never
+    /// lose the count, and it is delivered ahead of everything — the gap
+    /// is older than any survivor. note_sent tracks partial delivery.
+    std::string active_note;
+    std::size_t note_sent = 0;
+    /// Bytes the pipe refused, flushed ahead of fresh content.
     std::string pending;
+    /// The backlog's front continues a line whose head already reached
+    /// the pipe: eviction must not cut it, or the torn line the buffer
+    /// exists to prevent reappears.
+    bool front_partial = false;
     std::atomic<std::size_t> dropped_total = 0;
     std::size_t dropped_unreported = 0;
 };

--- a/tests/integration/agentic/test_agentic.py
+++ b/tests/integration/agentic/test_agentic.py
@@ -455,7 +455,7 @@ async def test_rpc_shutdown(executable, workspace):
     rpc.sock.close()
 
     try:
-        await assert_server_exited_cleanly(c.server)
+        await assert_server_exited_cleanly(c.server, client=c)
     finally:
         await c.stop_io()
 
@@ -575,7 +575,7 @@ async def test_shutdown_during_indexing(executable, tmp_path):
             await c.initialize(workspace, initialization_options=init_options)
         except Exception:
             if c.server.returncode is not None:
-                await assert_server_exited_cleanly(c.server, timeout=15.0)
+                await assert_server_exited_cleanly(c.server, timeout=15.0, client=c)
             raise
 
         # Give indexing a moment to start, then send shutdown
@@ -593,7 +593,7 @@ async def test_shutdown_during_indexing(executable, tmp_path):
             pass
         rpc.sock.close()
 
-        await assert_server_exited_cleanly(c.server, timeout=15.0)
+        await assert_server_exited_cleanly(c.server, timeout=15.0, client=c)
     finally:
         await c.stop_io()
         await asyncio.sleep(0.1)

--- a/tests/integration/server/test_stderr_backpressure.py
+++ b/tests/integration/server/test_stderr_backpressure.py
@@ -1,0 +1,41 @@
+"""A client that never drains stderr must not be able to wedge the server."""
+
+import asyncio
+
+import pytest
+
+from tests.tools.compile_commands import write_cdb
+from tests.tools.lifecycle import make_client, shutdown_client
+
+
+@pytest.mark.timeout(600)
+async def test_stderr_flood_never_wedges(executable, tmp_path):
+    # Editors drain stderr; a client that refuses to must cost log lines,
+    # never liveness. Each hover emits info-level perf lines AND doubles as
+    # the liveness probe: before the fix the event loop parked in write(2)
+    # once the pipe filled (~1000 hovers in) and never answered again.
+    (tmp_path / "probe.cpp").write_text("int value = 42;\n")
+    write_cdb(tmp_path, ["probe.cpp"])
+
+    client = await make_client(executable, tmp_path, drain_stderr=False)
+    try:
+        uri, _ = client.open(tmp_path / "probe.cpp")
+        for i in range(2000):
+            try:
+                hover = await asyncio.wait_for(
+                    client.hover_at(uri, 0, 5, timeout=15), timeout=18
+                )
+            except TimeoutError:
+                # Kill the wedged server first: a graceful teardown against
+                # a process that no longer reads stdin has nothing to wait
+                # for.
+                client.kill_server()
+                pytest.fail(f"server wedged after {i} hovers (stderr backpressure)")
+            assert hover is not None, f"empty hover at {i}"
+    finally:
+        # Hostile phase over: resume draining so teardown can observe pipe
+        # EOF (asyncio's Process.wait() waits on it) and collect the gap
+        # report the sink emits once writes flow again.
+        client.spawn_stderr_pump()
+        await shutdown_client(client)
+    assert b"client not draining" in client.drained_stderr()

--- a/tests/integration/server/test_stderr_backpressure.py
+++ b/tests/integration/server/test_stderr_backpressure.py
@@ -11,6 +11,23 @@ FLOOD_LINES = 3000
 FLOOD_SIZE = 256
 
 
+async def test_log_flood_gated(executable, tmp_path):
+    # The load-generating hook must not exist for ordinary clients.
+    (tmp_path / "probe.cpp").write_text("int value = 42;\n")
+    write_cdb(tmp_path, ["probe.cpp"])
+    client = await make_client(executable, tmp_path)
+    try:
+        with pytest.raises(Exception):
+            await asyncio.wait_for(
+                client.protocol.send_request_async(
+                    "clice/internal/logFlood", {"count": 1, "size": 16}
+                ),
+                timeout=10,
+            )
+    finally:
+        await shutdown_client(client)
+
+
 def flood_lines_in(text: str) -> int:
     return text.count("[stderr-flood ")
 
@@ -26,7 +43,12 @@ async def test_stderr_flood_never_wedges(executable, tmp_path):
     (tmp_path / "probe.cpp").write_text("int value = 42;\n")
     write_cdb(tmp_path, ["probe.cpp"])
 
-    client = await make_client(executable, tmp_path, drain_stderr=False)
+    client = await make_client(
+        executable,
+        tmp_path,
+        drain_stderr=False,
+        initialization_options={"project": {"test_hooks": True}},
+    )
     try:
         uri, _ = client.open(tmp_path / "probe.cpp")
         # ~1MB in ten batches, far past the pipe (~196KB with asyncio's

--- a/tests/integration/server/test_stderr_backpressure.py
+++ b/tests/integration/server/test_stderr_backpressure.py
@@ -7,21 +7,40 @@ import pytest
 from tests.tools.compile_commands import write_cdb
 from tests.tools.lifecycle import make_client, shutdown_client
 
+FLOOD_LINES = 3000
+FLOOD_SIZE = 256
+
+
+def flood_lines_in(text: str) -> int:
+    return text.count("[stderr-flood ")
+
 
 @pytest.mark.timeout(600)
 async def test_stderr_flood_never_wedges(executable, tmp_path):
-    # Editors drain stderr; a client that refuses to must cost log lines,
-    # never liveness. Each hover emits info-level perf lines AND doubles as
-    # the liveness probe: before the fix the event loop parked in write(2)
-    # once the pipe filled (~1000 hovers in) and never answered again.
+    # Editors drain stderr; a client that refuses to must cost mirror
+    # lines — never liveness, and never file-log completeness. The volume
+    # comes from a test hook so it is deterministic: feature log lines
+    # change shape over time and must not be load-bearing here. Before the
+    # fix the event loop parked in write(2) once the pipe filled (~1000
+    # info lines in) and never answered again.
     (tmp_path / "probe.cpp").write_text("int value = 42;\n")
     write_cdb(tmp_path, ["probe.cpp"])
 
     client = await make_client(executable, tmp_path, drain_stderr=False)
     try:
         uri, _ = client.open(tmp_path / "probe.cpp")
-        for i in range(2000):
+        # ~1MB in ten batches, far past the pipe (~196KB with asyncio's
+        # reader buffer) plus the sink's 256KB buffer budget; each hover
+        # in between is a bounded liveness probe.
+        for batch in range(10):
             try:
+                await asyncio.wait_for(
+                    client.protocol.send_request_async(
+                        "clice/internal/logFlood",
+                        {"count": FLOOD_LINES // 10, "size": FLOOD_SIZE},
+                    ),
+                    timeout=18,
+                )
                 hover = await asyncio.wait_for(
                     client.hover_at(uri, 0, 5, timeout=15), timeout=18
                 )
@@ -30,12 +49,25 @@ async def test_stderr_flood_never_wedges(executable, tmp_path):
                 # a process that no longer reads stdin has nothing to wait
                 # for.
                 client.kill_server()
-                pytest.fail(f"server wedged after {i} hovers (stderr backpressure)")
-            assert hover is not None, f"empty hover at {i}"
+                pytest.fail(f"server wedged in batch {batch} (stderr backpressure)")
+            assert hover is not None, f"empty hover in batch {batch}"
     finally:
         # Hostile phase over: resume draining so teardown can observe pipe
         # EOF (asyncio's Process.wait() waits on it) and collect the gap
         # report the sink emits once writes flow again.
         client.spawn_stderr_pump()
         await shutdown_client(client)
-    assert b"client not draining" in client.drained_stderr()
+
+    # Shedding happened where intended: the mirror lost flood lines and
+    # reported the gap...
+    drained = client.drained_stderr().decode("utf-8", errors="replace")
+    assert "client not draining" in drained
+    assert flood_lines_in(drained) < FLOOD_LINES
+
+    # ...while the file log kept every single one: the mirror is
+    # best-effort, the file log is the record.
+    logs_dir = tmp_path / ".clice" / "logs"
+    file_text = "".join(
+        p.read_text(errors="replace") for p in logs_dir.rglob("master.log")
+    )
+    assert flood_lines_in(file_text) == FLOOD_LINES

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -62,6 +62,7 @@ class CliceClient(BaseLanguageClient):
         self.init_result: InitializeResult | None = None
         self.workspace: Path | None = None
         self.stderr_chunks: list[bytes] = []
+        self.stderr_retained = 0
         self.stderr_pump: asyncio.Task | None = None
 
         @self.feature(TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
@@ -160,6 +161,11 @@ class CliceClient(BaseLanguageClient):
         )
         self._async_tasks.append(self.stderr_pump)
 
+    # Retention cap for drained stderr: long stress runs mirror the whole
+    # server log, and the teardown scans only need the tail (sanitizer
+    # reports and crash text arrive at exit).
+    STDERR_RETAIN_BYTES = 8 * 1024 * 1024
+
     async def pump_server_stderr(self) -> None:
         assert self._server is not None and self._server.stderr is not None
         while True:
@@ -167,6 +173,12 @@ class CliceClient(BaseLanguageClient):
             if not data:
                 return
             self.stderr_chunks.append(data)
+            self.stderr_retained += len(data)
+            while (
+                self.stderr_retained > self.STDERR_RETAIN_BYTES
+                and len(self.stderr_chunks) > 1
+            ):
+                self.stderr_retained -= len(self.stderr_chunks.pop(0))
 
     def drained_stderr(self) -> bytes:
         return b"".join(self.stderr_chunks)

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -61,6 +61,8 @@ class CliceClient(BaseLanguageClient):
         self.progress_events: list[dict] = []
         self.init_result: InitializeResult | None = None
         self.workspace: Path | None = None
+        self.stderr_chunks: list[bytes] = []
+        self.stderr_pump: asyncio.Task | None = None
 
         @self.feature(TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
         def on_diagnostics(params: PublishDiagnosticsParams) -> None:
@@ -136,6 +138,36 @@ class CliceClient(BaseLanguageClient):
 
     # Single home for the pygls internals these wrap; tests must not poke
     # at _server/_stop_event/_async_tasks directly.
+
+    async def start_io(self, *args, drain_stderr: bool = True, **kwargs) -> None:
+        await super().start_io(*args, **kwargs)
+        # The server treats stderr as best-effort, but a client that never
+        # reads it forfeits the full mirror (lines are dropped once the
+        # pipe fills). Drain it continuously so long tests keep the whole
+        # transcript; backpressure tests opt out to play the hostile client.
+        if drain_stderr and self._server and self._server.stderr:
+            self.spawn_stderr_pump()
+
+    def spawn_stderr_pump(self) -> None:
+        """Start (or restart) the continuous stderr drain. Backpressure
+        tests spawn it late: asyncio pauses an undrained stderr transport at
+        its buffer limit, and Process.wait() cannot observe pipe EOF —
+        hence process exit — until reading resumes."""
+        self.stderr_pump = asyncio.get_running_loop().create_task(
+            self.pump_server_stderr()
+        )
+        self._async_tasks.append(self.stderr_pump)
+
+    async def pump_server_stderr(self) -> None:
+        assert self._server is not None and self._server.stderr is not None
+        while True:
+            data = await self._server.stderr.read(65536)
+            if not data:
+                return
+            self.stderr_chunks.append(data)
+
+    def drained_stderr(self) -> bytes:
+        return b"".join(self.stderr_chunks)
 
     @property
     def server(self) -> asyncio.subprocess.Process | None:

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -199,16 +199,18 @@ class CliceClient(BaseLanguageClient):
                 self.stderr_retained -= len(self.stderr_chunks.pop(0))
 
     def scan_for_markers(self, data: bytes) -> None:
-        """Latch the first sanitizer fingerprint with some context; the
-        carry covers markers split across read boundaries."""
+        """Latch the earliest sanitizer fingerprint and keep appending
+        context from later reads; the carry covers markers split across
+        read boundaries."""
         if self.stderr_marker_hit is not None:
+            if len(self.stderr_marker_hit) < 4096:
+                self.stderr_marker_hit += data[: 4096 - len(self.stderr_marker_hit)]
             return
         window = self.stderr_scan_carry + data
-        for marker in SANITIZER_MARKER_BYTES:
-            at = window.find(marker)
-            if at >= 0:
-                self.stderr_marker_hit = window[at : at + 4096]
-                return
+        hits = [at for m in SANITIZER_MARKER_BYTES if (at := window.find(m)) >= 0]
+        if hits:
+            self.stderr_marker_hit = window[min(hits) : min(hits) + 4096]
+            return
         self.stderr_scan_carry = window[-64:]
 
     def drained_stderr(self) -> bytes:

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -79,6 +79,7 @@ class CliceClient(BaseLanguageClient):
         self.stderr_chunks: list[bytes] = []
         self.stderr_retained = 0
         self.stderr_pump: asyncio.Task | None = None
+        self.stderr_drained_from_start = True
         self.stderr_marker_hit: bytes | None = None
         self.stderr_scan_carry = b""
 
@@ -163,6 +164,7 @@ class CliceClient(BaseLanguageClient):
         # reads it forfeits the full mirror (lines are dropped once the
         # pipe fills). Drain it continuously so long tests keep the whole
         # transcript; backpressure tests opt out to play the hostile client.
+        self.stderr_drained_from_start = drain_stderr
         if drain_stderr and self._server and self._server.stderr:
             self.spawn_stderr_pump()
 

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -47,6 +47,21 @@ from lsprotocol.types import (
 )
 from pygls.lsp.client import BaseLanguageClient
 
+# Sanitizer/crash fingerprints scanned in server stderr. Detection happens
+# incrementally in the pump: a mid-session report (e.g. relayed from a
+# crashed worker) must survive the retention cap's eviction.
+SANITIZER_MARKERS = (
+    "AddressSanitizer",
+    "LeakSanitizer",
+    "MemorySanitizer",
+    "ThreadSanitizer",
+    "UndefinedBehaviorSanitizer",
+    "==ERROR:",
+    "runtime error:",
+)
+
+SANITIZER_MARKER_BYTES = tuple(m.encode() for m in SANITIZER_MARKERS)
+
 
 class CliceClient(BaseLanguageClient):
     """Language client that tracks server-sent notifications and provides
@@ -64,6 +79,8 @@ class CliceClient(BaseLanguageClient):
         self.stderr_chunks: list[bytes] = []
         self.stderr_retained = 0
         self.stderr_pump: asyncio.Task | None = None
+        self.stderr_marker_hit: bytes | None = None
+        self.stderr_scan_carry = b""
 
         @self.feature(TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
         def on_diagnostics(params: PublishDiagnosticsParams) -> None:
@@ -172,6 +189,7 @@ class CliceClient(BaseLanguageClient):
             data = await self._server.stderr.read(65536)
             if not data:
                 return
+            self.scan_for_markers(data)
             self.stderr_chunks.append(data)
             self.stderr_retained += len(data)
             while (
@@ -179,6 +197,19 @@ class CliceClient(BaseLanguageClient):
                 and len(self.stderr_chunks) > 1
             ):
                 self.stderr_retained -= len(self.stderr_chunks.pop(0))
+
+    def scan_for_markers(self, data: bytes) -> None:
+        """Latch the first sanitizer fingerprint with some context; the
+        carry covers markers split across read boundaries."""
+        if self.stderr_marker_hit is not None:
+            return
+        window = self.stderr_scan_carry + data
+        for marker in SANITIZER_MARKER_BYTES:
+            at = window.find(marker)
+            if at >= 0:
+                self.stderr_marker_hit = window[at : at + 4096]
+                return
+        self.stderr_scan_carry = window[-64:]
 
     def drained_stderr(self) -> bytes:
         return b"".join(self.stderr_chunks)

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -149,10 +149,12 @@ class CliceClient(BaseLanguageClient):
             self.spawn_stderr_pump()
 
     def spawn_stderr_pump(self) -> None:
-        """Start (or restart) the continuous stderr drain. Backpressure
-        tests spawn it late: asyncio pauses an undrained stderr transport at
-        its buffer limit, and Process.wait() cannot observe pipe EOF —
-        hence process exit — until reading resumes."""
+        """Start the continuous stderr drain if none is running.
+        Backpressure tests spawn it late: asyncio pauses an undrained
+        stderr transport at its buffer limit, and Process.wait() cannot
+        observe pipe EOF — hence process exit — until reading resumes."""
+        if self.stderr_pump is not None and not self.stderr_pump.done():
+            return
         self.stderr_pump = asyncio.get_running_loop().create_task(
             self.pump_server_stderr()
         )

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -118,6 +118,13 @@ async def assert_server_exited_cleanly(
     if server.returncode != 0:
         failures.append(f"server exited with code {server.returncode}")
 
+    # A client that drained continuously must never see the drop report:
+    # shedding under a live reader would mean ordinary tests silently lose
+    # parts of the stderr transcript they later assert on.
+    if client is not None and client.stderr_drained_from_start:
+        if "client not draining" in stderr_text:
+            failures.append("stderr mirror shed lines despite a draining client")
+
     marker_hit = client.stderr_marker_hit if client else None
     if marker_hit is not None:
         excerpt = marker_hit.decode("utf-8", errors="replace")

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -107,8 +107,10 @@ async def assert_server_exited_cleanly(
     if pump is not None:
         try:
             await asyncio.wait_for(asyncio.shield(pump), timeout=2.0)
-        except Exception:
-            pass
+        except Exception as exc:
+            # A pump that never saw EOF means the transcript below may be
+            # partial — the sanitizer scan must not silently pass on it.
+            failures.append(f"stderr pump did not complete: {exc!r}")
     elif server.stderr:
         try:
             stderr_data = await asyncio.wait_for(server.stderr.read(), timeout=2.0)

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -81,7 +81,7 @@ def server_stderr_excerpt(stderr_text: str) -> str:
 
 
 async def assert_server_exited_cleanly(
-    server, timeout: float = 10.0, client=None
+    server, timeout: float = 10.0, client: CliceClient | None = None
 ) -> None:
     failures: list[str] = []
 
@@ -103,7 +103,7 @@ async def assert_server_exited_cleanly(
     # running it owns the stream — wait for it to see EOF instead of
     # racing it with a second reader.
     stderr_text = ""
-    pump = getattr(client, "stderr_pump", None) if client else None
+    pump = client.stderr_pump if client else None
     if pump is not None:
         try:
             await asyncio.wait_for(asyncio.shield(pump), timeout=2.0)

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -48,10 +48,12 @@ def find_free_port() -> int:
     raise RuntimeError(f"no free port in range {base}-{base + 99}")
 
 
-async def make_client(executable: Path, workspace: Path) -> CliceClient:
+async def make_client(
+    executable: Path, workspace: Path, *, drain_stderr: bool = True
+) -> CliceClient:
     """Spawn a fresh clice server and initialize it. For multi-session tests."""
     c = CliceClient()
-    await c.start_io(str(executable), "serve")
+    await c.start_io(str(executable), "serve", drain_stderr=drain_stderr)
     await c.initialize(workspace)
     return c
 
@@ -78,7 +80,9 @@ def server_stderr_excerpt(stderr_text: str) -> str:
     return "\n".join(interesting[-80:])
 
 
-async def assert_server_exited_cleanly(server, timeout: float = 10.0) -> None:
+async def assert_server_exited_cleanly(
+    server, timeout: float = 10.0, client=None
+) -> None:
     failures: list[str] = []
 
     if server is None:
@@ -94,13 +98,27 @@ async def assert_server_exited_cleanly(server, timeout: float = 10.0) -> None:
 
     print(f"[server] exit code: {server.returncode}", flush=True)
 
+    # Collect stderr AFTER the exit wait: exit-time output (sanitizer
+    # reports, late crash text) must reach the scan below. When a pump is
+    # running it owns the stream — wait for it to see EOF instead of
+    # racing it with a second reader.
     stderr_text = ""
-    if server.stderr:
+    pump = getattr(client, "stderr_pump", None) if client else None
+    if pump is not None:
+        try:
+            await asyncio.wait_for(asyncio.shield(pump), timeout=2.0)
+        except Exception:
+            pass
+    elif server.stderr:
         try:
             stderr_data = await asyncio.wait_for(server.stderr.read(), timeout=2.0)
             stderr_text = stderr_data.decode("utf-8", errors="replace")
         except Exception as exc:
             failures.append(f"failed to collect server stderr: {exc!r}")
+    if client is not None:
+        stderr_text = (
+            client.drained_stderr().decode("utf-8", errors="replace") + stderr_text
+        )
 
     for line in server_stderr_excerpt(stderr_text).splitlines():
         print(f"[server] {line}", flush=True)
@@ -136,7 +154,7 @@ async def shutdown_client(c: CliceClient, *, verbose: bool = False) -> None:
             print(f"[logMessage/{level}] {msg.message}", flush=True)
 
     try:
-        await assert_server_exited_cleanly(c.server)
+        await assert_server_exited_cleanly(c.server, client=c)
     finally:
         try:
             await c.stop_io()

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -8,17 +8,7 @@ from pathlib import Path
 import pytest
 
 from tests.tools.checks import assert_no_anomaly
-from tests.tools.client import CliceClient
-
-SANITIZER_MARKERS = (
-    "AddressSanitizer",
-    "LeakSanitizer",
-    "MemorySanitizer",
-    "ThreadSanitizer",
-    "UndefinedBehaviorSanitizer",
-    "==ERROR:",
-    "runtime error:",
-)
+from tests.tools.client import SANITIZER_MARKERS, CliceClient
 
 next_port_offset = 0
 
@@ -128,7 +118,13 @@ async def assert_server_exited_cleanly(
     if server.returncode != 0:
         failures.append(f"server exited with code {server.returncode}")
 
-    if any(marker in stderr_text for marker in SANITIZER_MARKERS):
+    marker_hit = client.stderr_marker_hit if client else None
+    if marker_hit is not None:
+        excerpt = marker_hit.decode("utf-8", errors="replace")
+        failures.append(
+            f"server stderr contains sanitizer/runtime error output:\n{excerpt}"
+        )
+    elif any(marker in stderr_text for marker in SANITIZER_MARKERS):
         failures.append("server stderr contains sanitizer/runtime error output")
 
     if failures:

--- a/tests/tools/lifecycle.py
+++ b/tests/tools/lifecycle.py
@@ -39,12 +39,16 @@ def find_free_port() -> int:
 
 
 async def make_client(
-    executable: Path, workspace: Path, *, drain_stderr: bool = True
+    executable: Path,
+    workspace: Path,
+    *,
+    drain_stderr: bool = True,
+    initialization_options: dict | None = None,
 ) -> CliceClient:
     """Spawn a fresh clice server and initialize it. For multi-session tests."""
     c = CliceClient()
     await c.start_io(str(executable), "serve", drain_stderr=drain_stderr)
-    await c.initialize(workspace)
+    await c.initialize(workspace, initialization_options=initialization_options)
     return c
 
 

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -1,0 +1,117 @@
+#include <string>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#include "test/temp_dir.h"
+#include "test/test.h"
+#include "support/stderr_sink.h"
+
+#include "spdlog/details/log_msg.h"
+
+namespace clice::testing {
+
+namespace {
+
+#ifndef _WIN32
+
+spdlog::details::log_msg info_msg(std::string_view text) {
+    return spdlog::details::log_msg(spdlog::source_loc{},
+                                    "test",
+                                    spdlog::level::info,
+                                    spdlog::string_view_t(text.data(), text.size()));
+}
+
+struct Pipe {
+    int fds[2] = {-1, -1};
+
+    Pipe() {
+        [[maybe_unused]] int rc = ::pipe(fds);
+    }
+
+    ~Pipe() {
+        if(fds[0] >= 0) {
+            ::close(fds[0]);
+        }
+        if(fds[1] >= 0) {
+            ::close(fds[1]);
+        }
+    }
+
+    std::string drain() {
+        std::string out;
+        char buf[4096];
+        int flags = ::fcntl(fds[0], F_GETFL);
+        ::fcntl(fds[0], F_SETFL, flags | O_NONBLOCK);
+        while(true) {
+            auto n = ::read(fds[0], buf, sizeof(buf));
+            if(n <= 0) {
+                break;
+            }
+            out.append(buf, static_cast<std::size_t>(n));
+        }
+        ::fcntl(fds[0], F_SETFL, flags);
+        return out;
+    }
+};
+
+TEST_SUITE(StderrSink) {
+
+TEST_CASE(FullPipeDropsLines) {
+    Pipe pipe;
+    logging::StderrSink sink(pipe.fds[1]);
+
+    // Nobody reads: the pipe (64KB) fills and every further line must be
+    // shed on the spot. A blocking regression hangs right here — a clean,
+    // attributable failure.
+    auto line = std::string(100, 'x');
+    for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
+        sink.log(info_msg(line));
+    }
+    EXPECT_TRUE(sink.dropped() > 0);
+}
+
+TEST_CASE(DrainRecoversAndReports) {
+    Pipe pipe;
+    logging::StderrSink sink(pipe.fds[1]);
+
+    auto line = std::string(100, 'y');
+    for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
+        sink.log(info_msg(line));
+    }
+    ASSERT_TRUE(sink.dropped() > 0);
+
+    // The client starts reading again: the next line must be preceded by
+    // the gap report. Everything is synchronous — no waits involved.
+    pipe.drain();
+    sink.log(info_msg("after the flood"));
+    auto out = pipe.drain();
+    EXPECT_TRUE(out.find("client not draining") != std::string::npos);
+    EXPECT_TRUE(out.find("after the flood") != std::string::npos);
+}
+
+TEST_CASE(RegularFileStaysBlocking) {
+    // Only pipes get the non-blocking treatment: a tty's file description
+    // is shared with the parent shell, and regular files cannot exert
+    // client-controlled backpressure.
+    TempDir tmp;
+    tmp.touch("log.txt", "");
+    int fd = ::open(tmp.path("log.txt").c_str(), O_WRONLY | O_APPEND);
+    ASSERT_TRUE(fd >= 0);
+
+    logging::StderrSink sink(fd);
+    EXPECT_TRUE((::fcntl(fd, F_GETFL) & O_NONBLOCK) == 0);
+
+    sink.log(info_msg("to the file"));
+    EXPECT_TRUE(sink.dropped() == 0);
+    ::close(fd);
+}
+
+};  // TEST_SUITE(StderrSink)
+
+#endif
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -15,6 +15,9 @@ namespace clice::testing {
 
 namespace {
 
+// POSIX-only: the Windows PIPE_NOWAIT path has no unit harness (_pipe
+// buffers are not fillable without a reader thread); it is exercised
+// end-to-end by the integration flood test on the Windows CI runner.
 #ifndef _WIN32
 
 spdlog::details::log_msg info_msg(std::string_view text) {
@@ -62,6 +65,7 @@ TEST_SUITE(StderrSink) {
 TEST_CASE(FullPipeDropsLines) {
     Pipe pipe;
     logging::StderrSink sink(pipe.fds[1]);
+    EXPECT_TRUE((::fcntl(pipe.fds[1], F_GETFL) & O_NONBLOCK) != 0);
 
     // Nobody reads: the pipe (64KB) fills and every further line must be
     // shed on the spot. A blocking regression hangs right here — a clean,

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -144,6 +144,36 @@ TEST_CASE(TinyPipeStillReports) {
     sink.log(info_msg("nudge"));
     auto out = pipe.drain();
     EXPECT_TRUE(out.find("client not draining") != std::string::npos);
+    // Eviction must never cut the tail off a partially written line: a
+    // torn line shows as payload immediately followed by the next line's
+    // timestamp bracket, with no newline between.
+    EXPECT_TRUE(out.find("z[") == std::string::npos);
+}
+
+TEST_CASE(NoteSurvivesPressure) {
+    // The gap report lives outside the backlog: pressure that keeps
+    // evicting buffered lines must never evict the count itself.
+    Pipe pipe;
+    ::fcntl(pipe.fds[1], F_SETPIPE_SZ, 4096);
+    logging::StderrSink sink(pipe.fds[1], 8192);
+
+    auto line = std::string(100, 'w');
+    for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
+        sink.log(info_msg(line));
+    }
+    ASSERT_TRUE(sink.dropped() > 0);
+    auto seen = sink.dropped();
+
+    // Keep the flood going well past several full buffer turnovers.
+    for(int i = 0; i < 500; ++i) {
+        sink.log(info_msg(line));
+    }
+    EXPECT_TRUE(sink.dropped() > seen);
+
+    pipe.drain();
+    sink.log(info_msg("nudge"));
+    auto out = pipe.drain();
+    EXPECT_TRUE(out.find("client not draining") != std::string::npos);
 }
 #endif
 

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -2,6 +2,7 @@
 
 #ifndef _WIN32
 #include <fcntl.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #endif
 
@@ -94,6 +95,19 @@ TEST_CASE(DrainRecoversAndReports) {
     auto out = pipe.drain();
     EXPECT_TRUE(out.find("client not draining") != std::string::npos);
     EXPECT_TRUE(out.find("after the flood") != std::string::npos);
+}
+
+TEST_CASE(SocketGetsNonblocking) {
+    // Supervisors attach stderr to sockets; their drain is just as
+    // client-controlled as a pipe's.
+    int fds[2] = {-1, -1};
+    ASSERT_TRUE(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    logging::StderrSink sink(fds[1]);
+    EXPECT_TRUE((::fcntl(fds[1], F_GETFL) & O_NONBLOCK) != 0);
+
+    ::close(fds[0]);
+    ::close(fds[1]);
 }
 
 TEST_CASE(RegularFileStaysBlocking) {

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -122,6 +122,31 @@ TEST_CASE(DrainRecoversAndReports) {
     EXPECT_TRUE(out.find("client not draining") < out.find("after the flood"));
 }
 
+#ifdef F_SETPIPE_SZ
+TEST_CASE(TinyPipeStillReports) {
+    // Windows/macOS pipes are far smaller than Linux's 64KB, so a flushed
+    // backlog takes many calls to deliver — the gap report must ride the
+    // FIRST accepted quantum, not wait for the backlog to clear (that
+    // ordering bug only surfaced on small-pipe CI runners).
+    Pipe pipe;
+    ::fcntl(pipe.fds[1], F_SETPIPE_SZ, 4096);
+    logging::StderrSink sink(pipe.fds[1], 65536);
+
+    auto line = std::string(100, 'z');
+    for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
+        sink.log(info_msg(line));
+    }
+    ASSERT_TRUE(sink.dropped() > 0);
+
+    // Drain only one tiny pipe's worth, log once: the report must already
+    // be in that first quantum even though most of the backlog is not.
+    pipe.drain();
+    sink.log(info_msg("nudge"));
+    auto out = pipe.drain();
+    EXPECT_TRUE(out.find("client not draining") != std::string::npos);
+}
+#endif
+
 TEST_CASE(SocketGetsNonblocking) {
     // Supervisors attach stderr to sockets; their drain is just as
     // client-controlled as a pipe's.

--- a/tests/unit/support/stderr_sink_tests.cpp
+++ b/tests/unit/support/stderr_sink_tests.cpp
@@ -1,3 +1,4 @@
+#include <format>
 #include <string>
 
 #ifndef _WIN32
@@ -65,12 +66,13 @@ TEST_SUITE(StderrSink) {
 
 TEST_CASE(FullPipeDropsLines) {
     Pipe pipe;
-    logging::StderrSink sink(pipe.fds[1]);
+    logging::StderrSink sink(pipe.fds[1], 4096);
     EXPECT_TRUE((::fcntl(pipe.fds[1], F_GETFL) & O_NONBLOCK) != 0);
 
-    // Nobody reads: the pipe (64KB) fills and every further line must be
-    // shed on the spot. A blocking regression hangs right here — a clean,
-    // attributable failure.
+    // Nobody reads: the pipe (64KB) and the buffer budget fill, and every
+    // further line must evict an oldest one instead of blocking. A
+    // blocking regression hangs right here — a clean, attributable
+    // failure.
     auto line = std::string(100, 'x');
     for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
         sink.log(info_msg(line));
@@ -78,9 +80,29 @@ TEST_CASE(FullPipeDropsLines) {
     EXPECT_TRUE(sink.dropped() > 0);
 }
 
-TEST_CASE(DrainRecoversAndReports) {
+TEST_CASE(BackpressureBuffersLines) {
     Pipe pipe;
     logging::StderrSink sink(pipe.fds[1]);
+
+    // More than the pipe holds, less than the buffer budget: a reader
+    // that is merely slow loses nothing.
+    for(int i = 0; i < 600; ++i) {
+        sink.log(info_msg(std::format("line number {}", i)));
+    }
+    EXPECT_TRUE(sink.dropped() == 0);
+
+    auto out = pipe.drain();
+    sink.log(info_msg("the flush trigger"));
+    out += pipe.drain();
+    EXPECT_TRUE(out.find("line number 0") != std::string::npos);
+    EXPECT_TRUE(out.find("line number 599") != std::string::npos);
+    EXPECT_TRUE(out.find("the flush trigger") != std::string::npos);
+    EXPECT_TRUE(sink.dropped() == 0);
+}
+
+TEST_CASE(DrainRecoversAndReports) {
+    Pipe pipe;
+    logging::StderrSink sink(pipe.fds[1], 4096);
 
     auto line = std::string(100, 'y');
     for(int i = 0; i < 5000 && sink.dropped() == 0; ++i) {
@@ -88,13 +110,16 @@ TEST_CASE(DrainRecoversAndReports) {
     }
     ASSERT_TRUE(sink.dropped() > 0);
 
-    // The client starts reading again: the next line must be preceded by
-    // the gap report. Everything is synchronous — no waits involved.
+    // The client starts reading again: one call flushes the buffered
+    // survivors, then the gap report, then the fresh line — everything is
+    // synchronous, no waits involved.
     pipe.drain();
     sink.log(info_msg("after the flood"));
     auto out = pipe.drain();
+    EXPECT_TRUE(out.find('y') != std::string::npos);
     EXPECT_TRUE(out.find("client not draining") != std::string::npos);
     EXPECT_TRUE(out.find("after the flood") != std::string::npos);
+    EXPECT_TRUE(out.find("client not draining") < out.find("after the flood"));
 }
 
 TEST_CASE(SocketGetsNonblocking) {


### PR DESCRIPTION
## Background

The master writes every mirrored log line to stderr synchronously, on the event loop thread. stderr's reader is the client: an editor normally drains it into its output panel, but nothing in the protocol obliges a client to read stderr at all — scripted clients (including our own pygls-based test harness) typically never do. Once such a client lets the 64KB pipe fill, the next `write(2)` parks the event loop inside the kernel forever: the server stops reading stdin, stops answering requests, and cannot recover. The volume needed is unremarkable: ordinary info-level traffic (~1000 request log lines against the pipe plus asyncio's reader buffer) wedges the server deterministically. Reproduced live: main thread parked in `anon_pipe_write` for minutes, and externally draining the pipe revived the server instantly.

Surveyed prior art before fixing: spdlog has no non-blocking or drop-on-full sink of any kind (its only never-block option is the async queue-plus-thread logger), and clangd writes stderr synchronously under a mutex — it bets on the client draining, a bet our own tooling loses. The fix keeps logging fully synchronous and thread-free.

## Fix

`StderrSink` (an spdlog `base_sink`, the library's sanctioned extension point) replaces the stock stderr sink in both logger phases. Behavior chain: **write what fits → buffer what the pipe refuses → shed only past a bounded budget**.

- At construction the fd is switched to non-blocking **only when its drain is externally controlled** — pipes and sockets (POSIX `O_NONBLOCK` behind `S_ISFIFO || S_ISSOCK`; Windows `PIPE_NOWAIT` behind `GetFileType`). Terminals and regular files keep blocking mode: a tty's file description is shared with the parent shell, and neither shape can exert client-controlled backpressure. A pipe that refuses the switch disables the mirror outright (fail closed, with a file-log warning) — writing to it could still wedge the caller.
- Writes stay on the calling thread and never block. What the pipe refuses goes into a bounded in-memory buffer (256KB) flushed in place by later log calls and by `flush_()`: a slow-but-alive reader loses nothing, and torn lines cannot happen — a partially written line's remainder is buffered, and eviction never cuts the tail off a line whose head already reached the pipe.
- Only a reader stuck past the budget costs lines: whole oldest lines are evicted and counted. The gap report lives **outside** the backlog with partial-delivery tracking — continued pressure can evict survivors but never the count — and is delivered ahead of everything as soon as the pipe accepts a single quantum, however small the pipe (macOS pipes are 16KB, Windows anonymous pipes 4–8KB; the first CI iteration gated the report on the backlog fully clearing and starved it on exactly those platforms).
- Workers restore blocking mode right at startup: their stderr is reserved for third-party crash output (assertion failures, sanitizer reports) whose writers expect blocking semantics, and its reader is the master's always-running drain — a trusted party. This holds in rootless initialization too, where no log directory exists.
- The file log is untouched and stays synchronous with per-message flushing — it is the primary record and remains complete regardless of client behavior.

## Tests

The flood volume comes from a `clice/internal/logFlood` test hook (gated behind a `project.test_hooks` initialize option, rejected for ordinary clients) rather than any feature's incidental log lines, so the pressure is deterministic and survives future logging changes. The integration test drives ~1MB through a non-draining client with bounded liveness probes between batches, then asserts three things: the server answered throughout, the drained mirror carries the gap report and lost lines, and the file log contains **every** flood line. A suite-wide harness guard fails any test whose continuously-draining client ever sees the gap report — ordinary tests cannot silently lose mirror output. Unit tests pin the sink synchronously: full pipe sheds instead of blocking, transient backpressure loses nothing, the report survives sustained pressure and rides the first accepted quantum on 4KB pipes (`F_SETPIPE_SZ`), eviction never manufactures torn lines, sockets get the non-blocking treatment, and regular files are left alone. The test harness's pygls client now drains server stderr continuously (as real editors do) with an 8MB retained tail and incremental sanitizer-marker latching, so crash fingerprints survive both retention and mirror shedding.

Verified against `main`: the same flood wedges the server deterministically (`server wedged after ~1000 hovers`); on this branch it passes on every platform.

## Accepted residuals

- Backlog delivery rides later log calls and flush points; a server that goes completely silent holds undelivered mirror bytes until its next line. The file log never lags.
- Crash-path exception: LLVM's stack-trace printer spins on a full non-blocking pipe, so a master crash coinciding with an undrained stderr can stall the dying process (previously it blocked forever in the same corner); the trace is already in the log file either way.
- The Windows `PIPE_NOWAIT` path is exercised end-to-end by the flood test on Windows CI; the unit harness is POSIX-only.