### PR TITLE
ci(release): revive packaging pipeline and slim crash symbols

### DIFF
--- a/.github/workflows/publish-clice.yml
+++ b/.github/workflows/publish-clice.yml
@@ -2,6 +2,18 @@ name: clice
 
 on:
   workflow_call:
+  # Manual runs exercise the full packaging matrix from any branch without
+  # tagging; the upload steps below stay tag-gated.
+  workflow_dispatch:
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
+  SCCACHE_DIR: ${{ github.workspace }}/.cache/sccache
+  CCACHE_BASEDIR: ${{ github.workspace }}
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
+  CCACHE_COMPILERCHECK: content
+  CCACHE_MAXSIZE: 2G
+  SCCACHE_CACHE_SIZE: 2G
 
 jobs:
   publish-clice:
@@ -19,14 +31,14 @@ jobs:
           - os: ubuntu-24.04
             artifact_name: clice.tar.gz
             asset_name: clice-x86_64-linux-gnu.tar.gz
-            symbol_artifact_name: clice-symbol.tar.gz
-            symbol_asset_name: clice-x86_64-linux-gnu-symbol.tar.gz
+            symbol_artifact_name: clice-symbol.tar.xz
+            symbol_asset_name: clice-x86_64-linux-gnu-symbol.tar.xz
 
           - os: macos-15
             artifact_name: clice.tar.gz
             asset_name: clice-arm64-macos-darwin.tar.gz
-            symbol_artifact_name: clice-symbol.tar.gz
-            symbol_asset_name: clice-arm64-macos-darwin-symbol.tar.gz
+            symbol_artifact_name: clice-symbol.tar.xz
+            symbol_asset_name: clice-arm64-macos-darwin-symbol.tar.xz
 
           # Cross-compilation builds
           - os: macos-15
@@ -34,16 +46,16 @@ jobs:
             pixi_env: cross-macos-x64
             artifact_name: clice.tar.gz
             asset_name: clice-x86_64-macos-darwin.tar.gz
-            symbol_artifact_name: clice-symbol.tar.gz
-            symbol_asset_name: clice-x86_64-macos-darwin-symbol.tar.gz
+            symbol_artifact_name: clice-symbol.tar.xz
+            symbol_asset_name: clice-x86_64-macos-darwin-symbol.tar.xz
 
           - os: ubuntu-24.04
             target_triple: aarch64-linux-gnu
             pixi_env: cross-linux-aarch64
             artifact_name: clice.tar.gz
             asset_name: clice-aarch64-linux-gnu.tar.gz
-            symbol_artifact_name: clice-symbol.tar.gz
-            symbol_asset_name: clice-aarch64-linux-gnu-symbol.tar.gz
+            symbol_artifact_name: clice-symbol.tar.xz
+            symbol_asset_name: clice-aarch64-linux-gnu-symbol.tar.xz
 
           - os: windows-2025
             target_triple: aarch64-pc-windows-msvc
@@ -69,6 +81,26 @@ jobs:
         with:
           environments: ${{ matrix.pixi_env || 'package' }}
 
+      # LTO builds share nothing with the test builds' caches (different
+      # flags), so the package matrix keeps its own key space.
+      - name: Restore compiler cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.os == 'Windows' && '.cache/sccache' || '.cache/ccache' }}
+          key: ${{ runner.os }}-${{ matrix.target_triple || 'native' }}-package-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target_triple || 'native' }}-package-ccache-
+
+      - name: Zero cache stats
+        run: |
+          ENV="${{ matrix.pixi_env || 'package' }}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            pixi run -e "$ENV" -- sccache --stop-server || true
+            pixi run -e "$ENV" -- sccache --zero-stats || true
+          else
+            pixi run -e "$ENV" -- ccache --zero-stats || true
+          fi
+
       - name: Package (native)
         if: ${{ !matrix.target_triple }}
         run: pixi run package
@@ -80,6 +112,20 @@ jobs:
           pixi run -e "$ENV" package-config -- \
             "-DCLICE_TARGET_TRIPLE=${{ matrix.target_triple }}"
           pixi run -e "$ENV" cmake-build
+
+      # sccache runs a background server that holds file locks; if it is
+      # still alive when the pixi post-action tries to clean up the env
+      # cache on Windows, the cleanup fails and marks the job as failed.
+      - name: Print cache stats and stop server
+        if: always()
+        run: |
+          ENV="${{ matrix.pixi_env || 'package' }}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            pixi run -e "$ENV" -- sccache --show-stats
+            pixi run -e "$ENV" -- sccache --stop-server || true
+          else
+            pixi run -e "$ENV" -- ccache --show-stats
+          fi
 
       - name: Upload Main Package to Release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/publish-clice.yml
+++ b/.github/workflows/publish-clice.yml
@@ -113,6 +113,20 @@ jobs:
             "-DCLICE_TARGET_TRIPLE=${{ matrix.target_triple }}"
           pixi run -e "$ENV" cmake-build
 
