### PR TITLE
fix(server): retract corrupt PCH pairs instead of trusting them

### DIFF
--- a/src/compile/diagnostic.cpp
+++ b/src/compile/diagnostic.cpp
@@ -140,6 +140,18 @@ bool DiagnosticID::is_unused() const {
     return source == DiagnosticSource::Clang && unused_diags.contains(value);
 }
 
+bool DiagnosticID::is_deserialization_error() const {
+    // Category membership rather than an ID list: the family is large
+    // (DiagnosticSerializationKinds) and grows across clang versions,
+    // while the category is stable. Resolved through a member of the
+    // family instead of a hard-coded category number.
+    const static unsigned category =
+        clang::DiagnosticIDs::getCategoryNumberForDiag(clang::diag::err_fe_ast_file_malformed);
+    return source == DiagnosticSource::Clang &&
+           (level == DiagnosticLevel::Error || level == DiagnosticLevel::Fatal) &&
+           clang::DiagnosticIDs::getCategoryNumberForDiag(value) == category;
+}
+
 bool is_note(clang::DiagnosticsEngine::Level level) {
     return level == clang::DiagnosticsEngine::Note || level == clang::DiagnosticsEngine::Remark;
 }

--- a/src/compile/diagnostic.h
+++ b/src/compile/diagnostic.h
@@ -50,6 +50,14 @@ struct DiagnosticID {
 
     /// Whether this diagnostic represents an unused diagnostic.
     bool is_unused() const;
+
+    /// Whether this diagnostic reports a failure to read a prebuilt
+    /// artifact (PCH/PCM) — clang's "AST Deserialization Issue" category.
+    /// Messages in this family do not reliably carry the artifact path
+    /// (e.g. "malformed or corrupted precompiled file: 'Blob ends too
+    /// soon'"), so consumers that must blame a specific artifact combine
+    /// this with a path match over the inputs they passed.
+    bool is_deserialization_error() const;
 };
 
 struct Diagnostic {

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -930,6 +930,13 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             co_return;
         }
 
+        // The pair this round consumes, snapshotted at dispatch: the
+        // reply handling below must retract what it actually used —
+        // pch_key can be rewritten while the send is suspended (a context
+        // switch, a concurrent completion round), and blaming the current
+        // key would delete an unrelated pair.
+        auto dispatched_pch_key = session->pch_key;
+
         // A PCH crash inside ensure_deps may have tipped the document into
         // quarantine — the entry gate ran before the streak grew. Stop
         // before the stateful dispatch instead of feeding the same content
@@ -1023,12 +1030,14 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
             // contains it (the extra rebuilds stay bounded by that
             // budget).
             if(result.error().code == worker::dispatch_errc::worker_crashed &&
-               session->pch_key.has_value() && !params.pch.first.empty()) {
+               dispatched_pch_key.has_value() && !params.pch.first.empty()) {
                 LOG_WARN("Compile crashed consuming PCH pair {} for {}; retracting the pair",
-                         *session->pch_key,
+                         *dispatched_pch_key,
                          uri_str);
-                invalidate_pch(*session->pch_key);
-                session->pch_key.reset();
+                invalidate_pch(*dispatched_pch_key);
+                if(session->pch_key == dispatched_pch_key) {
+                    session->pch_key.reset();
+                }
             }
             // A quarantined document announces itself instead of hiding
             // behind the empty list; the clear path publishes empty
@@ -1061,19 +1070,29 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         // path below: retracting a healthy shared PCH over someone else's
         // failure would rebuild it on every request for as long as that
         // failure persists.
