### PR TITLE
fix(vscode): interim display name pending marketplace

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clice",
-  "displayName": "clice",
+  "displayName": "clice vscode",
   "description": "VSCode extension for clice",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Microsoft's Marketplace policy permanently reserves deleted extension display names, which currently blocks publishing `clice-io.clice` with the display name `clice` (held by the removed predecessor extension). Use `clice vscode` as an interim display name so the extension can ship; a release request for the original name is pending with Marketplace support. Display-name changes are plain updates — the extension ID stays `clice-io.clice`, so this is fully reversible once the name is released.