+      # The release asset only carries GSYM; the full DWARF (needed for
+      # core-dump debugging) is kept as a per-run artifact instead of
+      # bloating the release page.
+      - name: Upload full debug info artifact
+        if: ${{ !contains(matrix.os, 'windows') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: debug-info-${{ matrix.asset_name }}
+          path: |
+            build/RelWithDebInfo/pack-symbol/clice.debug
+            build/RelWithDebInfo/pack-symbol/clice.dSYM
+          if-no-files-found: error
+          retention-days: 90
+
       # sccache runs a background server that holds file locks; if it is
       # still alive when the pixi post-action tries to clean up the env
       # cache on Windows, the cleanup fails and marks the job as failed.

--- a/.github/workflows/publish-clice.yml
+++ b/.github/workflows/publish-clice.yml
@@ -81,8 +81,8 @@ jobs:
         with:
           environments: ${{ matrix.pixi_env || 'package' }}
 
-      # LTO builds share nothing with the test builds' caches (different
-      # flags), so the package matrix keeps its own key space.
+      # The package matrix keeps a cache key space separate from the test
+      # builds — release flags differ, so their objects never overlap.
       - name: Restore compiler cache
         uses: actions/cache@v6
         with:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,17 @@
+name: release-check
+
+# Dry run of the release packaging pipeline: builds all six clice packages.
+# Every upload step is tag-gated, so nothing is published. Runs automatically
+# on PRs that touch release plumbing, and on demand from any branch.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/publish-clice.yml"
+      - ".github/workflows/release-check.yml"
+      - "cmake/release.cmake"
+      - "cmake/archive.cmake"
+
+jobs:
+  clice:
+    uses: ./.github/workflows/publish-clice.yml

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - ".github/workflows/publish-clice.yml"
       - ".github/workflows/release-check.yml"
+      - "CMakeLists.txt"
       - "cmake/release.cmake"
       - "cmake/archive.cmake"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,9 @@ if(CLICE_RELEASE)
                 CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
         string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,/OPT:ICF")
     elseif(APPLE)
-        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--icf=safe")
+        # --keep-icf-stabs: without it dsymutil cannot see ICF-folded symbols,
+        # so they would be missing from the dSYM (and thus from GSYM).
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--icf=safe -Wl,--keep-icf-stabs")
     else()
         string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--icf=safe -Wl,-O2")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,20 @@ if(CLICE_ENABLE_LTO)
     string(APPEND CMAKE_MODULE_LINKER_FLAGS " -flto=thin")
 endif()
 
+if(CLICE_RELEASE)
+    # Identical code folding is release-only: folded functions share one
+    # address, which hurts debugging and profiling in dev builds. icf=safe
+    # (not =all) so address-taken functions keep C++ pointer identity.
+    if(MSVC OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+                CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,/OPT:ICF")
+    elseif(APPLE)
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--icf=safe")
+    else()
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--icf=safe -Wl,-O2")
+    endif()
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-fsanitize=address)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(CLICE_OFFLINE_BUILD "Disable network downloads during configuration" OFF)
 option(CLICE_ENABLE_TEST "Build unit tests" OFF)
 option(CLICE_CI_ENVIRONMENT "Enable CI-specific configuration" OFF)
 option(CLICE_ENABLE_BENCHMARK "Build benchmarks" OFF)
-option(CLICE_RELEASE "Enable release packaging (LTO + strip + pack)" OFF)
+option(CLICE_RELEASE "Enable release packaging (strip + pack + link optimizations)" OFF)
 
 # Global flags that apply to all targets (including FetchContent dependencies).
 if(NOT MSVC)
@@ -50,9 +50,11 @@ if(CLICE_USE_LIBCXX)
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -stdlib=libc++")
 endif()
 
-if(CLICE_RELEASE)
-    set(CLICE_ENABLE_LTO ON)
-endif()
+# Releases deliberately do NOT enable LTO yet: ThinLTO's cross-TU inlining
+# defeats kota's out-of-line workaround for llvm-project#105595 (clang < 21
+# drops coroutine promise policy writes under -O3), which silently breaks
+# cancellation — six cancellation unit tests fail on any ThinLTO build.
+# Re-enable together with the clang 21 toolchain upgrade.
 
 if(CLICE_ENABLE_LTO)
     string(APPEND CMAKE_C_FLAGS " -flto=thin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ if(APPLE)
     add_compile_definitions(_LIBCPP_DISABLE_AVAILABILITY=1)
 endif()
 
-if(MSVC OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
-            CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+# Keyed on the target OS, not the compiler frontend: CI links Windows with
+# GNU-driver clang++ + lld-link, where the frontend variant is "GNU" but the
+# linker still speaks MSVC-style /OPT flags (see the Debug /OPT:NOICF below).
+if(WIN32)
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,/OPT:REF")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,/OPT:REF")
 elseif(APPLE)
@@ -68,8 +70,7 @@ if(CLICE_RELEASE)
     # Identical code folding is release-only: folded functions share one
     # address, which hurts debugging and profiling in dev builds. icf=safe
     # (not =all) so address-taken functions keep C++ pointer identity.
-    if(MSVC OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
-                CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+    if(WIN32)
         string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,/OPT:ICF")
     elseif(APPLE)
         # --keep-icf-stabs: without it dsymutil cannot see ICF-folded symbols,

--- a/cmake/archive.cmake
+++ b/cmake/archive.cmake
@@ -5,8 +5,13 @@ if(OUTPUT MATCHES "\\.tar\\.gz$")
         COMMAND_ERROR_IS_FATAL ANY
     )
 elseif(OUTPUT MATCHES "\\.tar\\.xz$")
+    # cmake -E tar's built-in xz is single-threaded and dominates packaging
+    # time on large debug-info trees; pipe system tar through xz -T0 instead.
+    # This branch is only reached on non-Windows, where both tools exist.
     execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar cJf "${OUTPUT}" .
+        COMMAND tar cf - .
+        COMMAND xz -T0 -c
+        OUTPUT_FILE "${OUTPUT}"
         WORKING_DIRECTORY "${WORK_DIR}"
         COMMAND_ERROR_IS_FATAL ANY
     )

--- a/cmake/archive.cmake
+++ b/cmake/archive.cmake
@@ -4,6 +4,12 @@ if(OUTPUT MATCHES "\\.tar\\.gz$")
         WORKING_DIRECTORY "${WORK_DIR}"
         COMMAND_ERROR_IS_FATAL ANY
     )
+elseif(OUTPUT MATCHES "\\.tar\\.xz$")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar cJf "${OUTPUT}" .
+        WORKING_DIRECTORY "${WORK_DIR}"
+        COMMAND_ERROR_IS_FATAL ANY
+    )
 elseif(OUTPUT MATCHES "\\.zip$")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar cf "${OUTPUT}" --format=zip .

