### PR TITLE
chore: use the real coderabbit summary switch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,5 +3,7 @@ chat:
 reviews:
   auto_review:
     enabled: true
-  summary:
-    enabled: false
+  # The key #400 used (reviews.summary.enabled) does not exist in the
+  # schema and was silently ignored; high_level_summary is the real switch.
+  high_level_summary: false
+  sequence_diagrams: false


### PR DESCRIPTION
PR #400 tried to disable the auto summary with `reviews.summary.enabled`, but that key does not exist in CodeRabbit's configuration schema and was silently ignored — the summaries kept coming. The documented switch is `reviews.high_level_summary`. Also disables the walkthrough sequence diagrams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to use the supported high-level summary setting.
  * Disabled high-level summaries in automated review output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->