-        if(result.value().pch_suspect && session->pch_key.has_value() &&
-           !params.pch.first.empty() && !artifact_retried) {
-            artifact_retried = true;
-            LOG_WARN("Compile blamed PCH pair {} for {}; retracting the pair and rebuilding",
-                     *session->pch_key,
+        if(result.value().pch_suspect && dispatched_pch_key.has_value() &&
+           !params.pch.first.empty()) {
+            LOG_WARN("Compile blamed PCH pair {} for {}; retracting the pair",
+                     *dispatched_pch_key,
                      uri_str);
-            invalidate_pch(*session->pch_key);
-            session->pch_key.reset();
-            // Rerun the same attempt so the trial semantics are untouched
-            // (the loop counter is about probe rounds, not artifact
-            // retries).
-            --attempt;
-            continue;
+            // Retract unconditionally — a blamed pair never survives, even
+            // when the retry budget is spent — but rerun only once.
+            invalidate_pch(*dispatched_pch_key);
+            if(session->pch_key == dispatched_pch_key) {
+                session->pch_key.reset();
+            }
+            if(!artifact_retried) {
+                artifact_retried = true;
+                // Rerun the same attempt so the trial semantics are
+                // untouched (the loop counter is about probe rounds, not
+                // artifact retries).
+                --attempt;
+                continue;
+            }
+            // The rebuilt pair is blamed again: the storage itself is
+            // failing, and another rebuild would fare no better. The
+            // round proceeds — a Done reply publishes its real fatal
+            // diagnostics, a non-Done one falls to the honest gap below.
         }
 
         // A non-Done reply past the gate is a non-result: settling it

--- a/src/server/compiler/compiler.cpp
+++ b/src/server/compiler/compiler.cpp
@@ -414,6 +414,19 @@ static bool may_write_pch_key(const Session& session,
     return session.generation == launch_generation && session.dirty_epoch == launch_epoch;
 }
 
+void Compiler::invalidate_pch(llvm::StringRef pch_key) {
+    if(workspace.store) {
+        workspace.store->invalidate("pch", pch_key);
+    }
+    // An in-flight rebuild owns the entry (BuildingGuard); its commit will
+    // republish fresh blobs over the retracted pair, so only a settled
+    // entry is dropped here.
+    if(auto it = workspace.pch_cache.find(pch_key);
+       it != workspace.pch_cache.end() && !it->second.building) {
+        workspace.pch_cache.erase(it);
+    }
+}
+
 kota::task<bool> Compiler::ensure_pch(Session& session,
                                       std::uint64_t launch_generation,
                                       std::uint64_t launch_epoch,
@@ -868,6 +881,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
     // without a prefix first; if the diagnostics indicate missing includer
     // context, the second round re-compiles with a synthesized prefix.
     // The trial's diagnostics are never published.
+    bool artifact_retried = false;
     for(int attempt = 0; attempt < 2; ++attempt) {
         worker::CompileParams params;
         params.path = file_path;
@@ -936,8 +950,7 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
         std::vector<std::uint32_t> pch_inactive;
         std::shared_ptr<index::PreambleState> preamble_state;
         if(session->pch_key.has_value()) {
-            auto it = workspace.pch_cache.find(*session->pch_key);
-            preamble_state = it != workspace.pch_cache.end() ? it->second.load_state() : nullptr;
+            preamble_state = workspace.preamble_state(*session->pch_key);
         }
         if(preamble_state) {
             auto regions = preamble_state->inactive_regions();
@@ -1000,9 +1013,83 @@ kota::task<> Compiler::run_compile(std::shared_ptr<Session> session) {
                             uri_str,
                             result.error().message);
             }
+            // A death while consuming a prebuilt pair may be the pair's
+            // fault: deep corruption aborts the AST reader
+            // (report_fatal_error in the bitstream reader) before any
+            // diagnostic can anchor, so the attributable shapes above
+            // never get a say. Retract the pair — a corrupt artifact then
+            // heals on the next compile, while a genuinely poisonous
+            // document keeps crashing and its own quarantine budget still
+            // contains it (the extra rebuilds stay bounded by that
+            // budget).
+            if(result.error().code == worker::dispatch_errc::worker_crashed &&
+               session->pch_key.has_value() && !params.pch.first.empty()) {
+                LOG_WARN("Compile crashed consuming PCH pair {} for {}; retracting the pair",
+                         *session->pch_key,
+                         uri_str);
+                invalidate_pch(*session->pch_key);
+                session->pch_key.reset();
+            }
             // A quarantined document announces itself instead of hiding
             // behind the empty list; the clear path publishes empty
             // diagnostics without a version and no inactive regions.
+            if(session->quarantine.active()) {
+                publish_quarantined(session, source, suffix_line_limit);
+            } else {
+                session->output = CompileOutput{
+                    .version = std::nullopt,
+                    .source = source,
+                    .diagnostics = kota::codec::RawValue{},
+                    .line_limit = suffix_line_limit,
+                    .inactive_regions = std::nullopt,
+                };
+                on_output.emit(session);
+            }
+            co_return;
+        }
+
+        // The artifact quality gate: a failed parse whose diagnostics name
+        // the consumed PCH (worker-side pch_suspect — setup failure and
+        // fatal error alike). ensure_pch validated the pair fresh via its
+        // deps, yet the frontend could not read it — the bytes on disk
+        // are the suspect. Retract the pair (store + cache) and rerun the
+        // round once; ensure_pch misses and rebuilds both halves. Without
+        // this write-back a corrupt blob is trusted for the life of the
+        // store and the file stays broken on every restart. A setup
+        // failure whose diagnostics do NOT name the blob (bad invocation,
+        // broken module input) deliberately falls through to the non-Done
+        // path below: retracting a healthy shared PCH over someone else's
+        // failure would rebuild it on every request for as long as that
+        // failure persists.
+        if(result.value().pch_suspect && session->pch_key.has_value() &&
+           !params.pch.first.empty() && !artifact_retried) {
+            artifact_retried = true;
+            LOG_WARN("Compile blamed PCH pair {} for {}; retracting the pair and rebuilding",
+                     *session->pch_key,
+                     uri_str);
+            invalidate_pch(*session->pch_key);
+            session->pch_key.reset();
+            // Rerun the same attempt so the trial semantics are untouched
+            // (the loop counter is about probe rounds, not artifact
+            // retries).
+            --attempt;
+            continue;
+        }
+
+        // A non-Done reply past the gate is a non-result: settling it
+        // would freeze the document on a product that never existed —
+        // empty diagnostics, no index, an empty deps snapshot nothing can
+        // invalidate. Superseded rounds were already discarded at the
+        // generation gate above, so this round's inputs are broken in a
+        // way a PCH rebuild cannot fix.
+        if(result.value().status != worker::CompileStatus::Done) {
+            LOG_WARN("Compile produced no result for {} (status={})",
+                     uri_str,
+                     static_cast<int>(result.value().status));
+            // ast_dirty stays set: the next request recompiles instead of
+            // trusting the phantom product. Publish the honest gap like
+            // the dispatch-failure path above — versionless empty
+            // diagnostics rather than a stale list posing as current.
             if(session->quarantine.active()) {
                 publish_quarantined(session, source, suffix_line_limit);
             } else {

--- a/src/server/compiler/compiler.h
+++ b/src/server/compiler/compiler.h
@@ -192,6 +192,12 @@ private:
     bool is_stale(Session& session);
     void record_deps(Session& session, llvm::ArrayRef<DepFile> deps, std::int64_t build_at);
 
+    /// Retract a PCH pair the frontend could not consume: remove both
+    /// blobs from the store and drop the settled cache entry, so the next
+    /// ensure_pch misses and rebuilds instead of trusting corrupt bytes
+    /// for the life of the store.
+    void invalidate_pch(llvm::StringRef pch_key);
+
     kota::event_loop& loop;
     Workspace& workspace;
     ContextResolver& contexts;

--- a/src/server/protocol/worker.h
+++ b/src/server/protocol/worker.h
@@ -117,7 +117,34 @@ struct CompileParams {
     std::vector<std::uint8_t> open_conditionals;
 };
 
+/// Outcome of a stateful compile. Anything but `Done` is a non-result: the
+/// master must not settle the session, record dependencies, or publish the
+/// (empty) diagnostics as current — doing so freezes the document on a
+/// product that never existed.
+enum class CompileStatus : uint8_t {
+    /// The parse produced a usable product — a complete AST, or a fatal
+    /// error whose diagnostics describe the user's code.
+    Done,
+    /// The parse was interrupted by CancelCompile (superseded round).
+    Cancelled,
+    /// The frontend failed before parsing began: bad invocation, or a
+    /// prebuilt input (PCH/PCM) clang could not read. Whether the consumed
+    /// PCH is to blame is a separate signal (pch_suspect).
+    SetupFail,
+};
+
 struct CompileResult {
+    CompileStatus status = CompileStatus::Done;
+
+    /// The parse failed and its diagnostics blame the consumed PCH — they
+    /// name the blob's path, or they are AST-deserialization errors naming
+    /// no other prebuilt input. Holds whether the reader rejected the blob
+    /// at setup or hit a fatal error past it (a Done status with real,
+    /// publishable diagnostics). Either way the artifact is the culprit:
+    /// the master should retract the pair and rebuild instead of trusting
+    /// the corrupt bytes until the preamble changes.
+    bool pch_suspect = false;
+
     int version;
     /// Diagnostics serialized as JSON (RawValue) to avoid bincode/serde annotation conflicts.
     kota::codec::RawValue diagnostics;

--- a/src/server/service/feature_router.cpp
+++ b/src/server/service/feature_router.cpp
@@ -40,10 +40,7 @@ static kota::ipc::Error item_not_resolved(llvm::StringRef kind) {
 std::vector<feature::DocumentLink> FeatureRouter::find_preamble_links(const Session& session) {
     if(!session.pch_key)
         return {};
-    auto it = workspace.pch_cache.find(*session.pch_key);
-    if(it == workspace.pch_cache.end())
-        return {};
-    auto& state = it->second.load_state();
+    auto state = workspace.preamble_state(*session.pch_key);
     if(!state)
         return {};
     // Link offsets are buffer coordinates as of the PCH build; serve them

--- a/src/server/service/query.cpp
+++ b/src/server/service/query.cpp
@@ -49,13 +49,9 @@ std::shared_ptr<index::PreambleState> IndexQuery::overlay_of(const Session& sess
     if(!session.pch_key) {
         return nullptr;
     }
-    auto it = workspace.pch_cache.find(*session.pch_key);
-    if(it == workspace.pch_cache.end()) {
-        return nullptr;
-    }
-    // Return the shared_ptr by value: consumers run synchronously, but a
-    // reference into the map value would not survive a rehash.
-    return it->second.load_state();
+    // Returned by value: consumers run synchronously, but a reference into
+    // the map value would not survive a rehash.
+    return workspace.preamble_state(*session.pch_key);
 }
 
 void IndexQuery::visit_overlays(

--- a/src/server/state/workspace.cpp
+++ b/src/server/state/workspace.cpp
@@ -380,6 +380,27 @@ const std::shared_ptr<index::PreambleState>& PCHState::load_state() {
     return state;
 }
 
+std::shared_ptr<index::PreambleState> Workspace::preamble_state(llvm::StringRef pch_key) {
+    auto it = pch_cache.find(pch_key);
+    if(it == pch_cache.end()) {
+        return nullptr;
+    }
+
+    auto& st = it->second;
+    bool had_blob = !st.index_path.empty();
+    auto state = st.load_state();
+    if(!state && had_blob && store) {
+        // The blob was just found unreadable (load_state cleared the
+        // path): a pair that looks complete on disk but cannot be opened
+        // would be served to every session for the rest of the store's
+        // life. Retract it now; the entry itself stays until ensure_pch
+        // re-checks the store and rebuilds the pair.
+        LOG_WARN("Retracting PCH pair {} with unreadable PreambleState blob", pch_key);
+        store->invalidate("pch", pch_key);
+    }
+    return state;
+}
+
 void Workspace::load_cache(ContextResolver& contexts) {
     if(!store)
         return;

--- a/src/server/state/workspace.h
+++ b/src/server/state/workspace.h
@@ -290,6 +290,14 @@ struct Workspace {
     /// is a module unit so dependents can be re-evaluated on next compile.
     void on_file_closed(std::uint32_t path_id);
 
+    /// Open the PreambleState blob of a cached PCH. The single consumption
+    /// gate for `.pch.idx` blobs: when the blob turns out unreadable, the
+    /// on-disk pair is retracted from the store as well — otherwise every
+    /// later session re-adopts the corrupt pair from cache.json and
+    /// silently degrades again. With the pair gone the next ensure_pch is
+    /// a miss and rebuilds both halves.
+    std::shared_ptr<index::PreambleState> preamble_state(llvm::StringRef pch_key);
+
     /// Load PCH/PCM validity metadata plus the context resolver's slices
     /// from cache.json (under the store's versioned root); entries whose
     /// blob is gone from the store are dropped.

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -307,6 +307,19 @@ void StatefulWorker::register_handlers() {
                     llvm::raw_string_ostream os(result.tu_index_data);
                     tu_index.serialize(os);
                 }
+
+                // A unit that is neither complete nor a fatal-error result
+                // can never serve a query (with_ast_or refuses it), yet it
+                // pins the consumed artifacts — on Windows a mapped PCH
+                // cannot be replaced on disk, so holding it would block
+                // the master's rebuild of a retracted pair. Drop it last,
+                // after every use of the unit above; queries observe
+                // has_ast == false and return their missing value until a
+                // compile lands.
+                if(!doc->unit.completed() && !doc->unit.fatal_error()) {
+                    doc->unit = CompilationUnit(nullptr);
+                    doc->has_ast = false;
+                }
                 return result;
             },
             [stop] { stop->store(true, std::memory_order_relaxed); });

--- a/src/server/worker/stateful_worker.cpp
+++ b/src/server/worker/stateful_worker.cpp
@@ -1,5 +1,6 @@
 #include "server/worker/stateful_worker.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <list>
@@ -246,6 +247,34 @@ void StatefulWorker::register_handlers() {
 
                 worker::CompileResult result;
                 result.version = doc->version;
+
+                // A failed parse that blames the consumed PCH: either a
+                // diagnostic names the blob's path outright, or it is an
+                // AST-deserialization error naming no other prebuilt input
+                // (that family's messages do not reliably carry the path —
+                // "malformed or corrupted precompiled file: 'Blob ends too
+                // soon'"). User-code failures (missing include, modified
+                // header, bad flags) match neither, so the master never
+                // rebuilds an innocent shared PCH over a failure it did
+                // not cause. An anonymous read error with PCMs in play is
+                // ambiguous; blaming the PCH costs at most one retracted
+                // pair per round and self-corrects on the retry.
+                if(!doc->unit.completed() && !doc->pch.first.empty()) {
+                    result.pch_suspect =
+                        std::ranges::any_of(doc->unit.diagnostics(), [&](auto& diag) {
+                            llvm::StringRef message = diag.message;
+                            if(message.contains(doc->pch.first)) {
+                                return true;
+                            }
+                            if(!diag.id.is_deserialization_error()) {
+                                return false;
+                            }
+                            return std::ranges::none_of(doc->pcms, [&](auto& entry) {
+                                return message.contains(entry.getValue());
+                            });
+                        });
+                }
+
                 if(doc->unit.completed() || doc->unit.fatal_error()) {
                     auto diags = feature::diagnostics(doc->unit);
                     auto json = kota::codec::json::to_json<kota::ipc::lsp_config>(diags);
@@ -256,8 +285,13 @@ void StatefulWorker::register_handlers() {
                              diags.size(),
                              doc->unit.fatal_error());
                 } else {
+                    result.status = doc->unit.setup_fail() ? worker::CompileStatus::SetupFail
+                                                           : worker::CompileStatus::Cancelled;
                     result.diagnostics = kota::codec::RawValue{"[]"};
-                    LOG_WARN("Compile incomplete: path={}, {}ms", params.path, timer.ms());
+                    LOG_WARN("Compile incomplete: path={}, {}ms, setup_fail={}",
+                             params.path,
+                             timer.ms(),
+                             doc->unit.setup_fail());
                 }
                 result.memory_usage = 0;  // TODO: query actual memory
                 if(doc->unit.completed() && !stop->load(std::memory_order_relaxed)) {

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -618,6 +618,7 @@ async def test_corrupt_pch_rebuilt_on_restart(executable, tmp_path, where):
         # The flip landed in semantically dead bytes on this LLVM build
         # (PCH blobs carry no whole-file checksum): the reader consumed
         # the blob untouched and there is nothing to heal.
+        await shutdown_client(c2)
         pytest.skip("mid-file flip was semantically dead on this build")
     assert pch_files[0].read_bytes() != corrupted, (
         "The corrupt .pch must be rebuilt, not trusted forever"

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -592,7 +592,14 @@ async def test_corrupt_pch_rebuilt_on_restart(executable, tmp_path, where):
 
     corrupted = corrupt_preserving_stat(list_pch_files(tmp_path)[0], where=where)
 
-    c2 = await make_client(executable, tmp_path)
+    # The middle shape may crash a worker; Debug builds trap anomalies
+    # with abort() unless told otherwise (same as test_crash_recovery.py).
+    if where == "middle":
+        os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
+    try:
+        c2 = await make_client(executable, tmp_path)
+    finally:
+        os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
     uri2, _ = await c2.open_and_wait(tmp_path / "main.cpp")
     if not get_errors(c2.diagnostics.get(uri2, [])):
         # The crash shape ends its round with a versionless empty publish

--- a/tests/integration/compilation/test_persistent_cache.py
+++ b/tests/integration/compilation/test_persistent_cache.py
@@ -23,6 +23,7 @@ from tests.tools.checks import MTIME_GRANULARITY, SETTLE_TIME
 from tests.tools.workspace import (
     cache_root,
     list_pch_files,
+    list_pch_idx_files,
     list_pcm_files,
     list_tmp_files,
     pin_cache_to_workspace,
@@ -30,6 +31,9 @@ from tests.tools.workspace import (
 )
 from tests.tools.checks import assert_no_anomaly
 from tests.tools.checks import assert_clean_compile
+from tests.tools.checks import assert_has_errors
+from tests.tools.checks import get_errors
+from tests.tools.checks import wait_for_recompile
 
 
 async def test_pch_written_to_cache_dir(client, tmp_path):
@@ -536,6 +540,120 @@ async def test_kill9_recovery(executable, tmp_path):
     # Clean shutdown removed session 2's own tmp; session 1's residue was
     # swept at session 2 startup, so nothing may remain.
     assert list_tmp_files(tmp_path) == [], "tmp residue should be swept"
+
+
+def corrupt_preserving_stat(path, *, where="garbage", span=4096):
+    """Corrupt a blob in place, preserving file size and mtime; returns the
+    corrupted bytes. "garbage" replaces the whole file (caught by reader
+    validation), "middle" flips a span reached only during deserialization
+    (can abort the consuming process instead of failing cleanly)."""
+    stat = path.stat()
+    data = bytearray(path.read_bytes())
+    if where == "garbage":
+        data = bytearray(b"\x5a" * len(data))
+    else:
+        offset = len(data) // 2
+        for i in range(offset, min(len(data), offset + span)):
+            data[i] ^= 0xFF
+    path.write_bytes(bytes(data))
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    return bytes(data)
+
+
+@pytest.mark.parametrize(
+    "where",
+    [
+        "garbage",
+        # Mid-file corruption can abort the AST reader and kill the worker
+        # (an expected WorkerCrash anomaly); recovery then lands on the
+        # next request instead of inline.
+        pytest.param("middle", marks=pytest.mark.allow_anomaly),
+    ],
+)
+async def test_corrupt_pch_rebuilt_on_restart(executable, tmp_path, where):
+    """A .pch corrupted offline (size and mtime preserved, so freshness
+    checks pass) must not brick the file: the consumption failure retracts
+    the pair and rebuilds it, and real diagnostics come back."""
+    pin_cache_to_workspace(tmp_path)
+    (tmp_path / "header.h").write_text("#pragma once\nint known_func();\n")
+    # The body has a real error: a bricked file publishes an empty list
+    # instead, so the error is the recovery signal.
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { return undeclared_symbol; }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+
+    c1 = await make_client(executable, tmp_path)
+    uri, _ = await c1.open_and_wait(tmp_path / "main.cpp")
+    assert_has_errors(c1, uri, "Baseline session should report the body error")
+    assert len(list_pch_files(tmp_path)) == 1
+    assert_no_anomaly(c1, tmp_path)
+    await shutdown_client(c1)
+
+    corrupted = corrupt_preserving_stat(list_pch_files(tmp_path)[0], where=where)
+
+    c2 = await make_client(executable, tmp_path)
+    uri2, _ = await c2.open_and_wait(tmp_path / "main.cpp")
+    if not get_errors(c2.diagnostics.get(uri2, [])):
+        # The crash shape ends its round with a versionless empty publish
+        # after retracting the pair; the next request rebuilds it.
+        c2.diagnostics.pop(uri2, None)
+        await wait_for_recompile(c2, uri2)
+    # The specific body error, not just any error: a quarantine notice or
+    # a still-standing corruption fatal must not count as recovery.
+    assert any(
+        "undeclared_symbol" in d.message
+        for d in get_errors(c2.diagnostics.get(uri2, []))
+    ), f"Real diagnostics must recover, got: {c2.diagnostics.get(uri2, [])}"
+    pch_files = list_pch_files(tmp_path)
+    assert len(pch_files) == 1, "The pair must be rebuilt, not abandoned"
+    if where == "middle" and pch_files[0].read_bytes() == corrupted:
+        # The flip landed in semantically dead bytes on this LLVM build
+        # (PCH blobs carry no whole-file checksum): the reader consumed
+        # the blob untouched and there is nothing to heal.
+        pytest.skip("mid-file flip was semantically dead on this build")
+    assert pch_files[0].read_bytes() != corrupted, (
+        "The corrupt .pch must be rebuilt, not trusted forever"
+    )
+    if where == "garbage":
+        assert_no_anomaly(c2, tmp_path)
+    await shutdown_client(c2)
+
+
+async def test_corrupt_pch_idx_retracted(executable, tmp_path):
+    """A corrupt .pch.idx detected at load must retract the on-disk pair
+    (not just the in-memory path): a pair that looks complete would be
+    re-adopted and silently degrade every later session."""
+    pin_cache_to_workspace(tmp_path)
+    (tmp_path / "header.h").write_text("#pragma once\nstruct Idx { int v; };\n")
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { Idx i; return i.v; }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+
+    c1 = await make_client(executable, tmp_path)
+    uri, _ = await c1.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(c1, uri)
+    assert len(list_pch_idx_files(tmp_path)) == 1
+    assert_no_anomaly(c1, tmp_path)
+    await shutdown_client(c1)
+
+    corrupted = corrupt_preserving_stat(list_pch_idx_files(tmp_path)[0])
+
+    # Recovery rides the .pch artifact gate: detecting the corrupt idx
+    # retracts the whole pair from the store mid-round, the compile then
+    # setup-fails on the now-missing .pch, and the gate rebuilds both.
+    c2 = await make_client(executable, tmp_path)
+    uri2, _ = await c2.open_and_wait(tmp_path / "main.cpp")
+    assert_clean_compile(c2, uri2)
+    idx_files = list_pch_idx_files(tmp_path)
+    assert len(idx_files) == 1, "The pair must be rebuilt after idx corruption"
+    assert idx_files[0].read_bytes() != corrupted, (
+        "The corrupt .pch.idx must be retracted and rebuilt, not left posing "
+        "as a complete pair"
+    )
+    assert_no_anomaly(c2, tmp_path)
+    await shutdown_client(c2)
 
 
 async def test_cache_wiped_while_running(client, tmp_path):

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -638,3 +638,6 @@ async def test_setup_fail_keeps_dirty(client, tmp_path):
     # a retained dirty flag recompiles and republishes on the next request.
     client.diagnostics.pop(uri, None)
     await wait_for_recompile(client, uri, timeout=30.0)
+    assert client.diagnostics.get(uri, []) == [], (
+        "The retried non-result must stay an honest empty gap"
+    )

--- a/tests/integration/compilation/test_staleness.py
+++ b/tests/integration/compilation/test_staleness.py
@@ -607,3 +607,34 @@ async def test_orphan_header_default_command(client, tmp_path):
 
     orphan_uri, _ = await client.open_and_wait(tmp_path / "orphan.h")
     assert_clean_compile(client, orphan_uri)
+
+
+async def test_setup_fail_keeps_dirty(client, tmp_path):
+    """A compile that fails before parsing (bad target triple, no PCH to
+    blame) must not settle: the gap is published as empty diagnostics and
+    the next request recompiles instead of trusting the phantom product."""
+    import json
+
+    (tmp_path / "main.cpp").write_text("int main() { return 0; }\n")
+    entries = [
+        {
+            "directory": str(tmp_path),
+            "file": str(tmp_path / "main.cpp"),
+            "arguments": [
+                "clang++",
+                "--target=bogus-unknown-none",
+                "-fsyntax-only",
+                str(tmp_path / "main.cpp"),
+            ],
+        }
+    ]
+    (tmp_path / "compile_commands.json").write_text(json.dumps(entries))
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+    assert client.diagnostics.get(uri, []) == [], "Honest gap must be empty"
+
+    # A settled phantom would serve the stale AST and never publish again;
+    # a retained dirty flag recompiles and republishes on the next request.
+    client.diagnostics.pop(uri, None)
+    await wait_for_recompile(client, uri, timeout=30.0)

--- a/tests/tools/workspace.py
+++ b/tests/tools/workspace.py
@@ -66,6 +66,14 @@ def list_pch_files(workspace: Path) -> list[Path]:
     return sorted(pch_dir.glob("*.pch"))
 
 
+def list_pch_idx_files(workspace: Path) -> list[Path]:
+    """Return all .pch.idx files in the cache directory, sorted."""
+    pch_dir = cache_root(workspace) / "pch"
+    if not pch_dir.exists():
+        return []
+    return sorted(pch_dir.glob("*.pch.idx"))
+
+
 def list_pcm_files(workspace: Path) -> list[Path]:
     """Return all .pcm files in the cache directory, sorted."""
     pcm_dir = cache_root(workspace) / "pcm"

--- a/tests/unit/compile/compilation_tests.cpp
+++ b/tests/unit/compile/compilation_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <thread>
 
 #include "test/temp_dir.h"
@@ -62,6 +63,10 @@ int main() { return 0; }
 
     auto built = clice::compile(params);
     ASSERT_FALSE(built.completed());
+    // Pinned distinctly from setup_fail: the worker maps this status to
+    // CompileStatus::Cancelled, which the master discards without blaming
+    // any artifact.
+    ASSERT_TRUE(built.cancelled());
 }
 
 TEST_CASE(PCHBuildPopulatesInfo) {
@@ -118,6 +123,86 @@ int main() { return 0; }
     ASSERT_EQ(info.arguments.size(), params.arguments.size());
 
     // Clean up the temp file.
+    llvm::sys::fs::remove(*pch_path);
+}
+
+TEST_CASE(CorruptPCHAttributable) {
+    add_file("preamble.h", R"(
+#pragma once
+int preamble_func();
+)");
+
+    llvm::StringRef content = R"(
+#include "preamble.h"
+
+int main() { return preamble_func(); }
+)";
+    add_main("main.cpp", content);
+    prepare();
+
+    // Consuming the PCH reads it from real disk; overlay like compile_with_pch.
+    auto overlay =
+        llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(llvm::vfs::getRealFileSystem());
+    overlay->pushOverlay(vfs);
+    params.vfs = overlay;
+
+    auto pch_path = fs::createTemporaryFile("clice-test", "pch");
+    ASSERT_TRUE(pch_path.operator bool());
+
+    auto& source = sources.all_files["main.cpp"];
+    auto bound = compute_preamble_bound(source.content);
+    auto main_vfs_path = TestVFS::path("main.cpp");
+
+    // Corruption the reader detects in-process must stay attributable to
+    // the artifact — a setup failure, or a fatal error naming the blob —
+    // never a completed parse: that contract is what the master's quality
+    // gate (retract the pair and rebuild) keys on. Whole-file garbage is
+    // rejected by validation; truncation is caught reading the block
+    // structure. Mid-file bit flips can instead abort the process inside
+    // the bitstream reader (report_fatal_error), which in production
+    // kills the worker — that shape is exercised end-to-end by the
+    // integration corruption tests, not here.
+    auto corrupt = [](std::string blob, std::size_t shape) -> std::string {
+        return shape == 0 ? std::string(blob.size(), '\x5A')  // whole-file garbage
+                          : blob.substr(0, blob.size() / 2);  // truncation
+    };
+
+    for(std::size_t shape = 0; shape < 2; ++shape) {
+        params.kind = CompilationKind::Preamble;
+        params.output_file = *pch_path;
+        params.pch = {};
+        params.buffers.clear();
+        params.add_remapped_file(main_vfs_path, source.content, bound);
+
+        PCHInfo info;
+        {
+            auto preamble_unit = clice::compile(params, info);
+            ASSERT_TRUE(preamble_unit.completed());
+        }
+
+        auto blob = fs::read(*pch_path);
+        ASSERT_TRUE(blob.operator bool());
+        ASSERT_TRUE(fs::write(*pch_path, corrupt(std::move(*blob), shape)).operator bool());
+
+        params.kind = CompilationKind::Content;
+        params.output_file.clear();
+        params.pch = {*pch_path, static_cast<std::uint32_t>(info.preamble.size())};
+        params.buffers.clear();
+
+        auto content_unit = clice::compile(params);
+        ASSERT_FALSE(content_unit.completed());
+        ASSERT_TRUE(content_unit.setup_fail() || content_unit.fatal_error());
+        // The blame signal the master's retraction keys on (pch_suspect):
+        // a diagnostic naming the blob, or an AST-deserialization error —
+        // that family's messages do not reliably carry the path ("Blob
+        // ends too soon").
+        bool blames_pch = std::ranges::any_of(content_unit.diagnostics(), [&](auto& diag) {
+            return llvm::StringRef(diag.message).contains(*pch_path) ||
+                   diag.id.is_deserialization_error();
+        });
+        ASSERT_TRUE(blames_pch);
+    }
+
     llvm::sys::fs::remove(*pch_path);
 }
 


### PR DESCRIPTION
## Background

Compilation artifacts (the PCH and its paired index blob) are validated purely through dependency snapshots: as long as the source files they were built from are unchanged, the blobs are trusted. Nothing ever checks that the bytes on disk are still readable, and a consumption failure was never written back as invalidation. Three consequences:

- A `.pch` corrupted on disk (bit rot, partial write, external interference) was trusted for the life of the cache store. The stateful compile failed before parsing, the master treated the incomplete reply as success — published empty diagnostics as current, cleared the dirty flag, recorded an empty deps snapshot that nothing could ever invalidate — and the file went silently dead. Restarts did not heal it.
- `CompileResult` had no success signal at all, so *any* non-result (setup failure, interrupted parse) was settled as a valid product.
- A corrupt `.pch.idx` was detected when first opened, but only the in-memory path was cleared. The on-disk pair kept posing as complete, so every later session re-adopted it from the cache metadata and silently served degraded results (no preamble overlay, no preamble links) forever.

Investigating the repro also surfaced a third failure shape: corruption past the validation-covered region can abort the AST reader outright (`report_fatal_error` in the bitstream reader), killing the worker process. And notably, sparse flips in semantically dead bytes are consumed without any error at all — PCH blobs carry no whole-file checksum — which shaped the test vectors.

## Changes

- `CompileResult` now carries `CompileStatus` (`Done` / `Cancelled` / `SetupFail`) plus a `pch_suspect` flag: the parse failed and its diagnostics blame the consumed PCH — they name the blob's path, or they are AST-deserialization errors (matched by clang's diagnostic category via the new `DiagnosticID::is_deserialization_error()`, since that family's messages do not reliably carry the path, e.g. `malformed or corrupted precompiled file: 'Blob ends too soon'`) that name no other prebuilt input. A bare setup failure without that attribution deliberately does **not** blame the PCH: retracting a healthy shared pair over a broken module input or bad invocation would rebuild it on every request.
- `run_compile` gains an artifact quality gate: on a `pch_suspect` reply it retracts the pair (store + in-memory cache) and reruns the round once — `ensure_pch` misses and rebuilds both halves, so real diagnostics recover within the same request. A worker crash while consuming a PCH retracts the pair too (deep corruption aborts the reader before any diagnostic can anchor); recovery lands on the next request, and a genuinely poisonous document still pays its own quarantine budget.
- Non-`Done` replies are no longer settled: the dirty flag stays set, deps/index are not recorded, and the gap is published as versionless empty diagnostics instead of a stale list posing as current.
- `Workspace::preamble_state()` is now the single consumption gate for the index blob: when it turns out unreadable, the on-disk pair is retracted as well, so the next `ensure_pch` (this session or any later one) treats the key as a miss and rebuilds the pair.

## Testing

- Unit: `Compiler.CorruptPCHAttributable` pins the attribution contract — whole-file garbage and truncation must yield a setup failure or fatal error whose diagnostics blame the blob (path or deserialization category), never a completed parse. `Compiler.StopCompilation` now also pins the `Cancelled` status mapping.
- Integration: `test_corrupt_pch_rebuilt_on_restart` (parametrized: whole-file garbage → attributable failure healed inline; mid-file flip → may kill the worker, healed on the next request; flips that land in semantically dead bytes are consumed harmlessly and skip), `test_corrupt_pch_idx_retracted` (pair retracted and rebuilt, valid index blob back on disk), `test_setup_fail_keeps_dirty` (a non-result with no PCH to blame publishes an honest empty gap and recompiles on the next request instead of settling).
- All three integration tests verified red on the pre-fix binary, green after the fix. Full suites pass: 1016 unit, 292 integration, 3/3 smoke.

## Known residuals

- The worker-crash retraction path has no deterministic test: whether a given mid-file flip aborts the reader depends on which record it lands in. The integration `middle` vector exercises it on this LLVM build; the unit test deliberately excludes shapes that would abort the test process.
- On the non-`Done` path the previous buffer's file index is retained rather than reset; it is unreachable while the dirty flag is set (all consumers gate on it), matching the existing dispatch-crash path.
- Index-blob-only corruption now costs a full pair rebuild instead of a degraded-but-served compile; the pair is only usable complete, and the rebuild is a one-time cost at detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved corrupted precompiled header and index handling: unreadable artifacts are invalidated/retracted and rebuilt, including on restart.
  - Prevented stale or misleading diagnostic settling after setup failures or interrupted compilation.
  - Added stronger retry/quality-gate logic for suspect precompiled artifacts and improved attribution for deserialization-related diagnostics.

- **Tests**
  - Expanded integration and unit coverage for PCH/PCH-index corruption recovery, setup-failure “dirty” behavior, cancellation status mapping, and diagnostic blame attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->