--- a/cmake/release.cmake
+++ b/cmake/release.cmake
@@ -5,9 +5,13 @@ set(CLICE_SYMBOL_DIR "${PROJECT_BINARY_DIR}/pack-symbol")
 
 if(WIN32)
     set(CLICE_ARCHIVE_EXT ".zip")
+    set(CLICE_SYMBOL_ARCHIVE_EXT ".zip")
     set(CLICE_SYMBOL_NAME "clice.pdb")
 else()
     set(CLICE_ARCHIVE_EXT ".tar.gz")
+    # xz for the symbol archive: it is ~640MB of DWARF, and xz shaves ~40%
+    # off gzip; the main archive stays .tar.gz for downloader compatibility.
+    set(CLICE_SYMBOL_ARCHIVE_EXT ".tar.xz")
     if(APPLE)
         set(CLICE_SYMBOL_NAME "clice.dSYM")
     else()
@@ -71,7 +75,7 @@ add_custom_target(clice-pack-symbol ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CLICE_SYMBOL_DIR}/pack"
     COMMAND ${CLICE_COPY_SYMBOL_CMD}
     COMMAND ${CMAKE_COMMAND}
-        -DOUTPUT="${PROJECT_BINARY_DIR}/clice-symbol${CLICE_ARCHIVE_EXT}"
+        -DOUTPUT="${PROJECT_BINARY_DIR}/clice-symbol${CLICE_SYMBOL_ARCHIVE_EXT}"
         -DWORK_DIR="${CLICE_SYMBOL_DIR}/pack"
         -P "${PROJECT_SOURCE_DIR}/cmake/archive.cmake"
     COMMENT "Packaging clice debug symbols"

--- a/cmake/release.cmake
+++ b/cmake/release.cmake
@@ -76,8 +76,10 @@ else()
     else()
         set(CLICE_GSYM_INPUT "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}")
     endif()
