### PR TITLE
fix(semantic): restore RAV data recursion to avoid stack overflow

### DIFF
--- a/src/compile/compilation.cpp
+++ b/src/compile/compilation.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Support/Error.h"
 #include "llvm/Support/xxhash.h"
+#include "clang/Basic/Stack.h"
 #include "clang/Frontend/MultiplexConsumer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
@@ -331,6 +332,12 @@ CompilationUnit run_clang(CompilationParams& params,
                           llvm::function_ref<void(clang::CompilerInstance&)> before_execute = {},
                           llvm::function_ref<void(CompilationUnitRef)> after_execute = {}) {
     LOG_DEBUG("Compile command: {}", print_argv(params.arguments));
+
+    // Record the stack bottom so that clang's own recursion guards
+    // (`clang::runWithSufficientStackSpace` in the parser, constant
+    // evaluator, etc.) actually work. They are inert without it and
+    // deeply nested code would overflow the stack during parsing.
+    clang::noteBottomOfStack();
 
     auto self = new CompilationUnitRef::Self();
     self->kind = params.kind;

--- a/src/semantic/filtered_ast_visitor.h
+++ b/src/semantic/filtered_ast_visitor.h
@@ -76,18 +76,25 @@ public:
         }
     }
 
-    bool TraverseStmt(clang::Stmt* stmt) {
+    using DataRecursionQueue = typename Base::DataRecursionQueue;
+
+    /// Keep the `DataRecursionQueue` parameter so that `RecursiveASTVisitor`
+    /// still dispatches statements through its iterative data recursion.
+    /// Overriding the single-parameter form would silently disable it and
+    /// deep expression chains (e.g. a huge macro-generated `1+1+...+1`
+    /// initializer) would overflow the stack.
+    bool TraverseStmt(clang::Stmt* stmt, DataRecursionQueue* queue = nullptr) {
         CHECK_DERIVED_IMPL(TraverseStmt);
 
         if(!stmt) {
             return true;
         }
 
-        return Base::TraverseStmt(stmt);
+        return Base::TraverseStmt(stmt, queue);
     }
 
     /// FIXME: See https://github.com/llvm/llvm-project/issues/117687.
-    bool TraverseAttributedStmt(clang::AttributedStmt* stmt) {
+    bool TraverseAttributedStmt(clang::AttributedStmt* stmt, DataRecursionQueue* queue = nullptr) {
         CHECK_DERIVED_IMPL(TraverseAttributedStmt);
 
         if(!stmt) {
@@ -98,7 +105,7 @@ public:
             Base::TraverseAttr(const_cast<clang::Attr*>(attr));
         }
 
-        return Base::TraverseAttributedStmt(stmt);
+        return Base::TraverseAttributedStmt(stmt, queue);
     }
 
     /// We don't want to node without location information.

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -5,9 +5,12 @@
 #include "test/test.h"
 #include "test/tester.h"
 #include "feature/feature.h"
+#include "feature/inactive_regions.h"
 #include "index/tu_index.h"
 
 #include "kota/meta/enum.h"
+#include "llvm/Support/thread.h"
+#include "clang/Basic/Stack.h"
 
 namespace clice::testing {
 
@@ -820,6 +823,51 @@ int x = 1;
     auto include = graph.include_location_id(fid);
     ASSERT_TRUE(include != static_cast<std::uint32_t>(-1));
     ASSERT_TRUE(graph.path(graph.path_id(fid)).ends_with("foo.h"));
+}
+
+TEST_CASE(DeepExpressionChain) {
+    // Doubling macros expand to a ~32k-term binary expression chain.
+    // Regression test: indexing such an AST must not overflow the stack.
+    std::string code = "#define A0 1+1\n";
+    for(int i = 1; i <= 14; i++) {
+        code += std::format("#define A{} A{}+A{}\n", i, i - 1, i - 1);
+    }
+    code += "int bomb = A14;\n";
+    auto bomb_offset = static_cast<std::uint32_t>(code.find("bomb"));
+
+    add_main("main.cpp", code);
+
+    // Compile on a generous fixed-size stack: clang's own Sema checkers
+    // recurse once per term and need more than a default thread stack in
+    // sanitized builds (and Windows main threads only get 1MB). 32MB is
+    // an empirical bound with margin, not a derived number.
+    bool compiled = false;
+    llvm::thread compile_thread(std::optional<unsigned>(4 * clang::DesiredStackSize),
+                                [&] { compiled = compile(); });
+    compile_thread.join();
+    ASSERT_TRUE(compiled);
+
+    // Index on a deliberately tight stack: the traversal must use
+    // constant stack space however deep the expression is, so any
+    // reintroduced per-node recursion crashes here deterministically
+    // instead of only on production workers with deeper files.
+    feature::InactiveScan scan;
+    llvm::thread index_thread(std::optional<unsigned>(clang::DesiredStackSize / 4), [&] {
+        // Mirror the stateful worker's post-compile sequence.
+        scan = feature::inactive_regions(*unit);
+        tu_index = index::TUIndex::build(*unit, true);
+    });
+    index_thread.join();
+
+    ASSERT_TRUE(scan.regions.empty());
+
+    // The traversal must have actually reached the decl behind the chain,
+    // not bailed out early: expect an occurrence exactly at `bomb`.
+    auto& occurrences = tu_index.main_file_index.occurrences;
+    auto bomb = std::ranges::find(occurrences, bomb_offset, [](index::Occurrence& occurrence) {
+        return occurrence.range.begin;
+    });
+    ASSERT_TRUE(bomb != occurrences.end());
 }
 
 };  // TEST_SUITE(tu_index)


### PR DESCRIPTION
## Problem

Opening a file whose initializer expands to a very deep expression chain (e.g. `#define A0 1+1` doubled 14 times, giving a ~32k-term `1+1+...+1` initializer) crashes the stateful worker with SIGSEGV. The compile itself succeeds (`Compile done` is logged), then the worker dies while building the index for the translation unit. The crash-quarantine machinery contains it, but crashing on legitimate machine-generated code is unacceptable.

## Root cause

`FilteredASTVisitor` overrode `TraverseStmt` and `TraverseAttributedStmt` with single-parameter signatures. `RecursiveASTVisitor`'s statement dispatch (`TRAVERSE_STMT_BASE`) detects that signature mismatch and silently falls back to plain per-child recursion, disabling clang's built-in iterative (heap-queue) data recursion for statements. Recursion depth therefore equaled expression depth, and a deep `BinaryOperator` chain overflowed the worker thread's stack.

## Fix

- Restore the `DataRecursionQueue` parameter on both overrides so statement dispatch stays iterative (O(1) stack for statement chains). This protects every `FilteredASTVisitor`/`SemanticVisitor` consumer — TU indexing, semantic tokens, document symbols, inlay hints, folding ranges — at the single shared dispatch point.
- Call `clang::noteBottomOfStack()` in `run_clang` so clang's own `runWithSufficientStackSpace` guards (parser, etc.) actually function in-process; they are inert without it. cc1 and clangd both do this on their worker threads.

## Test

`tu_index.DeepExpressionChain` generates the doubling-macro source in the test, compiles it on a generous 32MB thread (clang's own unguarded Sema checker recursion needs more than sanitizer-default stacks), then indexes on a deliberately tight 2MB thread. With the fix reverted the test segfaults deterministically (3/3 runs); with the fix it passes on both RelWithDebInfo (~85ms) and Debug+ASan (~640ms). It asserts an occurrence at the variable's exact offset so a silent early-bailout would also be caught.

## Verification

- Unit, integration, and smoke suites green on RelWithDebInfo; full unit suite green on Debug (ASan).
- Verified the two-parameter signature matches RAV's `has_same_member_pointer_type` check, so derived dispatch and data recursion are both active; traversal order and per-node callback counts are unchanged (data recursion vs plain recursion differ only in stack usage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when parsing and indexing very deeply nested or expanded expressions.
  * Preserved recursive traversal behavior during AST processing to prevent failures on complex source code.

* **Tests**
  * Added coverage for large macro-expanded expression chains and indexing under constrained stack conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->