### PR TITLE
fix(completion): render destructor names without tag keyword

### DIFF
--- a/src/semantic/ast_utility.cpp
+++ b/src/semantic/ast_utility.cpp
@@ -22,6 +22,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/CharInfo.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/CodeCompleteConsumer.h"
 
@@ -229,6 +230,10 @@ llvm::StringRef identifier_of(clang::QualType type) {
 std::string name_of(const clang::NamedDecl* decl) {
     llvm::SmallString<128> result;
 
+    /// Use the language options of the declaration's context so that C++ types
+    /// print without their tag keyword, e.g. "~Account" instead of "~struct Account".
+    clang::PrintingPolicy policy(decl->getASTContext().getLangOpts());
+
     auto name = decl->getDeclName();
     switch(name.getNameKind()) {
         case clang::DeclarationName::Identifier: {
@@ -239,25 +244,31 @@ std::string name_of(const clang::NamedDecl* decl) {
         }
 
         case clang::DeclarationName::CXXConstructorName: {
-            result += name.getCXXNameType().getAsString();
+            result += name.getCXXNameType().getAsString(policy);
             break;
         }
 
         case clang::DeclarationName::CXXDestructorName: {
             result += '~';
-            result += name.getCXXNameType().getAsString();
+            result += name.getCXXNameType().getAsString(policy);
             break;
         }
 
         case clang::DeclarationName::CXXConversionFunctionName: {
             result += "operator ";
-            result += name.getCXXNameType().getAsString();
+            result += name.getCXXNameType().getAsString(policy);
             break;
         }
 
         case clang::DeclarationName::CXXOperatorName: {
-            result += "operator ";
-            result += clang::getOperatorSpelling(name.getCXXOverloadedOperator());
+            llvm::StringRef spelling = clang::getOperatorSpelling(name.getCXXOverloadedOperator());
+            result += "operator";
+            /// Mirror DeclarationName::print: separate with a space only for
+            /// word-like operators such as "new", "delete" and "co_await".
+            if(clang::isLowercase(spelling.front())) {
+                result += ' ';
+            }
+            result += spelling;
             break;
         }
 

--- a/tests/unit/feature/code_completion_tests.cpp
+++ b/tests/unit/feature/code_completion_tests.cpp
@@ -403,6 +403,90 @@ void bar() {
     ASSERT_TRUE(edit.new_text.find("${1:") != std::string::npos);
 }
 
+TEST_CASE(DestructorPlainName) {
+    code_complete(R"cpp(
+struct Account {
+    int balance;
+};
+
+void bar() {
+    Account acc;
+    acc.$(pos)
+}
+)cpp");
+
+    auto it = find_item("~Account");
+    ASSERT_TRUE(it != items.end());
+    auto& edit = std::get<protocol::TextEdit>(*it->text_edit);
+    ASSERT_EQ(edit.new_text, "~Account");
+
+    // No item may leak the tag keyword into its label or insert text.
+    for(auto& item: items) {
+        ASSERT_TRUE(item.label.find("~struct") == std::string::npos);
+        auto& text = std::get<protocol::TextEdit>(*item.text_edit).new_text;
+        ASSERT_TRUE(text.find("~struct") == std::string::npos);
+    }
+}
+
+TEST_CASE(DestructorTemplateClass) {
+    code_complete(R"cpp(
+template <typename T>
+struct Box {
+    T value;
+};
+
+void bar() {
+    Box<int> b;
+    b.$(pos)
+}
+)cpp");
+
+    auto it = find_item("~Box<int>");
+    ASSERT_TRUE(it != items.end());
+    auto& edit = std::get<protocol::TextEdit>(*it->text_edit);
+    ASSERT_EQ(edit.new_text, "~Box<int>");
+}
+
+TEST_CASE(ConversionOperatorPlainName) {
+    code_complete(R"cpp(
+struct Wallet {
+    int cents;
+};
+
+struct Account {
+    operator Wallet();
+};
+
+void bar() {
+    Account acc;
+    acc.$(pos)
+}
+)cpp");
+
+    auto it = find_item("operator Wallet");
+    ASSERT_TRUE(it != items.end());
+    for(auto& item: items) {
+        ASSERT_TRUE(item.label.find("operator struct") == std::string::npos);
+    }
+}
+
+TEST_CASE(OperatorAssignNoSpace) {
+    code_complete(R"cpp(
+struct Account {
+    int balance;
+};
+
+void bar() {
+    Account acc;
+    acc.$(pos)
+}
+)cpp");
+
+    auto it = find_item("operator=");
+    ASSERT_TRUE(it != items.end());
+    ASSERT_TRUE(find_item("operator =") == items.end());
+}
+
 TEST_CASE(Unqualified) {
     code_complete(R"cpp(
 namespace A {


### PR DESCRIPTION
## Problem

Member completion renders destructor items with the class type tag keyword: completing after `acc.` for `struct Account` yields label and insert text `~struct Account` — accepting it produces `acc.~struct Account`, which does not compile. The adjacent operator rendering also emits `operator =` with an embedded space.

## Fix

The completion label comes from `ast::name_of()` (src/semantic/ast_utility.cpp), which printed constructor/destructor/conversion name types through `QualType::getAsString()` with a default-constructed `PrintingPolicy` (empty `LangOptions`) — that keeps the tag keyword. The policy is now built from the declaration own `ASTContext::getLangOpts()` (which sets `SuppressTagKeyword` for C++) for all three name kinds. Operator spacing now mirrors clang `DeclarationName::print`: a space only for word-like operators (`operator new`, `operator co_await`); `operator=` is spaceless. C-mode TUs keep the tag keyword, matching clang.

## Testing

- Tests written FIRST and confirmed failing on the old code: destructor label and `TextEdit.new_text` exactly `~Account` (and no item contains `~struct`), template class `~Box<int>`, `operator=` without the space, and conversion-operator rendering — pre-fix actuals were `~struct Account` / `operator =`.
- 3-agent pre-PR review (correctness / style / tests) passed; a conversion-to-class-type test was added from review feedback.
- Rebased onto latest main; full local gates on the rebased state: format clean, unit 997, integration 283, smoke 3/3 — all green (RelWithDebInfo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ code completion formatting for destructors, including templated destructors.
  * Corrected conversion operator labels by removing unwanted type qualifiers.
  * Standardized assignment operator completion to use `operator=` without extra spacing.
  * Improved formatting for C++ constructors, destructors, conversion functions, and operator names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->