+    # --quiet: ICF-folded functions trip thousands of benign line-table
+    # diagnostics that would otherwise drown the CI log.
     set(CLICE_PACK_SYMBOL_CMD ${CLICE_GSYMUTIL} --convert "${CLICE_GSYM_INPUT}"
-        --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
+        --quiet --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
 endif()
 
 add_custom_target(clice-pack-symbol ALL

--- a/cmake/release.cmake
+++ b/cmake/release.cmake
@@ -76,10 +76,12 @@ else()
     else()
         set(CLICE_GSYM_INPUT "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}")
     endif()
-    # --quiet: ICF-folded functions trip thousands of benign line-table
+    # --merged-functions: ICF folds identical functions onto one address
+    # range; without it only one of the folded names survives conversion.
+    # --quiet: the same folding trips thousands of benign line-table
     # diagnostics that would otherwise drown the CI log.
     set(CLICE_PACK_SYMBOL_CMD ${CLICE_GSYMUTIL} --convert "${CLICE_GSYM_INPUT}"
-        --quiet --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
+        --merged-functions --quiet --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
 endif()
 
 add_custom_target(clice-pack-symbol ALL

--- a/cmake/release.cmake
+++ b/cmake/release.cmake
@@ -9,14 +9,15 @@ if(WIN32)
     set(CLICE_SYMBOL_NAME "clice.pdb")
 else()
     set(CLICE_ARCHIVE_EXT ".tar.gz")
-    # xz for the symbol archive: it is ~640MB of DWARF, and xz shaves ~40%
-    # off gzip; the main archive stays .tar.gz for downloader compatibility.
+    # The main archive stays .tar.gz for downloader compatibility; the symbol
+    # archive is new enough to pick xz.
     set(CLICE_SYMBOL_ARCHIVE_EXT ".tar.xz")
     if(APPLE)
         set(CLICE_SYMBOL_NAME "clice.dSYM")
     else()
         set(CLICE_SYMBOL_NAME "clice.debug")
     endif()
+    find_program(CLICE_GSYMUTIL llvm-gsymutil REQUIRED)
 endif()
 
 if(WIN32)
@@ -61,19 +62,29 @@ add_custom_target(clice-pack ALL
     COMMENT "Packaging clice distribution"
 )
 
-if(APPLE)
-    set(CLICE_COPY_SYMBOL_CMD ${CMAKE_COMMAND} -E copy_directory
-        "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}" "${CLICE_SYMBOL_DIR}/pack/${CLICE_SYMBOL_NAME}")
-else()
-    set(CLICE_COPY_SYMBOL_CMD ${CMAKE_COMMAND} -E copy
+# The released symbol package carries GSYM, not DWARF: it keeps everything
+# crash symbolization needs (functions, lines, inline chains) at ~1/10 the
+# size. The full DWARF stays in ${CLICE_SYMBOL_DIR} for CI to publish as a
+# workflow artifact. Windows has no GSYM path and ships the PDB directly.
+if(WIN32)
+    set(CLICE_PACK_SYMBOL_CMD ${CMAKE_COMMAND} -E copy
         "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}" "${CLICE_SYMBOL_DIR}/pack/")
+else()
+    if(APPLE)
+        set(CLICE_GSYM_INPUT
+            "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}/Contents/Resources/DWARF/clice")
+    else()
+        set(CLICE_GSYM_INPUT "${CLICE_SYMBOL_DIR}/${CLICE_SYMBOL_NAME}")
+    endif()
+    set(CLICE_PACK_SYMBOL_CMD ${CLICE_GSYMUTIL} --convert "${CLICE_GSYM_INPUT}"
+        --out-file "${CLICE_SYMBOL_DIR}/pack/clice.gsym")
 endif()
 
 add_custom_target(clice-pack-symbol ALL
     DEPENDS clice-strip
     COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLICE_SYMBOL_DIR}/pack"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CLICE_SYMBOL_DIR}/pack"
-    COMMAND ${CLICE_COPY_SYMBOL_CMD}
+    COMMAND ${CLICE_PACK_SYMBOL_CMD}
     COMMAND ${CMAKE_COMMAND}
         -DOUTPUT="${PROJECT_BINARY_DIR}/clice-symbol${CLICE_SYMBOL_ARCHIVE_EXT}"
         -DWORK_DIR="${CLICE_SYMBOL_DIR}/pack"

--- a/pixi.lock
+++ b/pixi.lock
@@ -2182,13 +2182,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.2.0-hed042b8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-20-20.1.8-h3b15d91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-20.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
@@ -3398,6 +3404,9 @@ packages:
   - libgcc >=14
   license: LGPL-2.1-only
   purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 790176
   timestamp: 1754908768807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hf7376ad_1.conda
@@ -3414,6 +3423,9 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
   size: 43977914
   timestamp: 1757353652788
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
@@ -3831,6 +3843,24 @@ packages:
   license_family: MIT
   size: 557492
   timestamp: 1772704601644
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+  sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
+  md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 559775
+  timestamp: 1776376739004
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h031cc0b_0.conda
   sha256: ee64e507b37b073e0bdad739e35330933dd5be7c639600a096551a6968f1035d
   md5: a67cd8f7b0369bbf2c40411f05a62f3b
@@ -3894,6 +3924,26 @@ packages:
   license_family: MIT
   size: 45968
   timestamp: 1772704614539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+  sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
+  md5: 995d8c8bad2a3cc8db14675a153dec2b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 hca6bf5a_0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 46810
+  timestamp: 1776376751152
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -3961,6 +4011,7 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports: {}
   size: 26528257
   timestamp: 1757353803953
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-20.1.8-hb700be7_1.conda
@@ -3980,6 +4031,7 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports: {}
   size: 87809
   timestamp: 1757353876330
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -2230,11 +2230,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-hfd2ba90_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.0-h022381a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42-h1022ec0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h064b767_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h9ba8346_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-tools-20-20.1.8-hb2a4a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-tools-20.1.8-hfefdfc9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.2-h546c87b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.4-hfd9ac0a_100_cp314.conda
@@ -5001,6 +5008,9 @@ packages:
   - libgcc >=14
   license: LGPL-2.1-only
   purls: []
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
   size: 791226
   timestamp: 1754910975665
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm20-20.1.8-hfd2ba90_1.conda
@@ -5016,6 +5026,9 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports:
+    weak:
+    - libllvm20 >=20.1.8,<20.2.0a0
   size: 42749733
   timestamp: 1757353785740
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm21-21.1.8-hfd2ba90_0.conda
@@ -5136,6 +5149,7 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
+  run_exports: {}
   size: 5541411
   timestamp: 1771378162499
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
@@ -5218,6 +5232,23 @@ packages:
   license_family: MIT
   size: 598438
   timestamp: 1772704671710
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h064b767_0.conda
+  sha256: 96e9bd642c013ce3407c23b3819204ea8a591567d62b49baa4bafb2f1487326c
+  md5: 876c5457664559cdc67c4ac71e2945cb
+  depends:
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - icu <0.0a0
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 601420
+  timestamp: 1776376789358
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.2-h49afab2_0.conda
   sha256: 7325511542b860dee82d862ab5264e9b89d47cf587eb0b627a74ab51c205928c
   md5: 8e7352cb825c97f6f8945db66ac074f4
@@ -5248,6 +5279,26 @@ packages:
   license_family: MIT
   size: 47837
   timestamp: 1772704681112
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h9ba8346_0.conda
+  sha256: 74aa3c62e0ec4491343b95ce4ca8812ad2f9bb015369e29cb3b4b9b4302d8cb0
+  md5: 15078261d03e3c3c83a42df605f7f34a
+  depends:
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 h064b767_0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 48311
+  timestamp: 1776376798296
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
   sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
   md5: 502006882cf5461adced436e410046d1
@@ -5297,6 +5348,7 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports: {}
   size: 25629947
   timestamp: 1757353881981
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/llvm-tools-20.1.8-hfefdfc9_1.conda
@@ -5315,6 +5367,7 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
+  run_exports: {}
   size: 87183
   timestamp: 1757353939522
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -97,6 +97,11 @@ gxx = "==14.2.0"
 # (linux-only, like the crash tests it builds on).
 llvm-tools = "==20.1.8"
 
+# The linux-aarch64 cross-test job runs the integration suite on a native
+# arm64 runner, so the symbolization test needs the same tools there.
+[feature.test.target.linux-aarch64.dependencies]
+llvm-tools = "==20.1.8"
+
 # On macOS, the system Apple clang emits vendor-specific flags that upstream
 # LLVM cannot parse.  Providing upstream clang + lld in PATH prevents
 # fallback to /usr/bin/clang++ and satisfies toolchain.cmake's -fuse-ld=lld.

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,6 +93,9 @@ python = ">=3.13"
 [feature.test.target.linux-64.dependencies]
 gcc = "==14.2.0"
 gxx = "==14.2.0"
+# The symbolization round-trip test replays the release strip/GSYM flow
+# (linux-only, like the crash tests it builds on).
+llvm-tools = "==20.1.8"
 
 # On macOS, the system Apple clang emits vendor-specific flags that upstream
 # LLVM cannot parse.  Providing upstream clang + lld in PATH prevents

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -58,19 +58,29 @@ def main() -> int:
         with open(args.log) as log_file:
             text = log_file.read()
 
-    base_match = BASE.search(text)
-    if base_match is None:
+    if BASE.search(text) is None:
         print(
             "error: no 'main executable base' line in the log; the crash predates "
             "base recording — addresses cannot be rebased",
             file=sys.stderr,
         )
         return 1
-    base = int(base_match.group(1), 16)
 
+    # A log can hold several crash sections appended by respawned processes,
+    # each with its own ASLR base — track the most recent one while scanning.
+    base = None
     for line in text.splitlines():
+        base_match = BASE.search(line)
+        if base_match is not None:
+            base = int(base_match.group(1), 16)
+            print(line)
+            continue
         frame = FRAME.match(line)
-        if frame is None or os.path.basename(frame.group(2)) != args.module:
+        if (
+            frame is None
+            or base is None
+            or os.path.basename(frame.group(2)) != args.module
+        ):
             print(line)
             continue
         offset = int(frame.group(3), 16) - base

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Symbolize a clice crash log against a released symbol file.
+
+Release binaries are stripped PIE executables, so the frame addresses in a
+crash log are ASLR-shifted. The crash handler records the executable's load
+address ("main executable base: 0x..."); this script subtracts it and feeds
+the resulting file offsets to llvm-symbolizer.
+
+Usage:
+    python symbolize.py crash.log --symbols clice.debug
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# "0  clice 0x00005ea84c157818" — the un-symbolized dump written when the
+# crashing machine has no llvm-symbolizer. Already-symbolized "#0 0x..."
+# frames do not match and pass through untouched.
+FRAME = re.compile(r"^\s*(\d+)\s+(\S+)\s+0x([0-9a-fA-F]+)")
+BASE = re.compile(r"main executable base: 0x([0-9a-fA-F]+)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="crash log file (or - for stdin)")
+    parser.add_argument(
+        "--symbols", required=True, help="symbol file (clice.debug / clice.dSYM)"
+    )
+    parser.add_argument(
+        "--module",
+        default="clice",
+        help="frame module name treated as the main executable (default: clice)",
+    )
+    parser.add_argument("--symbolizer", default="llvm-symbolizer")
+    args = parser.parse_args()
+
+    if shutil.which(args.symbolizer) is None:
+        print(f"error: {args.symbolizer} not found in PATH", file=sys.stderr)
+        return 1
+
+    if args.log == "-":
+        text = sys.stdin.read()
+    else:
+        with open(args.log) as log_file:
+            text = log_file.read()
+
+    base_match = BASE.search(text)
+    if base_match is None:
+        print(
+            "error: no 'main executable base' line in the log; the crash predates "
+            "base recording — addresses cannot be rebased",
+            file=sys.stderr,
+        )
+        return 1
+    base = int(base_match.group(1), 16)
+
+    for line in text.splitlines():
+        frame = FRAME.match(line)
+        if frame is None or os.path.basename(frame.group(2)) != args.module:
+            print(line)
+            continue
+        offset = int(frame.group(3), 16) - base
+        if offset < 0:
+            print(line)
+            continue
+        result = subprocess.run(
+            [args.symbolizer, f"--obj={args.symbols}", "-f", "-C", "-p", hex(offset)],
+            capture_output=True,
+            text=True,
+        )
+        symbolized = result.stdout.strip()
+        if result.returncode != 0 or not symbolized:
+            print(line)
+            continue
+        print(f"#{frame.group(1)} {hex(offset)} {symbolized}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -7,7 +7,11 @@ address ("main executable base: 0x..."); this script subtracts it and feeds
 the resulting file offsets to llvm-symbolizer.
 
 Usage:
-    python symbolize.py crash.log --symbols clice.debug
+    python symbolize.py crash.log --symbols clice.gsym
+
+Accepts either the released GSYM symbol file (resolved with llvm-gsymutil) or
+a full DWARF file / unstripped binary (resolved with llvm-symbolizer). GSYM
+output keeps names mangled; pipe through llvm-cxxfilt to demangle.
 """
 
 import argparse
@@ -36,10 +40,12 @@ def main() -> int:
         help="frame module name treated as the main executable (default: clice)",
     )
     parser.add_argument("--symbolizer", default="llvm-symbolizer")
+    parser.add_argument("--gsymutil", default="llvm-gsymutil")
     args = parser.parse_args()
 
-    if shutil.which(args.symbolizer) is None:
-        print(f"error: {args.symbolizer} not found in PATH", file=sys.stderr)
+    tool = args.gsymutil if args.symbols.endswith(".gsym") else args.symbolizer
+    if shutil.which(tool) is None:
+        print(f"error: {tool} not found in PATH", file=sys.stderr)
         return 1
 
     if args.log == "-":
@@ -67,16 +73,20 @@ def main() -> int:
         if offset < 0:
             print(line)
             continue
-        result = subprocess.run(
-            [args.symbolizer, f"--obj={args.symbols}", "-f", "-C", "-p", hex(offset)],
-            capture_output=True,
-            text=True,
-        )
-        symbolized = result.stdout.strip()
-        if result.returncode != 0 or not symbolized:
+        if tool == args.gsymutil:
+            command = [tool, "--address", hex(offset), args.symbols]
+        else:
+            command = [tool, f"--obj={args.symbols}", "-f", "-C", "-p", hex(offset)]
+        result = subprocess.run(command, capture_output=True, text=True)
+        lines = [
+            entry
+            for entry in result.stdout.splitlines()
+            if entry.strip() and "Looking up" not in entry
+        ]
+        if result.returncode != 0 or not lines:
             print(line)
             continue
-        print(f"#{frame.group(1)} {hex(offset)} {symbolized}")
+        print(f"#{frame.group(1)} {hex(offset)} " + "\n    ".join(lines))
     return 0
 
 

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -10,8 +10,10 @@ Usage:
     python symbolize.py crash.log --symbols clice.gsym
 
 Accepts either the released GSYM symbol file (resolved with llvm-gsymutil) or
-a full DWARF file / unstripped binary (resolved with llvm-symbolizer). GSYM
-output keeps names mangled; pipe through llvm-cxxfilt to demangle.
+a full DWARF file / unstripped binary (resolved with llvm-symbolizer). For a
+macOS dSYM pass the inner DWARF file (clice.dSYM/Contents/Resources/DWARF/clice),
+not the bundle directory. GSYM output keeps names mangled; pipe through
+llvm-cxxfilt to demangle.
 """
 
 import argparse
@@ -32,7 +34,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("log", help="crash log file (or - for stdin)")
     parser.add_argument(
-        "--symbols", required=True, help="symbol file (clice.debug / clice.dSYM)"
+        "--symbols",
+        required=True,
+        help="symbol file (clice.gsym / clice.debug / dSYM inner DWARF)",
     )
     parser.add_argument(
         "--module",

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -52,6 +52,11 @@ def main() -> int:
         print(f"error: {tool} not found in PATH", file=sys.stderr)
         return 1
 
+    # Fail up front rather than silently printing every frame unresolved.
+    if not os.path.isfile(args.symbols):
+        print(f"error: symbol file not found: {args.symbols}", file=sys.stderr)
+        return 1
+
     if args.log == "-":
         text = sys.stdin.read()
     else:

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -8,6 +8,17 @@
 #include "support/filesystem.h"
 #include "support/stderr_sink.h"
 
+#if defined(__linux__)
+#include <link.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(_WIN32)
+// See cache_store.cpp: windows.h must not spill min/max macros.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ringbuffer_sink.h"
 #include "llvm/ADT/SmallVector.h"
@@ -99,15 +110,51 @@ void file_logger(std::string_view name,
 
 static std::unique_ptr<llvm::raw_fd_ostream> crash_log_stream;
 
+// Captured at install time: querying the dynamic loader is not
+// async-signal-safe, so the handler may only print the cached value.
+static uintptr_t executable_base = 0;
+
+uintptr_t main_executable_base() {
+#if defined(__linux__)
+    uintptr_t base = 0;
+    dl_iterate_phdr(
+        [](dl_phdr_info* info, size_t, void* data) {
+            // The first entry is always the main executable.
+            *static_cast<uintptr_t*>(data) = info->dlpi_addr;
+            return 1;
+        },
+        &base);
+    return base;
+#elif defined(__APPLE__)
+    // The slide, not the header address: Mach-O executables have a nonzero
+    // preferred vmaddr, so only pc - slide yields the on-file address
+    // symbolizers expect — the same contract as the ELF load bias above.
+    return static_cast<uintptr_t>(_dyld_get_image_vmaddr_slide(0));
+#elif defined(_WIN32)
+    return reinterpret_cast<uintptr_t>(GetModuleHandleW(nullptr));
+#else
+    return 0;
+#endif
+}
+
 static void crash_handler(void*) {
     if(crash_log_stream) {
         *crash_log_stream << "\n=== CRASH STACK TRACE ===\n";
+        if(executable_base) {
+            // Release binaries are PIE and stripped: the frame addresses below
+            // are ASLR-shifted, so offline symbolization against the shipped
+            // symbol file needs this base (see scripts/symbolize.py).
+            *crash_log_stream << "main executable base: 0x";
+            crash_log_stream->write_hex(executable_base);
+            *crash_log_stream << "\n";
+        }
         llvm::sys::PrintStackTrace(*crash_log_stream);
         crash_log_stream->flush();
     }
 }
 
 void install_crash_handler(std::string_view log_path, bool stderr_trace) {
+    executable_base = main_executable_base();
     std::error_code ec;
     crash_log_stream =
         std::make_unique<llvm::raw_fd_ostream>(llvm::StringRef(log_path.data(), log_path.size()),

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -140,14 +140,13 @@ uintptr_t main_executable_base() {
 static void crash_handler(void*) {
     if(crash_log_stream) {
         *crash_log_stream << "\n=== CRASH STACK TRACE ===\n";
-        if(executable_base) {
-            // Release binaries are PIE and stripped: the frame addresses below
-            // are ASLR-shifted, so offline symbolization against the shipped
-            // symbol file needs this base (see scripts/symbolize.py).
-            *crash_log_stream << "main executable base: 0x";
-            crash_log_stream->write_hex(executable_base);
-            *crash_log_stream << "\n";
-        }
+        // Release binaries are PIE and stripped: the frame addresses below are
+        // ASLR-shifted, so offline symbolization against the shipped symbol
+        // file needs this rebase value (see scripts/symbolize.py). Zero is a
+        // legitimate value (a zero macOS slide) and must still be recorded.
+        *crash_log_stream << "main executable base: 0x";
+        crash_log_stream->write_hex(executable_base);
+        *crash_log_stream << "\n";
         llvm::sys::PrintStackTrace(*crash_log_stream);
         crash_log_stream->flush();
     }

--- a/src/support/logging.cpp
+++ b/src/support/logging.cpp
@@ -5,9 +5,6 @@
 #include <memory>
 #include <string>
 
-#include "support/filesystem.h"
-#include "support/stderr_sink.h"
-
 #if defined(__linux__)
 #include <link.h>
 #elif defined(__APPLE__)
@@ -18,6 +15,9 @@
 #define NOMINMAX
 #include <windows.h>
 #endif
+
+#include "support/filesystem.h"
+#include "support/stderr_sink.h"
 
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ringbuffer_sink.h"

--- a/src/support/logging.h
+++ b/src/support/logging.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <concepts>
+#include <cstdint>
 #include <cstdlib>
 #include <format>
 #include <source_location>
@@ -113,6 +114,12 @@ void file_logger(std::string_view name,
 /// trace belongs in its own log file only).
 /// Must be called after file_logger so the log file path is known.
 void install_crash_handler(std::string_view log_path, bool stderr_trace = true);
+
+/// Rebase value for crash-frame addresses (0 if unknown): the ELF load bias,
+/// Mach-O slide, or Windows image base. Crash traces record it so subtracting
+/// it from an ASLR-shifted frame address yields the address symbolizers
+/// expect against the released symbol file (scripts/symbolize.py).
+uintptr_t main_executable_base();
 
 template <typename... Args>
 struct logging_rformat {

--- a/tests/integration/lifecycle/test_anomaly.py
+++ b/tests/integration/lifecycle/test_anomaly.py
@@ -7,6 +7,7 @@ assert_no_anomaly() watches in every other test's teardown.
 
 import asyncio
 import os
+import re
 import signal
 import sys
 from pathlib import Path
@@ -90,6 +91,10 @@ async def test_worker_crash_reported(executable, tmp_path):
     assert any("CRASH STACK TRACE" in text for text in worker_texts), (
         "worker crash backtrace should be written to its log file"
     )
+    assert any(
+        re.search(r"main executable base: 0x[0-9a-fA-F]+", text)
+        for text in worker_texts
+    ), "crash trace should record the executable base for offline symbolization"
     master_texts = [p.read_text(errors="replace") for p in logs_dir.rglob("master.log")]
     assert master_texts and all(
         "CRASH STACK TRACE" not in text and "Stack dump" not in text

--- a/tests/integration/lifecycle/test_symbolize.py
+++ b/tests/integration/lifecycle/test_symbolize.py
@@ -46,7 +46,13 @@ async def test_stripped_crash_symbolization(executable, tmp_path):
     shutil.copy(executable, stripped)
     run_tool("llvm-objcopy", "--only-keep-debug", stripped, debug_file)
     run_tool(
-        "llvm-gsymutil", "--convert", debug_file, "--quiet", "--out-file", gsym_file
+        "llvm-gsymutil",
+        "--convert",
+        debug_file,
+        "--merged-functions",
+        "--quiet",
+        "--out-file",
+        gsym_file,
     )
     run_tool("llvm-strip", "--strip-debug", "--strip-unneeded", stripped)
 

--- a/tests/integration/lifecycle/test_symbolize.py
+++ b/tests/integration/lifecycle/test_symbolize.py
@@ -1,0 +1,114 @@
+"""End-to-end check of the release symbol-separation flow.
+
+Replays the release pipeline on the freshly built binary (split DWARF, convert
+to GSYM, strip), crashes a worker of the stripped binary, and verifies
+scripts/symbolize.py recovers function/file information from the raw-address
+crash log. This is the guarantee that shipped crash logs stay actionable.
+"""
+
+import asyncio
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.tools.lifecycle import make_client, shutdown_client
+from tests.tools.compile_commands import write_cdb
+from tests.tools.checks import anomalies_in_log_messages
+from tests.integration.lifecycle.test_anomaly import child_pids
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run_tool(*command: str | Path) -> None:
+    result = subprocess.run([str(c) for c in command], capture_output=True, text=True)
+    assert result.returncode == 0, f"{command[0]} failed: {result.stderr[:2000]}"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="worker discovery uses /proc")
+@pytest.mark.allow_anomaly
+@pytest.mark.timeout(600)
+async def test_stripped_crash_symbolization(executable, tmp_path):
+    if "Debug" in executable.parts:
+        pytest.skip("release separation flow targets non-ASan builds")
+
+    for tool in ("llvm-objcopy", "llvm-strip", "llvm-gsymutil"):
+        assert shutil.which(tool), f"{tool} must be available for the symbol flow"
+
+    # Replay the clice-strip / clice-pack-symbol steps from cmake/release.cmake.
+    stripped = tmp_path / "clice"
+    debug_file = tmp_path / "clice.debug"
+    gsym_file = tmp_path / "clice.gsym"
+    shutil.copy(executable, stripped)
+    run_tool("llvm-objcopy", "--only-keep-debug", stripped, debug_file)
+    run_tool(
+        "llvm-gsymutil", "--convert", debug_file, "--quiet", "--out-file", gsym_file
+    )
+    run_tool("llvm-strip", "--strip-debug", "--strip-unneeded", stripped)
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "main.cpp").write_text("int main() { return 0; }\n")
+    write_cdb(workspace, ["main.cpp"])
+
+    # Force the raw-address dump: with in-process symbolization disabled the
+    # log carries only "clice 0x..." frames, exactly like a user machine
+    # without llvm-symbolizer.
+    os.environ["LLVM_DISABLE_SYMBOLIZATION"] = "1"
+    os.environ["CLICE_ANOMALY_NO_TRAP"] = "1"
+    try:
+        client = await make_client(stripped, workspace)
+    finally:
+        os.environ.pop("LLVM_DISABLE_SYMBOLIZATION", None)
+        os.environ.pop("CLICE_ANOMALY_NO_TRAP", None)
+
+    try:
+        await client.open_and_wait(workspace / "main.cpp")
+
+        workers = child_pids(client.server.pid)
+        assert workers, "server should have spawned worker processes"
+        # SIGABRT for the same reasons as test_anomaly: it exercises the crash
+        # handler and is not intercepted by sanitizers.
+        os.kill(workers[0], signal.SIGABRT)
+
+        for _ in range(50):
+            if "WorkerCrash" in anomalies_in_log_messages(client):
+                break
+            await asyncio.sleep(0.2)
+    finally:
+        await shutdown_client(client)
+
+    logs_dir = workspace / ".clice" / "logs"
+    crash_logs = [
+        p
+        for p in logs_dir.rglob("*.log")
+        if p.name != "master.log"
+        and "CRASH STACK TRACE" in p.read_text(errors="replace")
+    ]
+    assert crash_logs, "worker crash backtrace should be written to its log file"
+    raw = crash_logs[0].read_text(errors="replace")
+    assert "main executable base: 0x" in raw
+    assert "logging.cpp" not in raw, "stripped binary must not self-symbolize"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "symbolize.py"),
+            str(crash_logs[0]),
+            "--symbols",
+            str(gsym_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"symbolize.py failed: {result.stderr[:2000]}"
+    # The crash handler itself is always on the stack; recovering its source
+    # file proves rebasing and GSYM lookup both worked.
+    assert "logging.cpp" in result.stdout, (
+        f"symbolized output should name the crash handler source:\n"
+        f"{result.stdout[:3000]}"
+    )

--- a/tests/unit/support/logging_tests.cpp
+++ b/tests/unit/support/logging_tests.cpp
@@ -1,0 +1,23 @@
+#include "test/test.h"
+#include "support/logging.h"
+
+namespace clice::testing {
+namespace {
+
+TEST_SUITE(Logging) {
+
+TEST_CASE(MainExecutableBase) {
+    // Linux relies on the binary being PIE — a non-PIE image has bias 0,
+    // which would silently void the crash-log rebase contract; Windows
+    // always maps the image at a nonzero base. The macOS slide may
+    // legitimately be zero, so only availability is exercised there.
+    [[maybe_unused]] auto base = logging::main_executable_base();
+#if !defined(__APPLE__)
+    EXPECT_NE(base, 0u);
+#endif
+}
+
+};  // TEST_SUITE(Logging)
+
+}  // namespace
+}  // namespace clice::testing


### PR DESCRIPTION
## Summary

The release packaging workflow had not run since v0.1.0-alpha.4. This PR makes it verifiable without tagging, trims the shipped artifacts, and makes stripped-binary crash logs offline-symbolizable — verified by three green six-target packaging runs and a new always-on CI round-trip test.

## Changes

### Workflow
- `publish-clice.yml` gains `workflow_dispatch`, so the full six-target packaging matrix can be exercised from any branch; release uploads stay tag-gated.
- Per-target compiler caches (ccache/sccache), mirroring native-test.
- Symbol assets switch to `.tar.xz`; full DWARF debug info is uploaded as a per-run CI artifact (90-day retention) instead of bloating the release page.

### Release binaries
- Identical code folding (`--icf=safe` on ELF/Mach-O, `/OPT:ICF` on Windows) and lld `-O2` in release builds.
- LTO is deliberately **not** enabled: ThinLTO's cross-TU inlining defeats kota's out-of-line workaround for llvm/llvm-project#105595 (clang < 21 drops coroutine promise policy writes under `-O3`), silently breaking cancellation — six cancellation unit tests fail deterministically on any ThinLTO build of current main. Re-enable together with the clang 21 toolchain upgrade.

### Crash symbolization
- The crash handler records the main executable's load bias (`main executable base`), making PIE crash logs rebasable offline. Without it, ASLR-shifted raw addresses are unrecoverable — and embedding debug info in the shipped binary would not help, since in-process symbolization needs llvm-symbolizer on the user machine.
- Released symbol packages carry GSYM (13 MB) instead of gzip DWARF (252 MB), with full function/line/inline fidelity for symbolization.
- New `scripts/symbolize.py` turns a user crash log plus the symbol file into a symbolized stack.

### Tests
- Unit test for the executable-base query; crash-log assertion added to the worker-crash integration test.
- New integration test replays the release strip/GSYM separation on the built binary, crashes a worker, and asserts `symbolize.py` recovers source locations from the raw-address log. It runs in every normal CI, so crash-log actionability cannot silently regress.

## Validation
- Three `workflow_dispatch` runs of the packaging matrix: all six targets green, the last on the final no-LTO configuration.
- Local release configuration: unit (1016) + integration (289) + smoke (3) suites green; crash → symbolize round-trip verified on the stripped, packaged binary.
- Artifact sizes: main package 15 MB; symbol package 13 MB (previously 252 MB); full DWARF 237–273 MB compressed as CI artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Crash logs now include the main executable base to enable offline symbolization.
  - Added a CLI tool to rebase and symbolize crash logs.
  - Symbol packaging now uses `.tar.xz` for non-Windows (Windows uses ZIP) as part of the release flow.
- **Bug Fixes**
  - Improved release packaging reliability with per-run compiler cache handling and safer Windows cache shutdown.
  - Release builds now focus on strip/pack plus link optimizations (avoiding LTO/ThinLTO) and improved platform-specific linker folding.
- **Tests**
  - Added end-to-end and unit coverage for the symbol separation flow and executable-base behavior.
- **Chores**
  - Added/updated release packaging workflows, including a dry-run release check and enhanced debug-information artifact uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Follow-ups in this PR
- `release-check.yml`: dry-runs the full packaging matrix automatically on PRs that touch release plumbing (and via `workflow_dispatch` from any branch), so the pipeline cannot silently rot again.
- Review findings addressed: GSYM conversion keeps ICF-merged function names (`--merged-functions`); the crash handler records the executable base unconditionally (a zero macOS slide is valid); `symbolize.py` tracks the most recent base when a log contains crash sections from several process generations.
