### PR TITLE
fix(index): flip shards back to disk blobs after save

### DIFF
--- a/src/index/merged_index.cpp
+++ b/src/index/merged_index.cpp
@@ -1,5 +1,6 @@
 #include "index/merged_index.h"
 
+#include <atomic>
 #include <ranges>
 #include <tuple>
 
@@ -277,6 +278,16 @@ struct MergedIndex::Impl {
 
 MergedIndex::MergedIndex(std::unique_ptr<llvm::MemoryBuffer> buffer, std::unique_ptr<Impl> impl) :
     buffer(std::move(buffer)), impl(std::move(impl)) {}
+
+/// Revision values come from one process-wide monotonic source, so a value
+/// never repeats across shard objects: an entry erased and re-created at
+/// the same key while a save's commit is in flight cannot alias the
+/// revision that save snapshotted (a per-object counter restarting at the
+/// same small numbers could).
+static std::uint64_t next_revision() {
+    static std::atomic<std::uint64_t> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 MergedIndex::MergedIndex() = default;
 
@@ -836,6 +847,7 @@ bool MergedIndex::has_contribution(this const Self& self, llvm::StringRef contex
 }
 
 void MergedIndex::remove(this Self& self, llvm::StringRef context_path) {
+    self.rev = next_revision();
     self.load_in_memory();
     auto& index = *self.impl;
 
@@ -895,6 +907,7 @@ bool MergedIndex::find_symbol(this const Self& self,
 }
 
 void MergedIndex::merge_symbols(this Self& self, const SymbolTable& symbols) {
+    self.rev = next_revision();
     self.load_in_memory();
     for(auto& [hash, symbol]: symbols) {
         auto [it, inserted] = self.impl->symbols.try_emplace(hash);
@@ -912,6 +925,7 @@ void MergedIndex::merge(this Self& self,
                         llvm::ArrayRef<DepLocation> deps,
                         FileIndex& index,
                         llvm::StringRef content) {
+    self.rev = next_revision();
     self.load_in_memory();
     self.impl->content = content.str();
     self.impl->line_starts = kota::ipc::lsp::build_line_starts(self.impl->content);
@@ -979,6 +993,7 @@ void MergedIndex::merge(this Self& self,
                         std::uint32_t include_id,
                         FileIndex& index,
                         llvm::StringRef content) {
+    self.rev = next_revision();
     self.load_in_memory();
     auto path_id = self.impl->paths.path_id(tu_path);
     // The stored content is the position-mapping truth for this file; a

--- a/src/index/merged_index.h
+++ b/src/index/merged_index.h
@@ -74,6 +74,17 @@ public:
         return impl != nullptr;
     }
 
+    /// Mutation stamp, reassigned by every merge/remove from a process-wide
+    /// monotonic source (values never repeat across objects, so an erase +
+    /// re-create at the same key cannot alias an older snapshot). 0 = not
+    /// mutated since construction. save() snapshots it before serializing
+    /// and flips the shard back to its committed blob only if no mutation
+    /// landed across the commit await — otherwise the flip would silently
+    /// drop the newer contribution.
+    std::uint64_t revision() const {
+        return rev;
+    }
+
     /// Whether this index holds any data (a rejected or missing blob loads
     /// as an empty index).
     bool loaded() const {
@@ -130,6 +141,9 @@ private:
 
     /// The in memory data of the index.
     std::unique_ptr<Impl> impl;
+
+    /// See revision().
+    std::uint64_t rev = 0;
 };
 
 }  // namespace clice::index

--- a/src/index/preamble_state.h
+++ b/src/index/preamble_state.h
@@ -108,6 +108,11 @@ public:
     /// mapped blob.
     llvm::ArrayRef<std::uint8_t> open_conditionals() const;
 
+    /// Size of the mapped blob in bytes (memory accounting gauge).
+    std::size_t size() const {
+        return buffer ? buffer->getBufferSize() : 0;
+    }
+
 private:
     explicit PreambleState(std::unique_ptr<llvm::MemoryBuffer> buffer);
 

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -236,7 +236,24 @@ kota::task<> Indexer::save() {
     }
     LOG_INFO("Saved ProjectIndex ({} symbols)", workspace.project_index.symbols.size());
 
-    llvm::SmallVector<CacheStore::PendingEntry> shards;
+    // Each write remembers which shard it snapshotted and at what
+    // revision, so the post-commit flip below can prove the shard is
+    // byte-identical to the blob it just published.
+    struct ShardWrite {
+        CacheStore::PendingEntry pending;
+        std::uint32_t path_id;
+        std::uint64_t revision;
+    };
+
+    // A commit's result pairs the published path with the blob reopened in
+    // the same job: the mmap plus the flatbuffer verification walk the
+    // whole file, and neither belongs on the event loop.
+    struct CommitOutcome {
+        std::expected<std::string, std::error_code> path;
+        index::MergedIndex reloaded;
+    };
+
+    llvm::SmallVector<ShardWrite> shards;
     std::size_t total = workspace.merged_indices.size();
     for(auto& [path_id, shard]: workspace.merged_indices) {
         if(!shard.need_rewrite())
@@ -244,14 +261,15 @@ kota::task<> Indexer::save() {
         if(auto pending = serialize_blob(store,
                                          shard_key(workspace.path_pool.resolve(path_id)),
                                          [&](llvm::raw_ostream& os) { shard.serialize(os); })) {
-            shards.push_back(std::move(*pending));
+            shards.push_back({std::move(*pending), path_id, shard.revision()});
         }
     }
-    LOG_INFO("Saved {} MergedIndex shards (of {} total)", shards.size(), total);
+    LOG_INFO("Serialized {} MergedIndex shards (of {} total)", shards.size(), total);
 
     // Phase 2: commit each blob (fsync + atomic rename) on the kota thread
     // pool, keeping the heavy IO off the event loop.  The project blob goes
     // first; if it cannot be published, drop the shards of this snapshot.
+    saved_shards = 0;
     auto committed =
         co_await kota::queue([&] { return store.commit(std::move(*project_pending)); });
     if(!committed.has_value() || !committed.value().has_value()) {
@@ -263,12 +281,39 @@ kota::task<> Indexer::save() {
     // FIXME: shard commits are strictly sequential (one co_await per shard).
     // For large projects this adds ~N×2ms of round-trip overhead.  Consider
     // batching commits or dispatching them in parallel on the thread pool.
-    for(auto& pending: shards) {
-        auto key = pending.key;
-        auto result = co_await kota::queue([&] { return store.commit(std::move(pending)); });
-        if(!result.has_value() || !result.value().has_value()) {
+    for(auto& write: shards) {
+        auto key = write.pending.key;
+
+        auto outcome = co_await kota::queue([&]() -> CommitOutcome {
+            CommitOutcome out{store.commit(std::move(write.pending)), {}};
+            if(out.path) {
+                out.reloaded = index::MergedIndex::load(*out.path);
+            }
+            return out;
+        });
+        if(!outcome.has_value() || !outcome.value().path.has_value()) {
             LOG_WARN("Failed to commit index blob {}", key);
+            continue;
         }
+        saved_shards += 1;
+
+        // Flip the shard back to its committed, buffer-backed blob: the
+        // heap Impl a merge materialized would otherwise live until
+        // shutdown (F21), and need_rewrite() would keep claiming the
+        // shard dirty forever, turning every later save into a full
+        // rewrite. Only a shard untouched across the commit await may
+        // flip — a merge that landed meanwhile made the blob stale, and
+        // the shard simply stays dirty for the next save. An unreadable
+        // reload keeps the live Impl for the same reason.
+        auto it = workspace.merged_indices.find(write.path_id);
+        if(it == workspace.merged_indices.end() || it->second.revision() != write.revision) {
+            continue;
+        }
+        if(!outcome.value().reloaded.loaded()) {
+            LOG_WARN("Committed index blob {} did not read back; keeping the in-memory shard", key);
+            continue;
+        }
+        it->second = std::move(outcome.value().reloaded);
     }
 
     LOG_PERF("index",

--- a/src/server/compiler/indexer.cpp
+++ b/src/server/compiler/indexer.cpp
@@ -207,6 +207,10 @@ static std::optional<CacheStore::PendingEntry>
 }
 
 kota::task<> Indexer::save() {
+    // Reset up front: every early return below means this save committed
+    // nothing, and the gauge must not keep exposing the previous round's
+    // count as current.
+    saved_shards = 0;
     if(!workspace.store)
         co_return;
     auto& store = *workspace.store;
@@ -269,7 +273,6 @@ kota::task<> Indexer::save() {
     // Phase 2: commit each blob (fsync + atomic rename) on the kota thread
     // pool, keeping the heavy IO off the event loop.  The project blob goes
     // first; if it cannot be published, drop the shards of this snapshot.
-    saved_shards = 0;
     auto committed =
         co_await kota::queue([&] { return store.commit(std::move(*project_pending)); });
     if(!committed.has_value() || !committed.value().has_value()) {

--- a/src/server/compiler/indexer.h
+++ b/src/server/compiler/indexer.h
@@ -169,6 +169,14 @@ public:
         return index_queue.size();
     }
 
+    /// How many shard blobs the last save() durably committed. With the
+    /// post-commit flip-back this is the true dirty set — a steady-state
+    /// save commits 0 — so the stats endpoint can pin full-rewrite
+    /// regressions.
+    std::size_t last_save_shards() const {
+        return saved_shards;
+    }
+
     /// Progress of the current (or last) indexing round. The reporter reads
     /// this on each on_progress_changed emission — the signal only wakes it,
     /// the numbers live here.
@@ -283,6 +291,7 @@ private:
     std::uint64_t reindex_ticket = 0;
     bool indexing_active = false;
     bool indexing_scheduled = false;
+    std::size_t saved_shards = 0;
     std::shared_ptr<kota::timer> index_idle_timer;
 
     /// Pause/resume: when paused, new index tasks wait on this event.

--- a/src/server/protocol/extension.h
+++ b/src/server/protocol/extension.h
@@ -110,4 +110,38 @@ struct LogFloodResult {
     std::uint32_t emitted = 0;
 };
 
+/// clice/internal/stats — TEST-ONLY, not a stable API. Ownership gauges
+/// for memory-lifecycle regression tests: instead of brittle RSS
+/// assertions, each leak class is pinned by a deterministic counter
+/// (consumed by tests/integration/server/test_memory_ownership.py).
+/// Absent from capabilities and user docs.
+struct StatsParams {};
+
+struct StatsResult {
+    /// pch_cache entries whose PreambleState blob is currently open, and
+    /// their mapped bytes. Steady state after closing documents: bounded
+    /// by the loaded-state budget, not by every key ever touched.
+    std::uint32_t pch_loaded_states = 0;
+    std::uint64_t pch_state_bytes = 0;
+
+    /// Index shards holding a heap Impl (need_rewrite() true), and their
+    /// stored-content bytes. Zero after a settled save: committed shards
+    /// flip back to their buffer-backed blobs.
+    std::uint32_t index_inmemory_shards = 0;
+    std::uint64_t index_shard_content_bytes = 0;
+
+    /// Shards the last index save actually wrote (the true dirty set).
+    std::uint32_t last_save_shards = 0;
+
+    /// In-flight tmp blobs of this instance's cache store. Zero once
+    /// builds settle — every pending write either committed or cleaned
+    /// itself up.
+    std::uint32_t pending_tmp_files = 0;
+
+    /// Trend gauges.
+    std::uint32_t pch_cache_entries = 0;
+    std::uint32_t header_contexts = 0;
+    std::uint32_t sessions = 0;
+};
+
 }  // namespace clice::ext

--- a/src/server/transport/lsp_client.cpp
+++ b/src/server/transport/lsp_client.cpp
@@ -621,6 +621,47 @@ void LSPClient::register_extensions() {
                         }
                         co_return to_raw(ext::LogFloodResult{count});
                     });
+
+    // Ownership gauges for memory-lifecycle tests (see ext::StatsParams).
+    // Read-only and synchronous: every counter is computed from live
+    // master state on the event loop, so an assertion made after a settled
+    // operation observes exactly the state that operation left behind.
+    peer.on_request(
+        "clice/internal/stats",
+        [this](RequestContext& ctx, const ext::StatsParams&) -> RawResult {
+            auto& srv = this->server;
+            ext::StatsResult stats;
+
+            for(auto& entry: srv.workspace.pch_cache) {
+                auto& st = entry.second;
+                if(st.state) {
+                    stats.pch_loaded_states += 1;
+                    stats.pch_state_bytes += st.state->size();
+                }
+            }
+            stats.pch_cache_entries = static_cast<std::uint32_t>(srv.workspace.pch_cache.size());
+
+            for(auto& [path_id, shard]: srv.workspace.merged_indices) {
+                if(shard.need_rewrite()) {
+                    stats.index_inmemory_shards += 1;
+                    stats.index_shard_content_bytes += shard.content().size();
+                }
+            }
+            stats.last_save_shards = static_cast<std::uint32_t>(srv.indexer.last_save_shards());
+
+            if(srv.workspace.store) {
+                stats.pending_tmp_files =
+                    static_cast<std::uint32_t>(srv.workspace.store->pending_tmp_files());
+            }
+
+            stats.header_contexts = static_cast<std::uint32_t>(srv.contexts.header_contexts.size());
+            srv.sessions.for_each([&](std::uint32_t, const Session&) -> bool {
+                stats.sessions += 1;
+                return true;
+            });
+
+            co_return to_raw(stats);
+        });
 }
 
 /// Publish clice.toml load problems as diagnostics, each on its own file's

--- a/src/support/cache_store.cpp
+++ b/src/support/cache_store.cpp
@@ -640,6 +640,18 @@ void CacheStore::invalidate(llvm::StringRef ns, llvm::StringRef key) {
     maybe_checkpoint();
 }
 
+std::size_t CacheStore::pending_tmp_files() const {
+    std::lock_guard guard(state->mutex);
+    std::size_t count = 0;
+    std::error_code ec;
+    for(auto it = llvm::sys::fs::directory_iterator(state->tmp_dir, ec);
+        !ec && it != llvm::sys::fs::directory_iterator();
+        it.increment(ec)) {
+        count += 1;
+    }
+    return count;
+}
+
 void CacheStore::for_each_key(llvm::StringRef ns, llvm::function_ref<void(llvm::StringRef)> fn) {
     llvm::SmallVector<std::string> keys;
     {

--- a/src/support/cache_store.h
+++ b/src/support/cache_store.h
@@ -189,6 +189,12 @@ public:
     /// Iterates over a snapshot, so fn may call back into the store.
     void for_each_key(llvm::StringRef ns, llvm::function_ref<void(llvm::StringRef)> fn);
 
+    /// Number of in-flight tmp blobs of this instance (files under
+    /// `tmp/{pid}`). A settled server has zero: every PendingEntry either
+    /// committed (renamed away) or cleaned itself up. Memory/leak gauge
+    /// for the stats endpoint; scans the directory, so not free.
+    std::size_t pending_tmp_files() const;
+
     /// The versioned root directory, e.g. `{root}/cache/v1`.  Callers may
     /// place their own metadata files directly under it (the store only
     /// manages namespace subdirectories); they die with the version.

--- a/tests/integration/server/test_memory_ownership.py
+++ b/tests/integration/server/test_memory_ownership.py
@@ -1,0 +1,164 @@
+"""Ownership-gauge tests for memory lifecycle regressions.
+
+Each leak class is pinned by a deterministic counter from the
+clice/internal/stats hook instead of a brittle RSS assertion: shards flip
+back to disk after a save, saves write only the true dirty set, and
+cancelled builds leave no tmp blobs behind.
+"""
+
+import asyncio
+
+from lsprotocol.types import (
+    DidChangeTextDocumentParams,
+    DidSaveTextDocumentParams,
+    TextDocumentContentChangeWholeDocument,
+    TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier,
+)
+
+from tests.tools.checks import (
+    MTIME_GRANULARITY,
+    assert_no_anomaly,
+    wait_for_index,
+    wait_for_recompile,
+)
+from tests.tools.compile_commands import write_cdb
+from tests.tools.workspace import get_field, list_tmp_files, pin_cache_to_workspace
+
+
+async def wait_stats(client, predicate, *, timeout=30.0, message=""):
+    """Poll clice/internal/stats until predicate(stats) holds."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        stats = await client.stats()
+        if predicate(stats):
+            return stats
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError(f"{message or 'stats condition'} not met: {stats}")
+        await asyncio.sleep(0.2)
+
+
+async def test_shards_flip_back_after_save(client, tmp_path):
+    pin_cache_to_workspace(tmp_path)
+    files = []
+    for i in range(4):
+        name = f"file{i}.cpp"
+        (tmp_path / name).write_text(f"int func_{i}() {{ return {i}; }}\n")
+        files.append(name)
+    write_cdb(tmp_path, files)
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "file0.cpp")
+    assert await wait_for_index(client, uri, "func_3"), (
+        "background index did not finish"
+    )
+
+    stats = await wait_stats(
+        client,
+        lambda s: get_field(s, "indexInmemoryShards") == 0,
+        message="shards did not flip back after save",
+    )
+    assert get_field(stats, "lastSaveShards") >= 1, (
+        f"the settled round should have written shards: {stats}"
+    )
+    assert_no_anomaly(client, tmp_path)
+
+
+async def test_save_writes_only_dirty_shards(client, tmp_path):
+    pin_cache_to_workspace(tmp_path)
+    files = []
+    for i in range(4):
+        name = f"file{i}.cpp"
+        (tmp_path / name).write_text(f"int func_{i}() {{ return {i}; }}\n")
+        files.append(name)
+    write_cdb(tmp_path, files)
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "file0.cpp")
+    assert await wait_for_index(client, uri, "func_3"), (
+        "background index did not finish"
+    )
+    await wait_stats(
+        client,
+        lambda s: get_field(s, "indexInmemoryShards") == 0,
+        message="initial round did not settle",
+    )
+    # The first workspace tick only seeds the stat baseline.
+    await client.poll("workspace")
+
+    # Change one file on disk and tick the tracker: only its shard should
+    # be re-merged and re-saved.
+    await asyncio.sleep(MTIME_GRANULARITY)
+    (tmp_path / "file2.cpp").write_text("int func_2_renamed() { return 2; }\n")
+    await client.poll("workspace")
+    assert await wait_for_index(client, uri, "func_2_renamed"), "reindex did not land"
+
+    stats = await wait_stats(
+        client,
+        lambda s: get_field(s, "indexInmemoryShards") == 0,
+        message="incremental round did not settle",
+    )
+    # Load-bearing assumptions for the exact count: the files are
+    # standalone (no includes, so no header-shard fan-out) and only
+    # background indexing merges shards (the open file's interactive
+    # compile does not contribute one).
+    assert get_field(stats, "lastSaveShards") == 1, (
+        f"an incremental save must write only the touched shard: {stats}"
+    )
+
+    # A round with nothing to write commits zero shards: saving the open
+    # file schedules a round, but its shard is served by the session and
+    # background indexing skips open files.
+    client.text_document_did_save(
+        DidSaveTextDocumentParams(text_document=TextDocumentIdentifier(uri=uri))
+    )
+    await wait_stats(
+        client,
+        lambda s: get_field(s, "lastSaveShards") == 0,
+        message="a no-op round must save zero shards",
+    )
+    assert_no_anomaly(client, tmp_path)
+
+
+async def test_cancel_storm_leaves_no_tmp(client, tmp_path):
+    pin_cache_to_workspace(tmp_path)
+    (tmp_path / "header.h").write_text("#pragma once\nint base_val = 1;\n")
+    (tmp_path / "main.cpp").write_text(
+        '#include "header.h"\nint main() { return base_val; }\n'
+    )
+    write_cdb(tmp_path, ["main.cpp"])
+    await client.initialize(tmp_path)
+
+    uri, _ = await client.open_and_wait(tmp_path / "main.cpp")
+
+    # Each edit changes the preamble text, so each supersedes the previous
+    # PCH build under a fresh content key.
+    for i in range(15):
+        client.text_document_did_change(
+            DidChangeTextDocumentParams(
+                text_document=VersionedTextDocumentIdentifier(uri=uri, version=i + 2),
+                content_changes=[
+                    TextDocumentContentChangeWholeDocument(
+                        text=f'#define STORM {i}\n#include "header.h"\n'
+                        "int main() { return base_val; }\n"
+                    )
+                ],
+            )
+        )
+        await asyncio.sleep(0.05)
+
+    await wait_for_recompile(client, uri)
+    await wait_stats(
+        client,
+        lambda s: get_field(s, "pendingTmpFiles") == 0,
+        message="cancelled builds leaked tmp blobs",
+    )
+    assert list_tmp_files(tmp_path) == [], (
+        "tmp directory should be empty after settling"
+    )
+    # Shape smoke for the gauges no test asserts on: a missing or renamed
+    # field reads back None, not a number.
+    stats = await client.stats()
+    assert get_field(stats, "pchCacheEntries") >= 1, f"a PCH was built: {stats}"
+    assert get_field(stats, "sessions") == 1, f"one open document: {stats}"
+    assert_no_anomaly(client, tmp_path)

--- a/tests/tools/client.py
+++ b/tests/tools/client.py
@@ -560,3 +560,11 @@ class CliceClient(BaseLanguageClient):
             self.protocol.send_request_async("clice/internal/poll", {"loop": loop}),
             timeout=timeout,
         )
+
+    async def stats(self, *, timeout: float = 60.0):
+        """Send clice/internal/stats (test hook): ownership gauges for
+        memory-lifecycle assertions. Returns the raw result object."""
+        return await asyncio.wait_for(
+            self.protocol.send_request_async("clice/internal/stats", {}),
+            timeout=timeout,
+        )

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -75,6 +75,39 @@ TEST_CASE(Serialization) {
     }
 }
 
+TEST_CASE(RevisionAndFlipBack) {
+    build_index(R"(
+            int flip_func() { return 1; }
+        )");
+
+    index::MergedIndex merged;
+    ASSERT_EQ(merged.revision(), 0u);
+
+    auto fid = unit->interested_file();
+    merged.merge("tu0", tu_index.graph.include_location_id(fid), tu_index.main_file_index, {});
+    auto merged_rev = merged.revision();
+    ASSERT_TRUE(merged_rev != 0u);
+    ASSERT_TRUE(merged.need_rewrite());
+
+    // The flip save() performs after a commit: the serialized twin is
+    // buffer-backed (no heap Impl, not dirty) and answers identically.
+    llvm::SmallString<1024> s;
+    llvm::raw_svector_ostream os(s);
+    merged.serialize(os);
+    auto reloaded = index::MergedIndex(s);
+    ASSERT_FALSE(reloaded.need_rewrite());
+    ASSERT_EQ(reloaded.revision(), 0u);
+
+    // Every mutation bumps the revision, so a save can prove no merge
+    // landed across its commit await. (Ordering is load-bearing: operator==
+    // materializes both sides' Impl, and serialize() compacts removed rows
+    // and caches — the comparison is only valid before remove()/lookup()
+    // touch either side.)
+    ASSERT_TRUE(merged == reloaded);
+    merged.remove("tu0");
+    ASSERT_TRUE(merged.revision() != merged_rev && merged.revision() != 0u);
+}
+
 TEST_CASE(LookupByOffset) {
     build_index(R"(
             int @func[$(func)foo]() { return 42; }

--- a/tests/unit/server/indexer_tests.cpp
+++ b/tests/unit/server/indexer_tests.cpp
@@ -130,6 +130,97 @@ TEST_CASE(MergeSkipsMovedDisk) {
     ASSERT_EQ(it->second.content(), "int renamed() { return 2; }\n");
 }
 
+void open_store(TempDir& tmp, Workspace& workspace) {
+    auto store = CacheStore::open(tmp.path("cache"), 1);
+    ASSERT_TRUE(store.has_value());
+    store->register_namespace(
+        {.name = "index", .extension = ".idx", .policy = CachePolicy::Persistent});
+    workspace.store.emplace(std::move(*store));
+}
+
+TEST_CASE(SaveFlipsShards) {
+    TempDir tmp;
+    tmp.touch("main.cpp", "int flip_value() { return 1; }\n");
+    auto src = tmp.path("main.cpp");
+    open_store(tmp, workspace);
+
+    auto indexed = index_file(tmp, src);
+    ASSERT_FALSE(indexed.data.empty());
+    indexer.merge(indexed.data.data(), indexed.data.size());
+
+    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+    ASSERT_TRUE(workspace.merged_indices.find(path_id)->second.need_rewrite());
+
+    // Named body: a temporary lambda's captures die with the statement
+    // while the coroutine frame still references them.
+    auto save_body = [&]() -> kota::task<> {
+        co_await indexer.save();
+    };
+    auto task = save_body();
+    loop.schedule(task);
+    loop.run();
+
+    // Committed and flipped back to the buffer-backed blob; the shard
+    // still answers identically.
+    auto it = workspace.merged_indices.find(path_id);
+    ASSERT_TRUE(it != workspace.merged_indices.end());
+    ASSERT_FALSE(it->second.need_rewrite());
+    ASSERT_EQ(it->second.content(), "int flip_value() { return 1; }\n");
+    ASSERT_TRUE(it->second.has_contribution(indexed.tu_path));
+}
+
+TEST_CASE(MidSaveMergeKept) {
+    TempDir tmp;
+    tmp.touch("main.cpp", "int first_value() { return 1; }\n");
+    auto src = tmp.path("main.cpp");
+    open_store(tmp, workspace);
+
+    auto indexed = index_file(tmp, src);
+    ASSERT_FALSE(indexed.data.empty());
+    indexer.merge(indexed.data.data(), indexed.data.size());
+    auto path_id = workspace.path_pool.intern(indexed.tu_path);
+
+    // Prepared before save() starts so the interleaved merge is purely an
+    // in-memory event.
+    tmp.touch("main.cpp", "int second_value() { return 2; }\n");
+    auto fresh = index_file(tmp, src);
+    ASSERT_FALSE(fresh.data.empty());
+
+    // The merge task runs when save() suspends at its first commit await:
+    // it lands between the serialize snapshot and the flip check, exactly
+    // the window the revision guard exists for.
+    auto save_body = [&]() -> kota::task<> {
+        co_await indexer.save();
+    };
+    auto merge_body = [&]() -> kota::task<> {
+        indexer.merge(fresh.data.data(), fresh.data.size());
+        co_return;
+    };
+    auto save_task = save_body();
+    auto merge_task = merge_body();
+    loop.schedule(save_task);
+    loop.schedule(merge_task);
+    loop.run();
+
+    // The stale committed blob must not overwrite the newer merge: the
+    // shard keeps the new content and stays dirty for the next save.
+    auto it = workspace.merged_indices.find(path_id);
+    ASSERT_TRUE(it != workspace.merged_indices.end());
+    ASSERT_TRUE(it->second.need_rewrite());
+    ASSERT_EQ(it->second.content(), "int second_value() { return 2; }\n");
+
+    auto again_body = [&]() -> kota::task<> {
+        co_await indexer.save();
+    };
+    auto task = again_body();
+    loop.schedule(task);
+    loop.run();
+
+    it = workspace.merged_indices.find(path_id);
+    ASSERT_FALSE(it->second.need_rewrite());
+    ASSERT_EQ(it->second.content(), "int second_value() { return 2; }\n");
+}
+
 };  // TEST_SUITE(IndexerMerge)
 
 TEST_SUITE(IndexerRequeue) {


### PR DESCRIPTION
## Background

Index shards are served from memory-mapped blobs, but any merge materializes a shard's in-memory form and drops the mapped buffer permanently. Two consequences:

- Memory grows one-way for the server's lifetime: every shard a background round touches stays heap-resident until shutdown (~100KB per small file, MB-level for large translation units). Only a restart releases it.
- The "needs rewrite" predicate keeps claiming every touched shard dirty forever, so each save rewrites the entire namespace: an incremental round costs seconds of serialization on large projects, and shutdown pays a full rewrite.

## Changes

- `MergedIndex` now carries a mutation stamp drawn from a process-wide monotonic source. Values never repeat across objects, so an entry erased and re-created at the same key while a save is mid-flight cannot alias a snapshot taken before the swap (a per-object counter restarting from zero could).
- `Indexer::save()` reopens each committed blob inside the same thread-pool job as the commit — the mmap and the flatbuffer verification walk the whole file and stay off the event loop — and flips the shard back to the buffer-backed reload, but only when the shard still exists and its stamp is unchanged across the commit await. A merge that landed meanwhile keeps the shard dirty for the next save instead of being silently overwritten by the stale blob.
- With flipped-back shards clean, the rewrite predicate is a true dirty set: an incremental round saves only the shards its merges touched, and a round with nothing to write commits zero blobs. The last save's committed count is exposed as a gauge.
- New TEST-ONLY `clice/internal/stats` request (absent from capabilities, same test-hook family as `clice/internal/poll`) exposes ownership gauges: loaded preamble states and their mapped bytes, in-memory shards and their content bytes, the last save's committed shard count, in-flight cache tmp blobs, and trend counters. Memory-lifecycle regressions are pinned by deterministic counters instead of brittle RSS assertions.

## Testing

- Unit: `MergedIndex.RevisionAndFlipBack` (stamp semantics, serialized twin is clean and equal), `IndexerMerge.SaveFlipsShards` (save flips a committed shard back and it still answers), `IndexerMerge.MidSaveMergeKept` (a merge interleaved into save's commit await is not lost: the shard keeps the newer content, stays dirty, and the next save writes it — the data-loss guard, exercised deterministically on the event loop).
- Integration (`tests/integration/server/test_memory_ownership.py`): shards flip back after a settled round; an incremental change saves exactly one shard; a round with nothing to write commits zero; a 15-edit preamble supersession storm leaves zero in-flight tmp blobs; plus shape smoke for the gauges.
- TDD: with the flip disabled, the flip-back and dirty-set tests fail; restored, all pass. Full suites green in RelWithDebInfo and Debug (1019 unit, 295 integration, 3/3 smoke).

## Notes

- The stats endpoint is read-only and intended for tests; `pending_tmp_files` scans the store's tmp directory under the store mutex, which is fine for a test hook but not meant for hot paths.
- The gauge counts durably committed shard blobs, not serialize-time intent: failed commits do not inflate it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added internal stats endpoint for test/runtime monitoring (memory-lifecycle counters and gauges).
  - Exposed revision tracking on merged index and size/count helpers for mapped preamble state and pending temporary cache files.

- **Bug Fixes**
  - Refined shard two-phase saving so committed/reloaded snapshots only replace in-memory data when revisions match.
  - Ensured concurrent or mid-save merges don’t get overwritten by stale committed snapshots.
  - Verified shard flip-back behavior and improved handling of cancelled/superseded processing cleanup.

- **Performance**
  - After save, merged index shards return to their persistent form to reduce retained in-memory rewrite state.

- **Tests**
  - Added integration and unit coverage for revision/flip-back, dirty-shard-only saves, and cancellation cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->