### PR TITLE
refactor(tests): annotation syntax with non-ASCII sigils

### DIFF
--- a/tests/data/hover/.clang-format
+++ b/tests/data/hover/.clang-format
@@ -1,4 +1,4 @@
-# These fixtures contain `$(name)` hover-point annotations that clang-format
+# These fixtures contain `§(name)` hover-point annotations that clang-format
 # would split apart, so formatting is disabled for this directory.
 DisableFormat: true
 SortIncludes: false

--- a/tests/data/hover/attributes.cpp
+++ b/tests/data/hover/attributes.cpp
@@ -1,4 +1,4 @@
 // Test cases ported from clangd's HoverTests.cpp (llvmorg-21.1.8), part of the LLVM project,
 // licensed under Apache License v2.0 with LLVM Exceptions.
 
-void foo(int * __attribute__((non$(01_attribute)null, noescape)) );
+void foo(int * __attribute__((non§(01_attribute)null, noescape)) );

--- a/tests/data/hover/auto.cpp
+++ b/tests/data/hover/auto.cpp
@@ -11,7 +11,7 @@ namespace std
 namespace structured_bindings {
 void foo() {
   struct S { int x; float y; };
-  au$(01_structured_bindings)to [x, y] = S();
+  au§(01_structured_bindings)to [x, y] = S();
 }
 }
 
@@ -19,20 +19,20 @@ void foo() {
 namespace undeduced {
 template<typename T>
 void foo() {
-  au$(02_undeduced_auto)to x = T{};
+  au§(02_undeduced_auto)to x = T{};
 }
 }
 
 // Constrained auto.
 namespace constrained {
 template <class T> concept F = true;
-F au$(03_constrained_auto)to x = 1;
+F au§(03_constrained_auto)to x = 1;
 }
 
 // auto on lambda.
 namespace on_lambda {
 void foo() {
-  au$(04_auto_lambda)to lamb = []{};
+  au§(04_auto_lambda)to lamb = []{};
 }
 }
 
@@ -40,7 +40,7 @@ void foo() {
 namespace on_instantiation {
 template<typename T> class Foo{};
 void foo() {
-  au$(05_auto_instantiation)to x = Foo<int>();
+  au§(05_auto_instantiation)to x = Foo<int>();
 }
 }
 
@@ -49,28 +49,28 @@ namespace on_specialization {
 template<typename T> class Foo{};
 template<> class Foo<int>{};
 void foo() {
-  au$(06_auto_specialized)to x = Foo<int>();
+  au§(06_auto_specialized)to x = Foo<int>();
 }
 }
 
 // Simple initialization with auto.
 namespace simple_init {
 void foo() {
-  $(07_simple_auto)auto i = 1;
+  §(07_simple_auto)auto i = 1;
 }
 }
 
 // Simple initialization with const auto.
 namespace const_init {
 void foo() {
-  const $(08_const_auto)auto i = 1;
+  const §(08_const_auto)auto i = 1;
 }
 }
 
 // Simple initialization with const auto&.
 namespace const_ref_init {
 void foo() {
-  const $(09_const_auto_ref)auto& i = 1;
+  const §(09_const_auto_ref)auto& i = 1;
 }
 }
 
@@ -78,7 +78,7 @@ void foo() {
 namespace ref_init {
 void foo() {
   int x;
-  $(10_auto_ref)auto& i = x;
+  §(10_auto_ref)auto& i = x;
 }
 }
 
@@ -86,7 +86,7 @@ void foo() {
 namespace ptr_init {
 void foo() {
   int a = 1;
-  $(11_auto_ptr)auto* i = &a;
+  §(11_auto_ptr)auto* i = &a;
 }
 }
 
@@ -94,27 +94,27 @@ void foo() {
 namespace from_pointer {
 void foo() {
   int a = 1;
-  $(12_auto_from_pointer)auto i = &a;
+  §(12_auto_from_pointer)auto i = &a;
 }
 }
 
 // Auto with initializer list.
 namespace init_list {
 void foo() {
-  $(13_auto_init_list)auto i = {1,2};
+  §(13_auto_init_list)auto i = {1,2};
 }
 }
 
 // User defined conversion to auto.
 namespace conversion {
 struct Bar {
-  operator $(14_auto_conversion)auto() const { return 10; }
+  operator §(14_auto_conversion)auto() const { return 10; }
 };
 }
 
 // Simple trailing return type.
 namespace trailing_return {
-$(15_auto_trailing_return)auto main() -> int {
+§(15_auto_trailing_return)auto main() -> int {
   return 0;
 }
 }
@@ -122,7 +122,7 @@ $(15_auto_trailing_return)auto main() -> int {
 namespace trailing_decltype_return {
 // auto function return with trailing type
 struct Bar {};
-$(16_auto_trailing_decltype)auto test() -> decltype(Bar()) {
+§(16_auto_trailing_decltype)auto test() -> decltype(Bar()) {
   return Bar();
 }
 }
@@ -130,7 +130,7 @@ $(16_auto_trailing_decltype)auto test() -> decltype(Bar()) {
 namespace fn_return {
 // auto in function return
 struct Bar {};
-$(17_auto_fn_return)auto test() {
+§(17_auto_fn_return)auto test() {
   return Bar();
 }
 }
@@ -138,7 +138,7 @@ $(17_auto_fn_return)auto test() {
 namespace ref_fn_return {
 // auto& in function return
 struct Bar {};
-$(18_auto_ref_fn_return)auto& test() {
+§(18_auto_ref_fn_return)auto& test() {
   static Bar x;
   return x;
 }
@@ -147,7 +147,7 @@ $(18_auto_ref_fn_return)auto& test() {
 namespace ptr_fn_return {
 // auto* in function return
 struct Bar {};
-$(19_auto_ptr_fn_return)auto* test() {
+§(19_auto_ptr_fn_return)auto* test() {
   Bar* bar;
   return bar;
 }
@@ -156,7 +156,7 @@ $(19_auto_ptr_fn_return)auto* test() {
 namespace const_ref_fn_return {
 // const auto& in function return
 struct Bar {};
-const $(20_const_auto_ref_fn_return)auto& test() {
+const §(20_const_auto_ref_fn_return)auto& test() {
   static Bar x;
   return x;
 }
@@ -165,48 +165,48 @@ const $(20_const_auto_ref_fn_return)auto& test() {
 // More complicated structured types.
 namespace fn_pointer {
 int bar();
-$(21_auto_fn_pointer)auto (*foo)() = bar;
+§(21_auto_fn_pointer)auto (*foo)() = bar;
 }
 
 // auto on alias.
 namespace alias_int {
 typedef int int_type;
-$(22_auto_alias_int)auto x = int_type();
+§(22_auto_alias_int)auto x = int_type();
 }
 
 namespace alias_class {
 // auto on alias
 struct cls {};
 typedef cls cls_type;
-$(23_auto_alias_class)auto y = cls_type();
+§(23_auto_alias_class)auto y = cls_type();
 }
 
 namespace alias_template_inst {
 // auto on alias
 template <class>
 struct templ {};
-$(24_auto_alias_template)auto z = templ<int>();
+§(24_auto_alias_template)auto z = templ<int>();
 }
 
 // Undeduced auto declaration.
 namespace undeduced_decl {
 template<typename T>
 void foo() {
-  $(25_undeduced_auto_decl)auto x = T();
+  §(25_undeduced_auto_decl)auto x = T();
 }
 }
 
 // Undeduced auto return type.
 namespace undeduced_return {
 template<typename T>
-$(26_undeduced_auto_return)auto foo() {
+§(26_undeduced_auto_return)auto foo() {
   return T();
 }
 }
 
 // Template auto parameter.
 namespace template_auto_param {
-template<a$(27_template_auto_param)uto T>
+template<a§(27_template_auto_param)uto T>
   void func() {
 }
 }

--- a/tests/data/hover/basics.cpp
+++ b/tests/data/hover/basics.cpp
@@ -2,56 +2,56 @@
 // licensed under Apache License v2.0 with LLVM Exceptions.
 
 // Best foo ever.
-void fo$(01_global_func)o() {}
+void fo§(01_global_func)o() {}
 
 namespace ns1 { namespace ns2 {
   /// Best foo ever.
-  void fo$(02_ns_func)o() {}
+  void fo§(02_ns_func)o() {}
 }}
 
 namespace ns1 { namespace ns2 {
   class Foo {
-    char b$(03_field)ar;
+    char b§(03_field)ar;
     double y[2];
   };
 }}
 
 union FooUnion {
-  char b$(04_union_field)ar;
+  char b§(04_union_field)ar;
   double y[2];
 };
 
 struct FooBits1 {
-  int $(05_bitfield)x : 1;
+  int §(05_bitfield)x : 1;
   int y : 1;
 };
 
 struct FooBits2 {
   char x;
-  char $(06_bitfield_padding)y : 1;
+  char §(06_bitfield_padding)y : 1;
   int z;
 };
 
 namespace ns1 { namespace ns2 {
   struct Bar {
     void foo() {
-      int b$(07_method_local)ar;
+      int b§(07_method_local)ar;
     }
   };
 }}
 
 namespace ns1 { namespace {
   struct {
-    char b$(08_anon_struct_field)ar;
+    char b§(08_anon_struct_field)ar;
   } T;
 }}
 
-struct $(09_struct_size)X {};
+struct §(09_struct_size)X {};
 
 void pf1() {
-  __f$(10_predefined_var)unc__;
+  __f§(10_predefined_var)unc__;
 }
 
 template<int> void pf2() {
-  __f$(11_predefined_var_dependent)unc__;
+  __f§(11_predefined_var_dependent)unc__;
 }

--- a/tests/data/hover/callee_args.cpp
+++ b/tests/data/hover/callee_args.cpp
@@ -6,7 +6,7 @@ namespace fn_call {
 void fun(int arg_a, int &arg_b) {};
 void code() {
   int a = 1, b = 2;
-  fun(a, $(01_arg_by_ref)b);
+  fun(a, §(01_arg_by_ref)b);
 }
 }
 
@@ -23,7 +23,7 @@ T make(Args&&... args)
 
 void code() {
   int a = 1;
-  auto foo = make<Foo>($(02_forwarded_arg)a);
+  auto foo = make<Foo>(§(02_forwarded_arg)a);
 }
 }
 
@@ -32,7 +32,7 @@ namespace converted_arg {
 void foobar(const float &arg);
 int main() {
   int a = 0;
-  foobar($(03_converted_arg)a);
+  foobar(§(03_converted_arg)a);
 }
 }
 
@@ -43,7 +43,7 @@ struct Foo {
 };
 int main() {
   int a = 0;
-  Foo foo($(04_converted_ctor_arg)a);
+  Foo foo(§(04_converted_ctor_arg)a);
 }
 }
 
@@ -52,7 +52,7 @@ namespace literal_arg {
 void fun(int arg_a, const int &arg_b) {};
 void code() {
   int a = 1;
-  fun(a, $(05_literal_arg)2);
+  fun(a, §(05_literal_arg)2);
 }
 }
 
@@ -61,7 +61,7 @@ namespace expression_arg {
 void fun(int arg_a, const int &arg_b) {};
 void code() {
   int a = 1;
-  fun(a, 1 $(06_expression_arg)+ 2);
+  fun(a, 1 §(06_expression_arg)+ 2);
 }
 }
 
@@ -69,7 +69,7 @@ void code() {
 namespace expression_by_value {
 int add(int lhs, int rhs);
 int main() {
-  add(1 $(07_expression_by_value)+ 2, 3);
+  add(1 §(07_expression_by_value)+ 2, 3);
 }
 }
 
@@ -77,7 +77,7 @@ int main() {
 namespace converted_literal {
 void foobar(const float &arg);
 int main() {
-  foobar($(08_converted_literal)0);
+  foobar(§(08_converted_literal)0);
 }
 }
 
@@ -90,7 +90,7 @@ class C {
 void code() {
   int a = 1, b = 2;
   C c;
-  c.fun($(09_method_arg_default)a, b);
+  c.fun(§(09_method_arg_default)a, b);
 }
 }
 
@@ -102,6 +102,6 @@ struct Foo {
 void foo(Foo);
 void bar() {
   const int x = 0;
-  foo($(10_converting_ctor_arg)x);
+  foo(§(10_converting_ctor_arg)x);
 }
 }

--- a/tests/data/hover/concepts.cpp
+++ b/tests/data/hover/concepts.cpp
@@ -4,31 +4,31 @@
 // Concept constraining a variable type.
 namespace constrained_var {
 template <class T> concept F = true;
-$(01_concept_on_var)F auto x = 1;
+§(01_concept_on_var)F auto x = 1;
 }
 
 // Constrained template parameter.
 namespace constrained_tparam {
 template<class T> concept Fooable = true;
-template<Foo$(02_concept_on_tparam)able T>
+template<Foo§(02_concept_on_tparam)able T>
 void bar(T t) {}
 }
 
 // The constrained template parameter itself.
 namespace constrained_tparam_decl {
 template<class T> concept Fooable = true;
-template<Fooable T$(03_constrained_tparam)T>
+template<Fooable T§(03_constrained_tparam)T>
 void bar(TT t) {}
 }
 
 // Constrained auto parameter.
 namespace constrained_auto_param {
 template<class T> concept Fooable = true;
-void bar(Foo$(04_concept_on_auto_param)able auto t) {}
+void bar(Foo§(04_concept_on_auto_param)able auto t) {}
 }
 
 // Concept reference.
 namespace concept_reference {
 template<class T> concept Fooable = true;
-auto X = Fooa$(05_concept_reference)ble<int>;
+auto X = Fooa§(05_concept_reference)ble<int>;
 }

--- a/tests/data/hover/decltype.cpp
+++ b/tests/data/hover/decltype.cpp
@@ -4,7 +4,7 @@
 // Simple initialization with decltype(auto).
 namespace simple_init {
 void foo() {
-  decl$(01_decltype_auto)type(auto) i = 1;
+  decl§(01_decltype_auto)type(auto) i = 1;
 }
 }
 
@@ -12,7 +12,7 @@ void foo() {
 namespace const_init {
 void foo() {
   const int j = 0;
-  decl$(02_const_decltype_auto)type(auto) i = j;
+  decl§(02_const_decltype_auto)type(auto) i = j;
 }
 }
 
@@ -21,7 +21,7 @@ namespace const_ref_init {
 void foo() {
   int k = 0;
   const int& j = k;
-  decl$(03_const_ref_decltype_auto)type(auto) i = j;
+  decl§(03_const_ref_decltype_auto)type(auto) i = j;
 }
 }
 
@@ -30,21 +30,21 @@ namespace ref_init {
 void foo() {
   int k = 0;
   int& j = k;
-  decl$(04_ref_decltype_auto)type(auto) i = j;
+  decl§(04_ref_decltype_auto)type(auto) i = j;
 }
 }
 
 namespace fn_return {
 // decltype(auto) in function return
 struct Bar {};
-decl$(05_decltype_auto_fn_return)type(auto) test() {
+decl§(05_decltype_auto_fn_return)type(auto) test() {
   return Bar();
 }
 }
 
 // decltype(auto) reference in function return.
 namespace ref_fn_return {
-decl$(06_decltype_auto_ref_return)type(auto) test() {
+decl§(06_decltype_auto_ref_return)type(auto) test() {
   static int a;
   return (a);
 }
@@ -54,7 +54,7 @@ decl$(06_decltype_auto_ref_return)type(auto) test() {
 namespace of_lvalue {
 void foo() {
   int I = 0;
-  decl$(07_decltype_lvalue)type(I) J = I;
+  decl§(07_decltype_lvalue)type(I) J = I;
 }
 }
 
@@ -63,7 +63,7 @@ namespace of_lvalue_ref {
 void foo() {
   int I = 0;
   int &K = I;
-  decl$(08_decltype_lvalue_ref)type(K) J = I;
+  decl§(08_decltype_lvalue_ref)type(K) J = I;
 }
 }
 
@@ -71,7 +71,7 @@ void foo() {
 namespace of_paren_lvalue {
 void foo() {
   int I = 0;
-  decl$(09_decltype_paren_lvalue)type((I)) J = I;
+  decl§(09_decltype_paren_lvalue)type((I)) J = I;
 }
 }
 
@@ -79,7 +79,7 @@ void foo() {
 namespace of_rvalue_ref {
 void foo() {
   int I = 0;
-  decl$(10_decltype_rvalue_ref)type(static_cast<int&&>(I)) J = static_cast<int&&>(I);
+  decl§(10_decltype_rvalue_ref)type(static_cast<int&&>(I)) J = static_cast<int&&>(I);
 }
 }
 
@@ -88,7 +88,7 @@ namespace of_rvalue_call {
 int && bar();
 void foo() {
   int I = 0;
-  decl$(11_decltype_rvalue_call)type(bar()) J = bar();
+  decl§(11_decltype_rvalue_call)type(bar()) J = bar();
 }
 }
 
@@ -99,7 +99,7 @@ auto test() -> decltype(Bar()) {
   return Bar();
 }
 void foo() {
-  decl$(12_decltype_trailing_return)type(test()) i = test();
+  decl§(12_decltype_trailing_return)type(test()) i = test();
 }
 }
 
@@ -108,7 +108,7 @@ namespace of_decltype_var {
 void foo() {
   int I = 0;
   decltype(I) J = I;
-  decl$(13_decltype_of_decltype)type(J) K = J;
+  decl§(13_decltype_of_decltype)type(J) K = J;
 }
 }
 
@@ -116,14 +116,14 @@ void foo() {
 namespace of_dependent {
 template <typename T>
 struct X {
-  using Y = decl$(14_decltype_dependent)type(T::Z);
+  using Y = decl§(14_decltype_dependent)type(T::Z);
 };
 }
 
 // Undeduced decltype(auto) return type.
 namespace undeduced_return {
 template<typename T>
-decl$(15_undeduced_decltype_auto)type(auto) foo() {
+decl§(15_undeduced_decltype_auto)type(auto) foo() {
   return T();
 }
 }
@@ -131,24 +131,24 @@ decl$(15_undeduced_decltype_auto)type(auto) foo() {
 // Variable whose type is written with decltype.
 namespace var_with_decltype {
 int a;
-decltype(a) $(16_var_decltype_type)b = a;
+decltype(a) §(16_var_decltype_type)b = a;
 }
 
 // Variable whose type chains through decltype.
 namespace var_with_decltype_chain {
 int a;
 decltype(a) c;
-decltype(c) $(17_var_decltype_chain)b = a;
+decltype(c) §(17_var_decltype_chain)b = a;
 }
 
 // Variable with const decltype type.
 namespace var_with_const_decltype {
 int a;
-const decltype(a) $(18_var_const_decltype)b = a;
+const decltype(a) §(18_var_const_decltype)b = a;
 }
 
 // Function with decltype in the signature.
 namespace fn_with_decltype {
 int a;
-auto $(19_fn_decltype_signature)foo(decltype(a) x) -> decltype(a) { return 0; }
+auto §(19_fn_decltype_signature)foo(decltype(a) x) -> decltype(a) { return 0; }
 }

--- a/tests/data/hover/docs.cpp
+++ b/tests/data/hover/docs.cpp
@@ -10,25 +10,25 @@ template <typename T> void bar() {}
 // doc
 template <typename T> T baz;
 void foo() {
-  au$(01_auto_class_doc)to t = X<int>();
-  X$(02_class_ref_doc)<int>();
-  b$(03_function_doc)ar<int>();
-  au$(04_auto_var_tmpl_doc)to T = ba$(05_var_tmpl_ref_doc)z<X<int>>;
-  ba$(06_var_tmpl_assign_doc)z<int> = 0;
+  au§(01_auto_class_doc)to t = X<int>();
+  X§(02_class_ref_doc)<int>();
+  b§(03_function_doc)ar<int>();
+  au§(04_auto_var_tmpl_doc)to T = ba§(05_var_tmpl_ref_doc)z<X<int>>;
+  ba§(06_var_tmpl_assign_doc)z<int> = 0;
 }
 }
 
 // Documentation from the most specialized declaration.
 namespace docs_special {
 // doc1
-template <typename T> class $(07_primary_doc)X {};
+template <typename T> class §(07_primary_doc)X {};
 // doc2
-template <> class $(08_full_spec_doc)X<int> {};
+template <> class §(08_full_spec_doc)X<int> {};
 // doc3
-template <typename T> class $(09_partial_spec_doc)X<T*> {};
+template <typename T> class §(09_partial_spec_doc)X<T*> {};
 void foo() {
-  X$(10_primary_ref_doc)<char>();
-  X$(11_full_spec_ref_doc)<int>();
-  X$(12_partial_spec_ref_doc)<int*>();
+  X§(10_primary_ref_doc)<char>();
+  X§(11_full_spec_ref_doc)<int>();
+  X§(12_partial_spec_ref_doc)<int*>();
 }
 }

--- a/tests/data/hover/expressions.cpp
+++ b/tests/data/hover/expressions.cpp
@@ -2,17 +2,17 @@
 // licensed under Apache License v2.0 with LLVM Exceptions.
 
 // character literal
-auto c = '$(01_char_literal)A';
+auto c = '§(01_char_literal)A';
 
 // string literal
-auto s = $(02_string_literal)"Hello, world!";
+auto s = §(02_string_literal)"Hello, world!";
 
 // sizeof expr
 void sizeof_expr() {
-  (void)size$(03_sizeof_expr)of(char);
+  (void)size§(03_sizeof_expr)of(char);
 }
 
 // alignof expr
 void alignof_expr() {
-  (void)align$(04_alignof_expr)of(char);
+  (void)align§(04_alignof_expr)of(char);
 }

--- a/tests/data/hover/fields.cpp
+++ b/tests/data/hover/fields.cpp
@@ -6,7 +6,7 @@ namespace field_access {
 struct Foo { int x; };
 int main() {
   Foo bar;
-  (void)bar.$(01_field)x;
+  (void)bar.§(01_field)x;
 }
 }
 
@@ -15,7 +15,7 @@ namespace field_init {
 struct Foo { int x = 5; };
 int main() {
   Foo bar;
-  (void)bar.$(02_field_init)x;
+  (void)bar.§(02_field_init)x;
 }
 }
 
@@ -23,7 +23,7 @@ int main() {
 namespace static_field {
 struct Foo { static int x; };
 int main() {
-  (void)Foo::$(03_static_field)x;
+  (void)Foo::§(03_static_field)x;
 }
 }
 
@@ -31,7 +31,7 @@ int main() {
 namespace member_initializer {
 struct Foo {
   int x;
-  Foo() : $(04_member_initializer)x(0) {}
+  Foo() : §(04_member_initializer)x(0) {}
 };
 }
 
@@ -39,7 +39,7 @@ struct Foo {
 namespace gnu_designator {
 struct Foo { int x; };
 int main() {
-  Foo bar = { $(05_gnu_designator)x : 1 };
+  Foo bar = { §(05_gnu_designator)x : 1 };
 }
 }
 
@@ -47,7 +47,7 @@ int main() {
 namespace field_designator {
 struct Foo { int x; int y; };
 int main() {
-  Foo bar = { .$(06_field_designator)x = 2, .y = 2 };
+  Foo bar = { .§(06_field_designator)x = 2, .y = 2 };
 }
 }
 
@@ -56,7 +56,7 @@ namespace method_call {
 struct Foo { int x(); };
 int main() {
   Foo bar;
-  bar.$(07_method_call)x();
+  bar.§(07_method_call)x();
 }
 }
 
@@ -64,6 +64,6 @@ int main() {
 namespace static_method_call {
 struct Foo { static int x(); };
 int main() {
-  Foo::$(08_static_method_call)x();
+  Foo::§(08_static_method_call)x();
 }
 }

--- a/tests/data/hover/functions.cpp
+++ b/tests/data/hover/functions.cpp
@@ -5,7 +5,7 @@ namespace fn_via_pointer {
 // Function definition via pointer
 void foo(int) {}
 int main() {
-  auto *X = &$(01_fn_via_pointer)foo;
+  auto *X = &§(01_fn_via_pointer)foo;
 }
 }
 
@@ -13,14 +13,14 @@ namespace fn_via_call {
 // Function declaration via call
 int foo(int);
 int main() {
-  return $(02_fn_via_call)foo(42);
+  return §(02_fn_via_call)foo(42);
 }
 }
 
 namespace fn_decl {
 // Function declaration
 void foo();
-void g() { $(03_fn_decl)foo(); }
+void g() { §(03_fn_decl)foo(); }
 void foo() {}
 }
 
@@ -28,6 +28,6 @@ void foo() {}
 namespace fn_default_tmpl_arg {
 template <typename T = int>
 void foo(const T& = T()) {
-  $(04_fn_default_tmpl_arg)foo<>(3);
+  §(04_fn_default_tmpl_arg)foo<>(3);
 }
 }

--- a/tests/data/hover/getter_setter.cpp
+++ b/tests/data/hover/getter_setter.cpp
@@ -5,20 +5,20 @@ namespace std { template<typename T> T&& move(T&& t); }
 
 // Trivial getter.
 namespace getter {
-struct X { int Y; float $(01_getter)y() { return Y; } };
+struct X { int Y; float §(01_getter)y() { return Y; } };
 }
 
 // Trivial setter.
 namespace setter {
-struct X { int Y; void $(02_setter)setY(float v) { Y = v; } };
+struct X { int Y; void §(02_setter)setY(float v) { Y = v; } };
 }
 
 // Trivial setter returning *this.
 namespace setter_builder {
-struct X { int Y; X& $(03_setter_builder)setY(float v) { Y = v; return *this; } };
+struct X { int Y; X& §(03_setter_builder)setY(float v) { Y = v; return *this; } };
 }
 
 // Trivial setter using std::move.
 namespace setter_move {
-struct X { int Y; void $(04_setter_move)setY(float v) { Y = std::move(v); } };
+struct X { int Y; void §(04_setter_move)setY(float v) { Y = std::move(v); } };
 }

--- a/tests/data/hover/lambdas.cpp
+++ b/tests/data/hover/lambdas.cpp
@@ -6,7 +6,7 @@ namespace ptr_to_lambda {
 void foo() {
   auto lamb = [](int T, bool B) -> bool { return T && B; };
   auto *b = &lamb;
-  auto *$(01_lambda_ptr_ptr)c = &b;
+  auto *§(01_lambda_ptr_ptr)c = &b;
 }
 }
 
@@ -14,7 +14,7 @@ void foo() {
 namespace decltype_ref_param {
 auto lamb = [](int T, bool B) -> bool { return T && B; };
 void foo(decltype(lamb)& bar) {
-  ba$(02_lambda_decltype_ref_param)r(0, false);
+  ba§(02_lambda_decltype_ref_param)r(0, false);
 }
 }
 
@@ -22,7 +22,7 @@ void foo(decltype(lamb)& bar) {
 namespace decltype_param {
 auto lamb = [](int T, bool B) -> bool { return T && B; };
 void foo(decltype(lamb) bar) {
-  ba$(03_lambda_decltype_param)r(0, false);
+  ba§(03_lambda_decltype_param)r(0, false);
 }
 }
 
@@ -31,13 +31,13 @@ namespace lambda_variable {
 void foo() {
   int bar = 5;
   auto lamb = [&bar](int T, bool B) -> bool { return T && B && bar; };
-  bool res = lam$(04_lambda_variable)b(bar, false);
+  bool res = lam§(04_lambda_variable)b(bar, false);
 }
 }
 
 // Local variable in lambda.
 namespace local_in_lambda {
 void foo() {
-  auto lamb = []{int te$(05_local_in_lambda)st;};
+  auto lamb = []{int te§(05_local_in_lambda)st;};
 }
 }

--- a/tests/data/hover/misc.cpp
+++ b/tests/data/hover/misc.cpp
@@ -12,14 +12,14 @@ template <bool X, typename T, typename F>
 using type = typename cond<X, T, F>::type;
 
 void foo() {
-  using f$(02_typedef_chain)oo = type<true, int, double>;
+  using f§(02_typedef_chain)oo = type<true, int, double>;
 }
 }
 
 struct FwdFoo;
 int fwd_bar;
-auto fwd_baz = (Fwd$(01_forward_struct_value)Foo*)&fwd_bar;
+auto fwd_baz = (Fwd§(01_forward_struct_value)Foo*)&fwd_bar;
 
 #define A(x) x, x, x, x
 #define B(x) A(A(A(A(x))))
-int a$(03_big_initializer)rr[] = {B(0)};
+int a§(03_big_initializer)rr[] = {B(0)};

--- a/tests/data/hover/no_hover.cpp
+++ b/tests/data/hover/no_hover.cpp
@@ -2,29 +2,29 @@
 // licensed under Apache License v2.0 with LLVM Exceptions.
 // Every point in this file is expected to produce NO hover.
 
-$(01_builtin_type)int nh_func1() {}
+§(01_builtin_type)int nh_func1() {}
 
-void nh_func2() {$(02_empty_braces)}
+void nh_func2() {§(02_empty_braces)}
 
 // FIXME: "decltype(auto)" should be a single hover
-decltype(au$(03_decltype_auto_inner)to) nh_x1 = 0;
+decltype(au§(03_decltype_auto_inner)to) nh_x1 = 0;
 
 // FIXME: not supported yet
 // Lambda auto parameter
-auto nh_lamb = [](a$(04_lambda_auto_param)uto){};
+auto nh_lamb = [](a§(04_lambda_auto_param)uto){};
 
 // non-named decls don't get hover. Don't crash!
-$(05_static_assert)static_assert(1, "");
+§(05_static_assert)static_assert(1, "");
 
 // non-evaluatable expr
 template <typename T> void nh_func3() {
-  (void)size$(06_dependent_sizeof)of(T);
+  (void)size§(06_dependent_sizeof)of(T);
 }
 
 // literals
-auto nh_a = t$(07_bool_literal)rue;
-auto nh_b = $(08_compound_literal)(int){42};
-auto nh_c = $(09_float_literal)42.;
-auto nh_d = $(10_imaginary_literal)42.0i;
-auto nh_e = $(11_int_literal)42;
-auto nh_f = $(12_nullptr_literal)nullptr;
+auto nh_a = t§(07_bool_literal)rue;
+auto nh_b = §(08_compound_literal)(int){42};
+auto nh_c = §(09_float_literal)42.;
+auto nh_d = §(10_imaginary_literal)42.0i;
+auto nh_e = §(11_int_literal)42;
+auto nh_f = §(12_nullptr_literal)nullptr;

--- a/tests/data/hover/no_hover_errors.cpp
+++ b/tests/data/hover/no_hover_errors.cpp
@@ -7,6 +7,6 @@ struct Foo {
   int xyz = 0;
 };
 class Bar {};
-constexpr Foo s = $(01_invalid_init_list){
+constexpr Foo s = §(01_invalid_init_list){
   .xyz = Bar(),
 };

--- a/tests/data/hover/pass_types.cpp
+++ b/tests/data/hover/pass_types.cpp
@@ -31,35 +31,35 @@ void fun() {
   float float_x;
 
   // Integer tests
-  int_by_value($(01_int_value_var)int_x);
-  int_by_value($(02_int_value_literal)123);
-  int_by_ref($(03_int_ref_var)int_x);
-  int_by_const_ref($(04_int_const_ref_var)int_x);
-  int_by_const_ref($(05_int_const_ref_literal)123);
-  int_by_value($(06_int_value_from_ref)int_ref);
-  int_by_const_ref($(07_int_const_ref_from_ref)int_ref);
-  int_by_const_ref($(08_int_const_ref_from_const_ref)int_const_ref);
+  int_by_value(§(01_int_value_var)int_x);
+  int_by_value(§(02_int_value_literal)123);
+  int_by_ref(§(03_int_ref_var)int_x);
+  int_by_const_ref(§(04_int_const_ref_var)int_x);
+  int_by_const_ref(§(05_int_const_ref_literal)123);
+  int_by_value(§(06_int_value_from_ref)int_ref);
+  int_by_const_ref(§(07_int_const_ref_from_ref)int_ref);
+  int_by_const_ref(§(08_int_const_ref_from_const_ref)int_const_ref);
   // Custom class tests
-  base_by_ref($(09_base_ref)base);
-  base_by_const_ref($(10_base_const_ref)base);
-  base_by_const_ref($(11_base_const_ref_from_const_ref)base_const_ref);
-  base_by_value($(12_base_value)base);
-  base_by_value($(13_base_value_from_const_ref)base_const_ref);
-  base_by_ref($(14_derived_to_base_ref)derived);
-  base_by_const_ref($(15_derived_to_base_const_ref)derived);
-  base_by_value($(16_derived_to_base_value)derived);
+  base_by_ref(§(09_base_ref)base);
+  base_by_const_ref(§(10_base_const_ref)base);
+  base_by_const_ref(§(11_base_const_ref_from_const_ref)base_const_ref);
+  base_by_value(§(12_base_value)base);
+  base_by_value(§(13_base_value_from_const_ref)base_const_ref);
+  base_by_ref(§(14_derived_to_base_ref)derived);
+  base_by_const_ref(§(15_derived_to_base_const_ref)derived);
+  base_by_value(§(16_derived_to_base_value)derived);
   // Custom class constructor tests
-  CustomClass c1($(17_ctor_base_const_ref)base);
-  auto c2 = new CustomClass($(18_new_ctor_base_const_ref)base);
-  CustomClass c3($(19_ctor_int_ref)int_x);
-  CustomClass c4(int_x, $(20_ctor_int_value)int_x);
+  CustomClass c1(§(17_ctor_base_const_ref)base);
+  auto c2 = new CustomClass(§(18_new_ctor_base_const_ref)base);
+  CustomClass c3(§(19_ctor_int_ref)int_x);
+  CustomClass c4(int_x, §(20_ctor_int_value)int_x);
   // Converted tests
-  float_by_value($(21_converted_int_var)int_x);
-  float_by_value($(22_converted_int_ref)int_ref);
-  float_by_value($(23_converted_int_const_ref)int_const_ref);
-  float_by_value($(24_float_literal)123.0f);
-  float_by_value($(25_converted_int_literal)123);
-  custom_by_value($(26_converted_custom_from_int)int_x);
-  custom_by_value($(27_converted_custom_from_float)float_x);
-  custom_by_value($(28_converted_custom_from_base)base);
+  float_by_value(§(21_converted_int_var)int_x);
+  float_by_value(§(22_converted_int_ref)int_ref);
+  float_by_value(§(23_converted_int_const_ref)int_const_ref);
+  float_by_value(§(24_float_literal)123.0f);
+  float_by_value(§(25_converted_int_literal)123);
+  custom_by_value(§(26_converted_custom_from_int)int_x);
+  custom_by_value(§(27_converted_custom_from_float)float_x);
+  custom_by_value(§(28_converted_custom_from_base)base);
 }

--- a/tests/data/hover/spaceship.cpp
+++ b/tests/data/hover/spaceship.cpp
@@ -19,4 +19,4 @@ struct Foo
   auto operator<=>(const Foo&) const = default;
 };
 
-bool x = Foo(1) !$(01_spaceship_neq)= Foo(2);
+bool x = Foo(1) !§(01_spaceship_neq)= Foo(2);

--- a/tests/data/hover/tag_decls.cpp
+++ b/tests/data/hover/tag_decls.cpp
@@ -7,7 +7,7 @@ namespace ns1 {
   struct MyClass {};
 } // namespace ns1
 int main() {
-  ns1::$(01_struct)MyClass* Params;
+  ns1::§(01_struct)MyClass* Params;
 }
 }
 
@@ -17,7 +17,7 @@ namespace ns1 {
   class MyClass {};
 } // namespace ns1
 int main() {
-  ns1::$(02_class)MyClass* Params;
+  ns1::§(02_class)MyClass* Params;
 }
 }
 
@@ -27,7 +27,7 @@ namespace ns1 {
   union MyUnion { int x; int y; };
 } // namespace ns1
 int main() {
-  ns1::$(03_union)MyUnion Params;
+  ns1::§(03_union)MyUnion Params;
 }
 }
 
@@ -35,7 +35,7 @@ namespace forward_decl {
 // Forward class declaration
 class Foo;
 class Foo {};
-$(04_forward_class)Foo* foo();
+§(04_forward_class)Foo* foo();
 }
 
 namespace enum_def {
@@ -44,7 +44,7 @@ enum Hello {
   ONE, TWO, THREE,
 };
 void foo() {
-  $(05_enum)Hello hello = ONE;
+  §(05_enum)Hello hello = ONE;
 }
 }
 
@@ -54,7 +54,7 @@ enum Hello {
   ONE, TWO, THREE,
 };
 void foo() {
-  Hello hello = $(06_enumerator)ONE;
+  Hello hello = §(06_enumerator)ONE;
 }
 }
 
@@ -65,7 +65,7 @@ enum class Hello {
 };
 void foo() {
   using enum Hello;
-  Hello hello = $(07_using_enum)ONE;
+  Hello hello = §(07_using_enum)ONE;
 }
 }
 
@@ -75,7 +75,7 @@ enum {
   ONE, TWO, THREE,
 };
 void foo() {
-  int hello = $(08_anon_enumerator)ONE;
+  int hello = §(08_anon_enumerator)ONE;
 }
 }
 
@@ -83,7 +83,7 @@ namespace typedef_decl {
 // Typedef
 typedef int Foo;
 int main() {
-  $(09_typedef)Foo bar;
+  §(09_typedef)Foo bar;
 }
 }
 
@@ -91,7 +91,7 @@ namespace typedef_embedded {
 // Typedef with embedded definition
 typedef struct Bar {} Foo;
 int main() {
-  $(10_typedef_embedded)Foo bar;
+  §(10_typedef_embedded)Foo bar;
 }
 }
 
@@ -100,7 +100,7 @@ namespace ns_decl {
 namespace ns {
 struct Foo { static void bar(); };
 } // namespace ns
-int main() { $(11_namespace)ns::Foo::bar(); }
+int main() { §(11_namespace)ns::Foo::bar(); }
 }
 
 // Field in anonymous struct.
@@ -109,7 +109,7 @@ static struct {
   int hello;
 } s;
 void foo() {
-  s.$(12_anon_struct_field)hello++;
+  s.§(12_anon_struct_field)hello++;
 }
 }
 
@@ -120,7 +120,7 @@ struct outer {
     int abc, def;
   } v;
 };
-void g() { struct outer o; o.v.$(13_anon_union_field)def++; }
+void g() { struct outer o; o.v.§(13_anon_union_field)def++; }
 }
 
 namespace templated_fn {
@@ -129,7 +129,7 @@ template <typename T>
 T foo() {
   return 17;
 }
-void g() { auto x = $(14_templated_function)foo<int>(); }
+void g() { auto x = §(14_templated_function)foo<int>(); }
 }
 
 // Should not crash on dependent method call.
@@ -138,17 +138,17 @@ template <class T> struct cls {
   int method();
 };
 
-auto test = cls<int>().$(15_template_method)method();
+auto test = cls<int>().§(15_template_method)method();
 }
 
 // Type of nested templates: the variable.
 namespace nested_templates_var {
 template <class T> struct cls {};
-cls<cls<cls<int>>> fo$(16_nested_template_var)o;
+cls<cls<cls<int>>> fo§(16_nested_template_var)o;
 }
 
 namespace nested_templates_class {
 // type of nested templates.
 template <class T> struct cls {};
-$(17_nested_template_class)cls<cls<cls<int>>> foo;
+§(17_nested_template_class)cls<cls<cls<int>>> foo;
 }

--- a/tests/data/hover/template_params.cpp
+++ b/tests/data/hover/template_params.cpp
@@ -3,15 +3,15 @@
 
 // Template type parameter.
 namespace type_param {
-template <typename $(01_type_param)T = int> void foo();
+template <typename §(01_type_param)T = int> void foo();
 }
 
 // Template template parameter.
 namespace template_template_param {
-template <template<typename> class $(02_template_template_param)T> void foo();
+template <template<typename> class §(02_template_template_param)T> void foo();
 }
 
 // Non-type template parameter.
 namespace non_type_param {
-template <int $(03_non_type_param)T = 5> void foo();
+template <int §(03_non_type_param)T = 5> void foo();
 }

--- a/tests/data/hover/templates.cpp
+++ b/tests/data/hover/templates.cpp
@@ -4,13 +4,13 @@
 // Variable with template type.
 namespace var_tmpl_type {
 template <typename T, class... Ts> class Foo { public: Foo(int); };
-Foo<int, char, bool> fo$(01_var_of_template_type)o = Foo<int, char, bool>(5);
+Foo<int, char, bool> fo§(01_var_of_template_type)o = Foo<int, char, bool>(5);
 }
 
 // Implicit template instantiation.
 namespace implicit_instantiation {
 template <typename T> class vector{};
-vec$(02_implicit_instantiation)tor<int> foo;
+vec§(02_implicit_instantiation)tor<int> foo;
 }
 
 // Class template.
@@ -21,7 +21,7 @@ template <template<typename, bool...> class C,
           bool Q = false,
           class... Ts> class Foo final {};
 template <template<typename, bool...> class T>
-F$(03_class_template)oo<T> foo;
+F§(03_class_template)oo<T> foo;
 }
 
 // Function template.
@@ -34,7 +34,7 @@ template <template<typename, bool...> class C,
 template<typename, bool...> class Foo;
 
 void bar() {
-  fo$(04_function_template)o<Foo>();
+  fo§(04_function_template)o<Foo>();
 }
 }
 
@@ -44,32 +44,32 @@ template<typename, bool...> class Foo {};
 Foo<bool, true, false> foo(int, bool T = false);
 
 void bar() {
-  fo$(05_function_decl)o(3);
+  fo§(05_function_decl)o(3);
 }
 }
 
 // Partially-specialized class template.
 namespace partial_spec {
 template <typename T> class X;
-template <typename T> class $(06_partial_specialization)X<T*> {};
+template <typename T> class §(06_partial_specialization)X<T*> {};
 }
 
 // Constructor of partially-specialized class template.
 namespace partial_spec_ctor {
 template<typename, typename=void> struct X;
-template<typename T> struct X<T*>{ $(07_partial_spec_constructor)X(); };
+template<typename T> struct X<T*>{ §(07_partial_spec_constructor)X(); };
 }
 
 namespace destructor {
-class X { $(08_destructor)~X(); };
+class X { §(08_destructor)~X(); };
 }
 
 namespace conversion_operator {
-class X { op$(09_conversion_operator)erator int(); };
+class X { op§(09_conversion_operator)erator int(); };
 }
 
 namespace conversion_target {
-class X { operator $(10_conversion_target)X(); };
+class X { operator §(10_conversion_target)X(); };
 }
 
 // Falls back to primary template, when the type is not instantiated.
@@ -79,7 +79,7 @@ template <typename T> class Foo {};
 // comment from specialization
 template <typename T> class Foo<T*> {};
 void foo() {
-  Fo$(11_primary_template_doc)o<int*> *x = nullptr;
+  Fo§(11_primary_template_doc)o<int*> *x = nullptr;
 }
 }
 
@@ -87,7 +87,7 @@ void foo() {
 namespace var_template {
 using m_int = int;
 
-template <int Size> m_int $(12_variable_template)arr[Size];
+template <int Size> m_int §(12_variable_template)arr[Size];
 }
 
 // Var template decl specialization.
@@ -96,7 +96,7 @@ using m_int = int;
 
 template <int Size> m_int arr[Size];
 
-template <> m_int $(13_variable_template_spec)arr<4>[4];
+template <> m_int §(13_variable_template_spec)arr<4>[4];
 }
 
 // Canonical type.
@@ -107,20 +107,20 @@ struct TestHover {
 };
 
 void code() {
-  TestHover<int>::Type $(14_canonical_type)a;
+  TestHover<int>::Type §(14_canonical_type)a;
 }
 }
 
 // Canonical template type.
 namespace canonical_tmpl_type {
 template<typename T>
-void $(15_function_template_type)foo(T arg) {}
+void §(15_function_template_type)foo(T arg) {}
 }
 
 // TypeAlias template.
 namespace alias_template {
 template<typename T>
-using $(16_alias_template)alias = T;
+using §(16_alias_template)alias = T;
 }
 
 // TypeAlias template referring to another alias.
@@ -129,21 +129,21 @@ template<typename T>
 using A = T;
 
 template<typename T>
-using $(17_alias_template_chain)AA = A<T>;
+using §(17_alias_template_chain)AA = A<T>;
 }
 
 // Constant array.
 namespace constant_array {
 using m_int = int;
 
-m_int $(18_constant_array)arr[10];
+m_int §(18_constant_array)arr[10];
 }
 
 // Incomplete array.
 namespace incomplete_array {
 using m_int = int;
 
-extern m_int $(19_incomplete_array)arr[];
+extern m_int §(19_incomplete_array)arr[];
 }
 
 // Dependent size array.
@@ -152,6 +152,6 @@ using m_int = int;
 
 template<int Size>
 struct Test {
-  m_int $(20_dependent_size_array)arr[Size];
+  m_int §(20_dependent_size_array)arr[Size];
 };
 }

--- a/tests/data/hover/this_expr.cpp
+++ b/tests/data/hover/this_expr.cpp
@@ -5,7 +5,7 @@
 namespace ns {
   class Foo1 {
     Foo1* bar() {
-      return t$(01_this_class)his;
+      return t§(01_this_class)his;
     }
   };
 }
@@ -15,7 +15,7 @@ namespace ns {
   template <typename T>
   class Foo2 {
     Foo2* bar() const {
-      return t$(02_this_template_class)his;
+      return t§(02_this_template_class)his;
     }
   };
 }
@@ -26,7 +26,7 @@ namespace ns {
   template <>
   struct Foo3<int> {
     Foo3* bar() {
-      return thi$(03_this_specialization)s;
+      return thi§(03_this_specialization)s;
     }
   };
 }
@@ -37,7 +37,7 @@ namespace ns {
   template <typename F>
   struct Foo4<int, F> {
     Foo4* bar() const {
-      return thi$(04_this_partial_specialization)s;
+      return thi§(04_this_partial_specialization)s;
     }
   };
 }

--- a/tests/data/hover/using_decls.cpp
+++ b/tests/data/hover/using_decls.cpp
@@ -8,7 +8,7 @@ namespace ns {
 }
 int main() {
   using ns::foo;
-  $(01_using_function)foo();
+  §(01_using_function)foo();
 }
 }
 
@@ -16,5 +16,5 @@ int main() {
 namespace using_overloads {
 namespace ns { void foo(int); void foo(char); }
 using ns::foo;
-template <typename T> void bar() { $(02_using_overloads)foo(T{}); }
+template <typename T> void bar() { §(02_using_overloads)foo(T{}); }
 }

--- a/tests/data/hover/values.cpp
+++ b/tests/data/hover/values.cpp
@@ -4,12 +4,12 @@
 // Constexpr function call value.
 namespace constexpr_call {
 constexpr int add(int a, int b) { return a + b; }
-int b$(01_constexpr_call_value)ar = add(1, 2);
+int b§(01_constexpr_call_value)ar = add(1, 2);
 }
 
 // sizeof value.
 namespace sizeof_value {
-int b$(02_sizeof_value)ar = sizeof(char);
+int b§(02_sizeof_value)ar = sizeof(char);
 }
 
 // Template member value.
@@ -17,20 +17,20 @@ namespace template_member {
 template<int a, int b> struct Add {
   static constexpr int result = a + b;
 };
-int ba$(03_template_member_value)r = Add<1, 2>::result;
+int ba§(03_template_member_value)r = Add<1, 2>::result;
 }
 
 // Enumerator value.
 namespace enumerator_value {
 enum Color { RED = -123, GREEN = 5, };
-Color x = GR$(04_enumerator_value)EEN;
+Color x = GR§(04_enumerator_value)EEN;
 }
 
 // Variable initialized from an enumerator: symbolic value.
 namespace enum_var_value {
 enum Color { RED = -123, GREEN = 5, };
 Color x = RED;
-Color y = $(05_enum_var_value)x;
+Color y = §(05_enum_var_value)x;
 }
 
 // Static member constant value.
@@ -38,19 +38,19 @@ namespace static_member {
 template<int a, int b> struct Add {
   static constexpr int result = a + b;
 };
-int bar = Add<1, 2>::resu$(06_static_member_value)lt;
+int bar = Add<1, 2>::resu§(06_static_member_value)lt;
 }
 
 // Constexpr function with aliased return type.
 namespace aliased_return {
 using my_int = int;
 constexpr my_int answer() { return 40 + 2; }
-int x = ans$(07_constexpr_fn_value)wer();
+int x = ans§(07_constexpr_fn_value)wer();
 }
 
 // String pointer value.
 namespace string_pointer {
-const char *ba$(08_string_pointer_value)r = "1234";
+const char *ba§(08_string_pointer_value)r = "1234";
 }
 
 // Should not crash on dependent constructor argument.
@@ -62,7 +62,7 @@ struct Tmpl {
 
 template <typename A>
 void boom(int name) {
-  new Tmpl<A>(na$(09_dependent_ctor_arg)me);
+  new Tmpl<A>(na§(09_dependent_ctor_arg)me);
 }
 }
 
@@ -81,7 +81,7 @@ namespace ns {
   } // in_ns
 } // ns
 void foo() {
-  ns::a::b::F$(10_skip_inline_anon_ns)oo x;
+  ns::a::b::F§(10_skip_inline_anon_ns)oo x;
   (void)x;
 }
 
@@ -90,6 +90,6 @@ namespace auto_incomplete_arg {
 template <typename T> class Foo {};
 class X;
 void foo() {
-  $(11_auto_incomplete_arg)auto x = Foo<X>();
+  §(11_auto_incomplete_arg)auto x = Foo<X>();
 }
 }

--- a/tests/data/hover/variables.cpp
+++ b/tests/data/hover/variables.cpp
@@ -5,7 +5,7 @@
 namespace local_var {
 int main() {
   int bonjour;
-  $(01_local_var)bonjour = 2;
+  §(01_local_var)bonjour = 2;
   int test1 = bonjour;
 }
 }
@@ -15,7 +15,7 @@ namespace method_var {
 struct s {
   void method() {
     int bonjour;
-    $(02_method_local_var)bonjour = 2;
+    §(02_method_local_var)bonjour = 2;
   }
 };
 }
@@ -23,14 +23,14 @@ struct s {
 // Global variable
 static int hey = 10;
 void inc_hey() {
-  $(03_global_var)hey++;
+  §(03_global_var)hey++;
 }
 
 namespace ns1 {
   static long long hey = -36637162602497;
 }
 void inc_ns_hey() {
-  ns1::$(04_ns_global_var)hey++;
+  ns1::§(04_ns_global_var)hey++;
 }
 
 namespace ns {
@@ -38,4 +38,4 @@ namespace ns {
     int foo;
   } // anonymous namespace
 } // namespace ns
-int main() { ns::$(05_anon_ns_var)foo++; }
+int main() { ns::§(05_anon_ns_var)foo++; }

--- a/tests/unit/compile/directive_tests.cpp
+++ b/tests/unit/compile/directive_tests.cpp
@@ -110,12 +110,12 @@ TEST_CASE(Include) {
 #endif
 
 #[main.cpp]
-#$(0)include "test.h"
-#$(1)include "test.h"
-#$(2)include "pragma_once.h"
-#$(3)include "pragma_once.h"
-#$(4)include "guard_macro.h"
-#$(5)include "guard_macro.h"
+#§(0)include "test.h"
+#§(1)include "test.h"
+#§(2)include "pragma_once.h"
+#§(3)include "pragma_once.h"
+#§(4)include "guard_macro.h"
+#§(5)include "guard_macro.h"
 )cpp");
 
     ASSERT_EQ(includes.size(), 6U);
@@ -135,10 +135,10 @@ TEST_CASE(HasInclude) {
 
 #[main.cpp]
 #include "test.h"
-#if __has_include($(0)"test.h")
+#if __has_include(§(0)"test.h")
 #endif
 
-#if __has_include($(1)"test2.h")
+#if __has_include(§(1)"test2.h")
 #endif
 )cpp");
 
@@ -150,15 +150,15 @@ TEST_CASE(HasInclude) {
 TEST_CASE(Condition) {
     run(R"cpp(
 #[main.cpp]
-#$(0)if 0
-#$(1)elif 1
-#$(2)else
-#$(3)endif
+#§(0)if 0
+#§(1)elif 1
+#§(2)else
+#§(3)endif
 
-#$(4)ifdef name
-#$(5)elifdef name
-#$(6)else
-#$(7)endif
+#§(4)ifdef name
+#§(5)elifdef name
+#§(6)else
+#§(7)endif
 )cpp");
 
     ASSERT_EQ(conditions.size(), 8U);
@@ -175,21 +175,21 @@ TEST_CASE(Condition) {
 TEST_CASE(Macro) {
     run(R"cpp(
 #[main.cpp]
-#define $(0)expr(v) v
+#define §(0)expr(v) v
 
-#ifdef $(1)expr
-int x = $(2)expr(1);
+#ifdef §(1)expr
+int x = §(2)expr(1);
 #endif
 
-#undef $(3)expr
+#undef §(3)expr
 
-#define $(4)expr(v) v
+#define §(4)expr(v) v
 
-#ifdef $(5)expr
-int y = $(6)expr($(7)expr(1));
+#ifdef §(5)expr
+int y = §(6)expr(§(7)expr(1));
 #endif
 
-#undef $(8)expr
+#undef §(8)expr
 
 )cpp");
 
@@ -208,9 +208,9 @@ int y = $(6)expr($(7)expr(1));
 TEST_CASE(Pragma) {
     run(R"cpp(
 #[main.cpp]
-$(0)#pragma GCC poison printf sprintf fprintf
-$(1)#pragma region
-$(2)#pragma endregion
+§(0)#pragma GCC poison printf sprintf fprintf
+§(1)#pragma region
+§(2)#pragma endregion
 )cpp");
 
     ASSERT_EQ(pragmas.size(), 3U);
@@ -229,23 +229,23 @@ ABCDE
 
 #[main.cpp]
 const char e0 = {
-$(0)#embed "bytes10.bin"
+§(0)#embed "bytes10.bin"
 };
 
 const char e1 = {
-$(1)#embed "bytes10.bin"
+§(1)#embed "bytes10.bin"
 };
 
 const char e2 = {
-$(2)#embed "bytes5.bin"
+§(2)#embed "bytes5.bin"
 };
 
 const char e3 = {
-$(3)#embed "bytes5.bin"
+§(3)#embed "bytes5.bin"
 };
 
 const char e4 = {
-$(4)#embed "non-existed.bin"
+§(4)#embed "non-existed.bin"
 };
 
 )cpp");
@@ -266,10 +266,10 @@ TEST_CASE(HasEmbed) {
 #[main.cpp]
 #embed "test.bin"
 
-#if __has_embed$(0)("test.bin")
+#if __has_embed§(0)("test.bin")
 #endif
 
-#if __has_embed$(1)("non-existed.bin")
+#if __has_embed§(1)("non-existed.bin")
 #endif
 )cpp");
 

--- a/tests/unit/feature/code_completion_tests.cpp
+++ b/tests/unit/feature/code_completion_tests.cpp
@@ -43,7 +43,7 @@ auto find_item(llvm::StringRef label) {
 TEST_CASE(Score) {
     code_complete(R"cpp(
 int foooo(int x);
-int x = fo$(pos)
+int x = fo§(pos)
 )cpp");
 
     auto it = find_item("foooo");
@@ -55,7 +55,7 @@ int x = fo$(pos)
 TEST_CASE(Signature) {
     code_complete(R"cpp(
 int foooo(int x, float y);
-int x = fo$(pos)
+int x = fo§(pos)
 )cpp");
 
     auto it = find_item("foooo");
@@ -71,7 +71,7 @@ int x = fo$(pos)
 TEST_CASE(ReturnType) {
     code_complete(R"cpp(
 double foooo(int x);
-int x = fo$(pos)
+int x = fo§(pos)
 )cpp");
 
     auto it = find_item("foooo");
@@ -85,7 +85,7 @@ int x = fo$(pos)
 
 TEST_CASE(Snippet) {
     code_complete(R"cpp(
-int x = tru$(pos)
+int x = tru§(pos)
 )cpp");
 
     ASSERT_TRUE(!items.empty());
@@ -95,7 +95,7 @@ TEST_CASE(Overload) {
     code_complete(R"cpp(
 int foooo(int x);
 int foooo(int x, int y);
-int x = fooo$(pos)
+int x = fooo§(pos)
 )cpp");
 
     ASSERT_TRUE(!items.empty());
@@ -118,7 +118,7 @@ TEST_CASE(FilterUnderscore) {
     code_complete(R"cpp(
 int _private_thing;
 int public_thing;
-int x = pu$(pos)
+int x = pu§(pos)
 )cpp");
 
     // _private_thing should be filtered when prefix doesn't start with _.
@@ -132,7 +132,7 @@ int x = pu$(pos)
 TEST_CASE(FilterUnderscoreExplicit) {
     code_complete(R"cpp(
 int _private_thing;
-int x = _p$(pos)
+int x = _p§(pos)
 )cpp");
 
     // When user types _, underscore-prefixed symbols should appear.
@@ -148,7 +148,7 @@ struct Foo {
 
 void bar() {
     Foo f;
-    f.ba$(pos);
+    f.ba§(pos);
 }
 )cpp");
 
@@ -175,7 +175,7 @@ template <typename T>
 Foo(T) -> Foo<T>;
 
 void bar() {
-    Fo$(pos)
+    Fo§(pos)
 }
 )cpp");
 
@@ -210,7 +210,7 @@ template <typename T>
 Bazzz(T) -> Bazzz<T, int>;
 
 void bar() {
-    Ba$(pos)
+    Ba§(pos)
 }
 )cpp",
                   opts);
@@ -236,7 +236,7 @@ void bar() {
 TEST_CASE(DeprecatedTag) {
     code_complete(R"cpp(
 [[deprecated]] int foooo(int x);
-int z = fo$(pos)
+int z = fo§(pos)
 )cpp");
 
     auto it = find_item("foooo");
@@ -249,7 +249,7 @@ int z = fo$(pos)
 TEST_CASE(NotDeprecated) {
     code_complete(R"cpp(
 int foooo(int x);
-int z = fo$(pos)
+int z = fo§(pos)
 )cpp");
 
     auto it = find_item("foooo");
@@ -267,7 +267,7 @@ TEST_CASE(NoBundleOverloads) {
 int foooo(int x);
 int foooo(int x, int y);
 double foooo(double d);
-int x = fooo$(pos)
+int x = fooo§(pos)
 )cpp",
                   opts);
 
@@ -293,7 +293,7 @@ TEST_CASE(NoBundleNoDeduplicate) {
 int foooo(int x);
 int foooo(int x, int y);
 double foooo(double d);
-int x = fooo$(pos)
+int x = fooo§(pos)
 )cpp",
                   opts);
 
@@ -311,7 +311,7 @@ TEST_CASE(SnippetFunctionArgs) {
     opts.enable_function_arguments_snippet = true;
     code_complete(R"cpp(
 int foooo(int x, float y);
-int z = fo$(pos)
+int z = fo§(pos)
 )cpp",
                   opts);
 
@@ -334,7 +334,7 @@ TEST_CASE(SnippetNoArgs) {
     opts.enable_function_arguments_snippet = true;
     code_complete(R"cpp(
 void foooo();
-void bar() { fo$(pos) }
+void bar() { fo§(pos) }
 )cpp",
                   opts);
 
@@ -351,7 +351,7 @@ TEST_CASE(SnippetDisabled) {
     opts.enable_function_arguments_snippet = false;
     code_complete(R"cpp(
 int foooo(int x, float y);
-int z = fo$(pos)
+int z = fo§(pos)
 )cpp",
                   opts);
 
@@ -370,7 +370,7 @@ TEST_CASE(SnippetBundleMode) {
     code_complete(R"cpp(
 int foooo(int x);
 int foooo(int x, int y);
-int z = fo$(pos)
+int z = fo§(pos)
 )cpp",
                   opts);
 
@@ -390,7 +390,7 @@ struct Foo {
 };
 void bar() {
     Foo f;
-    f.ba$(pos);
+    f.ba§(pos);
 }
 )cpp",
                   opts);
@@ -411,7 +411,7 @@ struct Account {
 
 void bar() {
     Account acc;
-    acc.$(pos)
+    acc.§(pos)
 }
 )cpp");
 
@@ -437,7 +437,7 @@ struct Box {
 
 void bar() {
     Box<int> b;
-    b.$(pos)
+    b.§(pos)
 }
 )cpp");
 
@@ -459,7 +459,7 @@ struct Account {
 
 void bar() {
     Account acc;
-    acc.$(pos)
+    acc.§(pos)
 }
 )cpp");
 
@@ -478,7 +478,7 @@ struct Account {
 
 void bar() {
     Account acc;
-    acc.$(pos)
+    acc.§(pos)
 }
 )cpp");
 
@@ -494,7 +494,7 @@ namespace A {
 }
 
 void bar() {
-    fo$(pos)
+    fo§(pos)
 }
 )cpp");
 }
@@ -507,7 +507,7 @@ struct X {
 
 void bar() {
     X foo;
-    fo$(pos);
+    fo§(pos);
 }
 )cpp");
 }
@@ -516,7 +516,7 @@ TEST_CASE(Lambda) {
     code_complete(R"cpp(
 void bar() {
     auto foo = [](int x){ };
-    fo$(pos);
+    fo§(pos);
 }
 )cpp");
 }

--- a/tests/unit/feature/document_link_tests.cpp
+++ b/tests/unit/feature/document_link_tests.cpp
@@ -44,12 +44,12 @@ TEST_CASE(Include) {
 #endif
 
 #[main.cpp]
-#include @0["test.h"$]
-#include @1["test.h"$]
-#include @2["pragma_once.h"$]
-#include @3["pragma_once.h"$]
-#include @4["guard_macro.h"$]
-#include @5["guard_macro.h"$]
+#include §(0)⟦"test.h"§⟧
+#include §(1)⟦"test.h"§⟧
+#include §(2)⟦"pragma_once.h"§⟧
+#include §(3)⟦"pragma_once.h"§⟧
+#include §(4)⟦"guard_macro.h"§⟧
+#include §(5)⟦"guard_macro.h"§⟧
 )cpp");
 
     ASSERT_EQ(links.size(), 6U);
@@ -66,9 +66,9 @@ TEST_CASE(HasInclude) {
 #[test.h]
 
 #[main.cpp]
-#include @0["test.h"]
+#include §(0)⟦"test.h"⟧
 
-#if __has_include(@1["test.h"])
+#if __has_include(§(1)⟦"test.h"⟧)
 #endif
 
 #if __has_include("test2.h")
@@ -86,7 +86,7 @@ TEST_CASE(MacroInclude) {
 
 #[main.cpp]
 #define HEADER "test.h"
-#include @0[HEADER$]
+#include §(0)⟦HEADER§⟧
 )cpp");
 
     ASSERT_EQ(links.size(), 1U);
@@ -100,7 +100,7 @@ TEST_CASE(Embed) {
 
 #[main.cpp]
 const char e[] = {
-#embed @0["bytes.bin"$]
+#embed §(0)⟦"bytes.bin"§⟧
 };
 )cpp",
         "-std=c++23");
@@ -115,7 +115,7 @@ TEST_CASE(HasEmbed) {
 ABCDE
 
 #[main.cpp]
-#if __has_embed(@0["data.bin"$])
+#if __has_embed(§(0)⟦"data.bin"§⟧)
 #endif
 
 #if __has_embed("non_existent.bin")
@@ -130,8 +130,8 @@ ABCDE
 TEST_CASE(IncludeDefinition) {
     add_file("test.h", "#pragma once\n");
     add_main("main.cpp", R"(
-#include @arg["test.h"]
-$(inside)
+#include §(arg)⟦"test.h"⟧
+§(inside)
 int x = 0;
 )");
     ASSERT_TRUE(compile());

--- a/tests/unit/feature/folding_range_tests.cpp
+++ b/tests/unit/feature/folding_range_tests.cpp
@@ -74,22 +74,22 @@ TEST_CASE(Namespace) {
     run(R"cpp(
 namespace single_line { }
 
-namespace with_nodes $(1){
-    struct inner $(3){
+namespace with_nodes §(1){
+    struct inner §(3){
         int x;
-    }$(4);
-}$(2)
+    }§(4);
+}§(2)
 
 namespace strange
-                 $(5){
+                 §(5){
 
-                 }$(6)
+                 }§(6)
 
 #define NS_BEGIN namespace ns {
 #define NS_END }
 
-$(7)NS_BEGIN
-NS_END$(8)
+§(7)NS_BEGIN
+NS_END§(8)
 )cpp");
 
     ASSERT_EQ(ranges.size(), 4U);
@@ -101,17 +101,17 @@ NS_END$(8)
 
 TEST_CASE(Enum) {
     run(R"cpp(
-enum e1 $(1){
+enum e1 §(1){
     A,
     B,
     C
-}$(2);
+}§(2);
 
-enum class e2 $(3){
+enum class e2 §(3){
     A,
     B,
     C
-}$(4);
+}§(4);
 
 enum e3 { D };
 
@@ -124,31 +124,31 @@ enum e3 { D };
 
 TEST_CASE(Record) {
     run(R"cpp(
-struct s1 $(1){
+struct s1 §(1){
     int x;
     float y;
-}$(2);
+}§(2);
 
 struct s2 {};
 
 struct s3;
 
-union u1 $(3){
+union u1 §(3){
     int x;
     float y;
-}$(4);
+}§(4);
 
-struct u2 $(5){
-    struct s4 $(7){
+struct u2 §(5){
+    struct s4 §(7){
 
-    }$(8);
-}$(6);
+    }§(8);
+}§(6);
 
-void foo() $(9){
-    struct s5 $(11){
+void foo() §(9){
+    struct s5 §(11){
 
-    }$(12);
-}$(10)
+    }§(12);
+}§(10)
 )cpp");
 
     ASSERT_EQ(ranges.size(), 6U);
@@ -162,26 +162,26 @@ void foo() $(9){
 
 TEST_CASE(Method) {
     run(R"cpp(
-struct s2 $(1){
+struct s2 §(1){
     int x;
     float y;
 
     s2() = default;
-}$(2);
+}§(2);
 
 struct s3;
 
-struct s3 $(3){
-    void method() $(5){
+struct s3 §(3){
+    void method() §(5){
         int x = 0;
-    }$(6)
+    }§(6)
 
-    void parameter() $(7){
+    void parameter() §(7){
 
-    }$(8)
+    }§(8)
 
     void skip() {};
-}$(4);
+}§(4);
 )cpp");
 
     ASSERT_EQ(ranges.size(), 4U);
@@ -193,38 +193,38 @@ struct s3 $(3){
 
 TEST_CASE(Lambda) {
     run(R"cpp(
-auto z = $(1)[
+auto z = §(1)[
     x = 0, y = 1
-]$(2) () $(3){
+]§(2) () §(3){
 
-}$(4);
+}§(4);
 
 static int array[4];
 
-auto s = $(5)[
+auto s = §(5)[
     x=0,
     y = 1,
     z = array[
     0],
     k = -1
-]$(6) () $(7){
+]§(6) () §(7){
     return;
-}$(8);
+}§(8);
 
 auto l1 = [] () {};
 
-auto l2 = [] () $(9){
+auto l2 = [] () §(9){
 
-}$(10);
+}§(10);
 
-auto l3 = [] () $(11){
+auto l3 = [] () §(11){
     return 0;
-}$(12);
+}§(12);
 
-auto l4 = [] $(13)(
+auto l4 = [] §(13)(
     int x1,
     int x2
-)$(14) {};
+)§(14) {};
 )cpp");
 
     ASSERT_EQ(ranges.size(), 7U);
@@ -241,35 +241,35 @@ TEST_CASE(Function) {
     run(R"cpp(
 void e() {};
 
-void f $(1)(
+void f §(1)(
 
 
-)$(2) $(3){
+)§(2) §(3){
 
-}$(4)
+}§(4)
 
-void g $(5)(
+void g §(5)(
     int x,
     int y = 2
-)$(6) $(7){
+)§(6) §(7){
     int z;
-}$(8)
+}§(8)
 
-void h() $(9){
+void h() §(9){
     int x = 0;
-}$(10)
+}§(10)
 
 void i(  ) {   };
 
-void j $(11)(
+void j §(11)(
     int p1,
     int p2,
     ...
-)$(12);
+)§(12);
 
-void k() $(13){
+void k() §(13){
 
-}$(14)
+}§(14)
 )cpp");
 
     ASSERT_EQ(ranges.size(), 7U);
@@ -286,19 +286,19 @@ TEST_CASE(FunctionCall) {
     run(R"cpp(
 int f(int p1, int p2, int p3, int p4, int p5, int p6) { return p1 + p2; }
 
-int main() $(1){
+int main() §(1){
     int x = f(1, 2, 3, 4, 5, 6);
 
-    int y = f $(2)(
+    int y = f §(2)(
         1, 2, 3,
         4, 5, 6
-    )$(3);
+    )§(3);
 
-    return f $(4)(
+    return f §(4)(
         1, 2, 3,
         4, 5, 6
-    )$(5);
-}$(6)
+    )§(5);
+}§(6)
 )cpp");
 
     ASSERT_EQ(ranges.size(), 3U);
@@ -309,22 +309,22 @@ int main() $(1){
 
 TEST_CASE(CompoundStmt) {
     run(R"cpp(
-int main() $(1){
+int main() §(1){
 
-    $(3){
-        $(5){
+    §(3){
+        §(5){
             //
-        }$(6)
+        }§(6)
 
-        $(7){
+        §(7){
             //
-        }$(8)
+        }§(8)
 
         //
-    }$(4)
+    }§(4)
 
     return 0;
-}$(2)
+}§(2)
 
 )cpp");
 }
@@ -333,14 +333,14 @@ TEST_CASE(InitializeList) {
     run(R"cpp(
 struct L { int xs[4]; };
 
-L l1 = $(1){
+L l1 = §(1){
     1, 2, 3, 4
-}$(2);
+}§(2);
 
-L l2 = $(3){
+L l2 = §(3){
 //
 //
-}$(4);
+}§(4);
 
 )cpp");
 
@@ -351,35 +351,35 @@ L l2 = $(3){
 
 TEST_CASE(AccessSpecifier) {
     run(R"cpp(
-class c1 $(1){
-public$(3):
-private$(4):
-protected$(5):
-}$(2);
+class c1 §(1){
+public§(3):
+private§(4):
+protected§(5):
+}§(2);
 
-class c2 $(6){
-public$(8):
+class c2 §(6){
+public§(8):
     int x;
 
-private$(9):
+private§(9):
     float y;
 
-protected$(10):
+protected§(10):
     double z;
-}$(7);
+}§(7);
 
 #define PUBLIC public:
 #define PRIVATE private:
 #define PROTECTED protected:
 
-class c3 $(11){
-$(13)PUBLIC
+class c3 §(11){
+§(13)PUBLIC
     int a;
-$(15)PRIVATE$(14)
+§(15)PRIVATE§(14)
     int b;
-$(17)PROTECTED$(16)
+§(17)PROTECTED§(16)
     int c;
-}$(12);
+}§(12);
 )cpp");
 
     EXPECT_FOLDING(0, "1", "2", Class);
@@ -415,17 +415,17 @@ TEST_CASE(Directive) {
 
 TEST_CASE(PragmaRegion) {
     run(R"cpp(
-$(1)#pragma region level1
-    $(2)#pragma region level2
-        $(3)#pragma region level3
+§(1)#pragma region level1
+    §(2)#pragma region level2
+        §(3)#pragma region level3
 
-        #$(4)pragma endregion level3
-
-
-    #$(5)pragma endregion level2
+        #§(4)pragma endregion level3
 
 
-#$(6)pragma endregion level1
+    #§(5)pragma endregion level2
+
+
+#§(6)pragma endregion level1
 
 #pragma endregion   // mismatch region, skipped
 #pragma region  // mismatch region, skipped

--- a/tests/unit/feature/hover_tests.cpp
+++ b/tests/unit/feature/hover_tests.cpp
@@ -219,8 +219,8 @@ void compile_only(llvm::StringRef code) {
 }
 
 /// Compile the code and compute hover info on the (single) annotated point.
-/// The point is either a nameless `$` marker or a named `$(p)` marker, and the
-/// expected highlighted token may be wrapped in a `@sym[...]` range.
+/// The point is either a nameless `§` marker or a named `§(p)` marker, and the
+/// expected highlighted token may be wrapped in a `§(sym)⟦...⟧` range.
 void run_info(llvm::StringRef code,
               const feature::HoverOptions& options = {},
               llvm::StringRef standard = "-std=c++20") {
@@ -278,7 +278,7 @@ void expect_hover(const HoverInfo& expected) {
 }
 
 void check_sym_range() {
-    if(!info || !current_code.contains("@sym[")) {
+    if(!info || !current_code.contains("§(sym)⟦")) {
         return;
     }
 
@@ -308,7 +308,7 @@ void check_cases(llvm::ArrayRef<HoverCase> cases, llvm::StringRef standard = "-s
 
 TEST_CASE(namespace_decl) {
     run(R"cpp(
-namespace $A {
+namespace §A {
 }
 )cpp");
 
@@ -321,7 +321,7 @@ namespace $A {
 TEST_CASE(function_reference) {
     run(R"cpp(
 int foo() { return 0; }
-int x = $foo();
+int x = §foo();
 )cpp");
 
     ASSERT_TRUE(result.has_value());
@@ -430,34 +430,34 @@ void f() {
 
 TEST_CASE(auto_and_decltype) {
     compile_only(R"cpp(
-$(a1)aut$(a2)o$(a3) i = -1;
+§(a1)aut§(a2)o§(a3) i = -1;
 
-$(d1)dec$(d2)ltype$(d3)(i) j = 2;
+§(d1)dec§(d2)ltype§(d3)(i) j = 2;
 
 struct A { int x; };
 
-aut$(a4)o va$(a5)r = A{};
+aut§(a4)o va§(a5)r = A{};
 
-a$(fa)uto f1() { return 1; }
+a§(fa)uto f1() { return 1; }
 
-de$(fn_decltype)cltype(au$(fn_decltype_auto)to) f2() {}
+de§(fn_decltype)cltype(au§(fn_decltype_auto)to) f2() {}
 
-int f3(au$(fn_para_auto)to x) {}
+int f3(au§(fn_para_auto)to x) {}
 )cpp");
 }
 
 TEST_CASE(expr) {
     compile_only(R"cpp(
 int xxxx = 1;
-int yyyy = xx$(e1)xx;
+int yyyy = xx§(e1)xx;
 
 struct A {
     int function(int param) {
-        return thi$(e2)s$(e3)->$(e4)funct$(e5)ion(para$(e6)m);
+        return thi§(e2)s§(e3)->§(e4)funct§(e5)ion(para§(e6)m);
     }
 
     int fn(int param) {
-        return static$(e7)_cast<A*>(nul$(e8)lptr)->function(par$(e9)am);
+        return static§(e7)_cast<A*>(nul§(e8)lptr)->function(par§(e9)am);
     }
 };
 )cpp");
@@ -468,7 +468,7 @@ TEST_CASE(structured_no_crash) {
         // Field type initializer.
         {R"cpp(
           struct X { int x = 2; };
-          X @sym[$x];
+          X §(sym)⟦§x⟧;
           )cpp",
          [](HoverInfo& hi) {
              hi.name = "x";
@@ -478,7 +478,7 @@ TEST_CASE(structured_no_crash) {
              hi.type = "X";
          }},
         // Don't crash on null types.
-        {R"cpp(auto [@sym[$x]] = 1; /*error-ok*/)cpp",
+        {R"cpp(auto [§(sym)⟦§x⟧] = 1; /*error-ok*/)cpp",
          [](HoverInfo& hi) {
              hi.name = "x";
              hi.kind = SymbolKind::Variable;
@@ -490,7 +490,7 @@ TEST_CASE(structured_no_crash) {
          }},
         // Don't crash on invalid decl with invalid init expr.
         {R"cpp(
-          Unknown @sym[$abc] = invalid;
+          Unknown §(sym)⟦§abc⟧ = invalid;
           // error-ok
           )cpp",
          [](HoverInfo& hi) {
@@ -505,7 +505,7 @@ TEST_CASE(structured_no_crash) {
         {R"cpp(
         // error-ok
         struct Foo {
-          Bar @sym[x$x];
+          Bar §(sym)⟦x§x⟧;
         };)cpp",
          [](HoverInfo& hi) {
              hi.name = "xx";
@@ -520,7 +520,7 @@ TEST_CASE(structured_no_crash) {
         // error-ok
         struct Foo {
           Bar xx;
-          int @sym[y$y];
+          int §(sym)⟦y§y⟧;
         };)cpp",
          [](HoverInfo& hi) {
              hi.name = "yy";
@@ -537,7 +537,7 @@ TEST_CASE(structured_no_crash) {
             int a[10];
           };
           constexpr Foo k2 = {
-            @sym[${]1} // FIXME: why the hover range is 1 character?
+            §(sym)⟦§{⟧1} // FIXME: why the hover range is 1 character?
           };
          )cpp",
          [](HoverInfo& hi) {
@@ -554,7 +554,7 @@ TEST_CASE(all_no_crash) {
     HoverCase cases[] = {
         {R"cpp(// Should not crash when evaluating the initializer.
             struct Test {};
-            void test() { Test && @sym[te$st] = {}; }
+            void test() { Test && §(sym)⟦te§st⟧ = {}; }
           )cpp",
          [](HoverInfo& hi) {
              hi.name = "test";
@@ -567,7 +567,7 @@ TEST_CASE(all_no_crash) {
         {R"cpp(// Shouldn't crash when evaluating the initializer.
             struct Bar {}; // error-ok
             struct Foo { void foo(Bar x = y); }
-            void Foo::foo(Bar @sym[$x]) {})cpp",
+            void Foo::foo(Bar §(sym)⟦§x⟧) {})cpp",
          [](HoverInfo& hi) {
              hi.name = "x";
              hi.kind = SymbolKind::Parameter;
@@ -598,7 +598,7 @@ TEST_CASE(spaceship_doc_no_crash) {
     // Foo bar baz
     friend auto operator<=>(S, S) = default;
   };
-  static_assert(S<void>() =$= S<void>());
+  static_assert(S<void>() =§= S<void>());
     )cpp");
 
     ASSERT_TRUE(info.has_value());
@@ -610,14 +610,14 @@ TEST_CASE(invalid_default_args) {
     run_info(R"cpp(
         // error-ok testing behavior on invalid decl
         class Foo {};
-        void foo(Foo p$aram = nullptr);
+        void foo(Foo p§aram = nullptr);
         )cpp");
     ASSERT_TRUE(info.has_value());
     EXPECT_FALSE(info->value.has_value());
 
     run_info(R"cpp(
         class Foo {};
-        void foo(Foo *p$aram = nullptr);
+        void foo(Foo *p§aram = nullptr);
         )cpp");
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(dump(info->value), "nullptr");
@@ -629,7 +629,7 @@ TEST_CASE(disable_show_aka) {
 
     run_info(R"cpp(
     using m_int = int;
-    m_int @sym[$a];
+    m_int §(sym)⟦§a⟧;
   )cpp",
              options,
              "-std=c++17");
@@ -643,14 +643,14 @@ TEST_CASE(big_ints_no_crash) {
     // APInt64 wrap around.
     run_info(R"cpp(
     constexpr unsigned long value = -1; // wrap around
-    void foo() { va$lue; }
+    void foo() { va§lue; }
   )cpp");
     ASSERT_TRUE(info.has_value());
 
     // __int128_t value printing.
     run_info(R"cpp(
     constexpr __int128_t value = -4;
-    void foo() { va$lue; }
+    void foo() { va§lue; }
   )cpp");
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(dump(info->value), "-4 (0xfffffffc)");
@@ -664,7 +664,7 @@ TEST_CASE(global_casts_no_crash) {
     enum Test : uintptr_t {};
     unsigned global_var;
     void foo() {
-      Test v$al = static_cast<Test>(reinterpret_cast<uintptr_t>(&global_var));
+      Test v§al = static_cast<Test>(reinterpret_cast<uintptr_t>(&global_var));
     }
   )cpp");
     ASSERT_TRUE(info.has_value());
@@ -674,7 +674,7 @@ TEST_CASE(global_casts_no_crash) {
     using uintptr_t = unsigned long long;
     unsigned global_var;
     void foo() {
-      uintptr_t a$ddress = reinterpret_cast<uintptr_t>(&global_var);
+      uintptr_t a§ddress = reinterpret_cast<uintptr_t>(&global_var);
     }
   )cpp");
     ASSERT_TRUE(info.has_value());
@@ -687,7 +687,7 @@ TEST_CASE(setter_heuristic_no_crash) {
     template<typename T> T foo(T);
 
     // Setter variable heuristic might fail if the callexpr is broken.
-    struct X { int Y; void @sym[$setY](float) { Y = foo(undefined); } };)cpp");
+    struct X { int Y; void §(sym)⟦§setY⟧(float) { Y = foo(undefined); } };)cpp");
     ASSERT_TRUE(info.has_value());
 }
 
@@ -981,7 +981,7 @@ TEST_CASE(parse_documentation) {
 
 TEST_CASE(plaintext_content) {
     add_main("main.cpp", R"cpp(
-int $foo = 1;
+int §foo = 1;
 )cpp");
     ASSERT_TRUE(compile());
 
@@ -998,7 +998,7 @@ int $foo = 1;
 
 TEST_CASE(protocol_range) {
     run(R"cpp(
-int $foo = 1;
+int §foo = 1;
 )cpp");
 
     ASSERT_TRUE(result.has_value());
@@ -1013,7 +1013,7 @@ int $foo = 1;
 
 TEST_CASE(scoped_attribute) {
     run_info(R"cpp(
-[[gnu::no$inline]] void foo();
+[[gnu::no§inline]] void foo();
 )cpp");
 
     ASSERT_TRUE(info.has_value());
@@ -1025,7 +1025,7 @@ TEST_CASE(scoped_attribute) {
 TEST_CASE(whitespace_no_hover) {
     add_main("main.cpp", R"cpp(
 int x = 1;
-$(p)
+§(p)
 int y = 2;
 )cpp");
     ASSERT_TRUE(compile());

--- a/tests/unit/feature/inlay_hint_tests.cpp
+++ b/tests/unit/feature/inlay_hint_tests.cpp
@@ -71,7 +71,7 @@ TEST_CASE(Parameters) {
     /// Name hint for normal param.
     run(R"c(
             int foo(int param);
-            int x = foo($(0)42);
+            int x = foo(§(0)42);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "param:");
@@ -87,7 +87,7 @@ TEST_CASE(Parameters) {
     run(R"c(
             int foo(int&);
             int x = 1;
-            int y = foo($(0)x);
+            int y = foo(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "&:");
@@ -128,7 +128,7 @@ TEST_CASE(Parameters) {
     // Parameter name picked up from definition if necessary
     run(R"c(
             int foo(int);
-            int x = foo($(0)42);
+            int x = foo(§(0)42);
             int foo(int param) {
                 return 0;
             }
@@ -139,7 +139,7 @@ TEST_CASE(Parameters) {
     // Parameter name picked up from definition if necessary
     run(R"c(
             int foo(int, int b);
-            int x = foo($(0)42, $(1)42);
+            int x = foo(§(0)42, §(1)42);
             int foo(int a, int) {
                 return 0;
             }
@@ -155,7 +155,7 @@ TEST_CASE(Parameters) {
             int bar(Args... args) {
                 return foo(args...);
             }
-            int x = bar($(0)42, $(1)42);
+            int x = bar(§(0)42, §(1)42);
             int foo(int a, int b) {
                 return 0;
             }
@@ -167,7 +167,7 @@ TEST_CASE(Parameters) {
     // Prefer name from declaration
     run(R"c(
             int foo(int good);
-            int x = foo($(0)42);
+            int x = foo(§(0)42);
             int foo(int bad) {
                 return 0;
             }
@@ -178,7 +178,7 @@ TEST_CASE(Parameters) {
     // Only name hint for const l-value ref parameter
     run(R"c(
             int foo(const int& param);
-            int x = foo($(0)42);
+            int x = foo(§(0)42);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "param:");
@@ -188,7 +188,7 @@ TEST_CASE(Parameters) {
             using alias = const int&;
             int foo(alias param);
             int x = 1;
-            int y = foo($(0)x);
+            int y = foo(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "param:");
@@ -197,7 +197,7 @@ TEST_CASE(Parameters) {
     run(R"c(
             int foo(int& param);
             int x = 1;
-            int y = foo($(0)x);
+            int y = foo(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "&param:");
@@ -207,7 +207,7 @@ TEST_CASE(Parameters) {
             using alias = int&;
             int foo(alias param);
             int x = 1;
-            int y = foo($(0)x);
+            int y = foo(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "&param:");
@@ -215,7 +215,7 @@ TEST_CASE(Parameters) {
     // Only name hint for r-value ref parameter
     run(R"c(
             int foo(int&& param);
-            int x = foo($(0)42);
+            int x = foo(§(0)42);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "param:");
@@ -231,7 +231,7 @@ TEST_CASE(Parameters) {
                 // Do not show redundant "param: param".
                 foo(param);
                 // But show it if the argument is qualified.
-                foo($(0)S::param);
+                foo(§(0)S::param);
             }
             struct A {
                 int param;
@@ -251,7 +251,7 @@ TEST_CASE(Parameters) {
             void bar() {
                 int param;
                 // show reference hint on mutable reference
-                foo($(0)param);
+                foo(§(0)param);
                 // but not on const reference
                 foo2(param);
             }
@@ -266,7 +266,7 @@ TEST_CASE(Parameters) {
             template <typename T, typename... Args>
             T bar(Args&&... args) { return T{std::forward<Args>(args)...}; }
             int x = 1;
-            S y = bar<S>($(0)x);
+            S y = bar<S>(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "a:");
@@ -277,7 +277,7 @@ TEST_CASE(Parameters) {
             template <typename T, typename... Args>
             T bar(Args&&... args) { return T{args...}; }
             int x = 1;
-            S y = bar<S>($(0)x);
+            S y = bar<S>(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "a:");
@@ -289,7 +289,7 @@ TEST_CASE(Parameters) {
             template <typename... Args>
             int bar(Args&&... args) { return foo(std::forward<Args>(args)...); }
             int x = 1;
-            int y = bar($(0)x);
+            int y = bar(§(0)x);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "a:");
@@ -299,7 +299,7 @@ TEST_CASE(Parameters) {
             int foo(int a);
             template <typename... Args>
             int bar(Args&&... args) { return foo(args...); }
-            int x = bar($(0)42);
+            int x = bar(§(0)42);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "a:");
@@ -310,7 +310,7 @@ TEST_CASE(Parameters) {
             int foo(int a);
             template <typename... Args, typename Arg>
             int bar(Arg, Args&&... args) { return foo(args...); }
-            int x = bar(1, $(0)42);
+            int x = bar(1, §(0)42);
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", "a:");
@@ -325,7 +325,7 @@ TEST_CASE(Parameters) {
             }
             template <typename... Args>
             int bar(Args&&... args) { return foo(std::forward<Args>(args)...); }
-            int x = bar($(0)32, $(1)42);
+            int x = bar(§(0)32, §(1)42);
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", "a:");
@@ -358,18 +358,18 @@ TEST_CASE(Parameters) {
                 auto l2 = [](int x) static -> void {};
 
                 S s;
-                s($(0)1);
-                s.operator()($(1)1);
-                s.operator()($(2)1, $(3)2);
-                S::operator()($(4)1, $(5)2);
+                s(§(0)1);
+                s.operator()(§(1)1);
+                s.operator()(§(2)1, §(3)2);
+                S::operator()(§(4)1, §(5)2);
 
-                l1($(6)1);
-                l1.operator()($(7)1);
-                l2($(8)1);
-                l2.operator()($(9)1);
+                l1(§(6)1);
+                l1.operator()(§(7)1);
+                l2(§(8)1);
+                l2.operator()(§(9)1);
 
                 void (*ptr)(int a, int b) = &S::operator();
-                ptr($(10)1, $(11)2);
+                ptr(§(10)1, §(11)2);
             }
         )c");
 
@@ -400,13 +400,13 @@ TEST_CASE(Parameters) {
             };
             void work() {
                 S s;
-                s($(0)42);
-                s.function($(1)42);
-                S()($(2)42);
+                s(§(0)42);
+                s.function(§(1)42);
+                S()(§(2)42);
                 auto lambda = [](this auto &Self, char C) -> void {
                     return Self(C);
                 };
-                lambda($(3)'A');
+                lambda(§(3)'A');
             }
         )c");
 
@@ -421,7 +421,7 @@ TEST_CASE(Parameters) {
                 S(int param);
             };
             void bar() {
-                S obj($(0)42);
+                S obj(§(0)42);
             }
         )c");
     EXPECT_SIZE(1);
@@ -433,7 +433,7 @@ TEST_CASE(Parameters) {
                 S(int param);
             };
             void bar() {
-                S obj{$(0)42};
+                S obj{§(0)42};
             }
         )c");
     EXPECT_SIZE(1);
@@ -447,7 +447,7 @@ TEST_CASE(Parameters) {
 
             struct T {
                 S member;
-                T() : member($(0)42) {}
+                T() : member(§(0)42) {}
             };
         )c");
     EXPECT_SIZE(1);
@@ -463,10 +463,10 @@ TEST_CASE(Parameters) {
             f4_t f4;
 
             void bar() {
-                f1($(0)42);
-                f2($(1)42);
-                f3($(2)42);
-                f4($(3)42);
+                f1(§(0)42);
+                f2(§(1)42);
+                f3(§(2)42);
+                f4(§(3)42);
             }
         )c");
     EXPECT_SIZE(4);
@@ -479,7 +479,7 @@ TEST_CASE(Parameters) {
     run(R"c(
             void foo(int p1, int _p2, int __p3);
             void bar() {
-                foo($(0)41, $(1)42, $(2)43);
+                foo(§(0)41, §(1)42, §(2)43);
             }
         )c");
     EXPECT_SIZE(3);
@@ -493,7 +493,7 @@ TEST_CASE(Parameters) {
             void foo(int fixed, T... variadic);
 
             void bar() {
-                foo($(0)41, 42, 43);
+                foo(§(0)41, 42, 43);
             }
         )c");
     EXPECT_SIZE(1);
@@ -504,7 +504,7 @@ TEST_CASE(Parameters) {
             void foo(int fixed, ...);
 
             void bar() {
-                foo($(0)41, 42, 43);
+                foo(§(0)41, 42, 43);
             }
         )c");
     EXPECT_SIZE(1);
@@ -545,8 +545,8 @@ TEST_CASE(Parameters) {
                 #define Y X
                 #define Z(...) Y
                 foo(/*param=*/Z(a));
-                foo($(0)Z(a));
-                foo(/* the answer */$(1)42);
+                foo(§(0)Z(a));
+                foo(/* the answer */§(1)42);
             }
         )c");
     EXPECT_SIZE(2);
@@ -568,9 +568,9 @@ TEST_CASE(Parameters) {
                 // Support snake_case
                 s.set_parent(nullptr);
                 // Parameter name may contain extra info - show hint.
-                s.setTimeout($(0)120);
+                s.setTimeout(§(0)120);
                 // FIXME: Ideally we'd want to omit this.
-                s.setTimeoutMillis($(1)120);
+                s.setTimeoutMillis(§(1)120);
             }
         )c");
     EXPECT_SIZE(2);
@@ -581,7 +581,7 @@ TEST_CASE(Parameters) {
 TEST_CASE(Types) {
     // Basic type hint
     run(R"c(
-            auto waldo$(0) = 42;
+            auto waldo§(0) = 42;
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", ": int");
@@ -589,9 +589,9 @@ TEST_CASE(Types) {
     // Decorations
     run(R"c(
             int x = 42;
-            auto* var1$(0) = &x;
-            auto&& var2$(1) = x;
-            const auto& var3$(2) = x;
+            auto* var1§(0) = &x;
+            auto&& var2§(1) = x;
+            const auto& var3§(2) = x;
         )c");
     EXPECT_SIZE(3);
     EXPECT_HINT("0", ": int *");
@@ -602,7 +602,7 @@ TEST_CASE(Types) {
     run(R"c(
             int x = 42;
             int& y = x;
-            decltype(auto) z$(0) = y;
+            decltype(auto) z§(0) = y;
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", ": int &");
@@ -613,7 +613,7 @@ TEST_CASE(Types) {
                 namespace B {
                     struct S1 {};
                     S1 foo();
-                    auto x$(0) = foo();
+                    auto x§(0) = foo();
 
                     struct S2 {
                         template <typename T>
@@ -621,7 +621,7 @@ TEST_CASE(Types) {
                     };
 
                     S2::Inner<int> bar();
-                    auto y$(1) = bar();
+                    auto y§(1) = bar();
                 }
             }
         )c");
@@ -633,7 +633,7 @@ TEST_CASE(Types) {
     run(R"c(
             void f() {
                 int cap = 42;
-                auto L$(0) = [cap, init$(1) = 1 + 1](int a)$(2) {
+                auto L§(0) = [cap, init§(1) = 1 + 1](int a)§(2) {
                     return a + cap + init;
                 };
             }
@@ -645,7 +645,7 @@ TEST_CASE(Types) {
 
     // Lambda return hint shown even if no param list
     run(R"c(
-            auto x$(0) = []$(1){return 42;};
+            auto x§(0) = []§(1){return 42;};
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": (lambda)");
@@ -658,7 +658,7 @@ TEST_CASE(Types) {
                 int y;
             };
             Point foo();
-            auto [x$(0), y$(1)] = foo();
+            auto [x§(0), y§(1)] = foo();
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": int");
@@ -667,7 +667,7 @@ TEST_CASE(Types) {
     // Structured bindings - array
     run(R"c(
             int arr[2];
-            auto [x$(0), y$(1)] = arr;
+            auto [x§(0), y§(1)] = arr;
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": int");
@@ -708,7 +708,7 @@ TEST_CASE(Types) {
             }
 
             IntPair bar();
-            auto [x$(0), y$(1)] = bar();
+            auto [x§(0), y§(1)] = bar();
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": int");
@@ -716,12 +716,12 @@ TEST_CASE(Types) {
 
     // Return type deduction
     run(R"c(
-            auto f1(int x)$(0);  // Hint forward declaration too
-            auto f1(int x)$(1) { return x + 1; }
+            auto f1(int x)§(0);  // Hint forward declaration too
+            auto f1(int x)§(1) { return x + 1; }
 
             // Include pointer operators in hint
             int s;
-            auto& f2()$(2) { return s; }
+            auto& f2()§(2) { return s; }
 
             // Do not hint `auto` for trailing return type.
             auto f3() -> int;
@@ -729,11 +729,11 @@ TEST_CASE(Types) {
             // Do not hint when a trailing return type is specified.
             auto f4() -> auto* { return "foo"; }
 
-            auto f5()$(3) {}
+            auto f5()§(3) {}
 
             // `auto` conversion operator
             struct A {
-                operator auto()$(4) { return 42; }
+                operator auto()§(4) { return 42; }
             };
         )c");
     EXPECT_SIZE(5);
@@ -745,17 +745,17 @@ TEST_CASE(Types) {
 
     // Decltype
     run(R"c(
-            decltype(0)$(0) a;
-            decltype(a)$(1) b;
-            const decltype(0)$(2) &c = b;
+            decltype(0)§(0) a;
+            decltype(a)§(1) b;
+            const decltype(0)§(2) &c = b;
 
-            decltype(0)$(3) e();
-            auto f() -> decltype(0)$(4);
+            decltype(0)§(3) e();
+            auto f() -> decltype(0)§(4);
 
             template <class, class> struct Foo;
-            using G = Foo<decltype(0)$(5), float>;
+            using G = Foo<decltype(0)§(5), float>;
 
-            auto h$(6) = decltype(0)$(7){};
+            auto h§(6) = decltype(0)§(7){};
         )c");
     EXPECT_SIZE(8);
     EXPECT_HINT("0", ": int");
@@ -783,9 +783,9 @@ TEST_CASE(Types) {
             template <typename, typename = int>
             struct A {};
             A<float> foo();
-            auto var$(0) = foo();
+            auto var§(0) = foo();
             A<float> bar[1];
-            auto [binding$(1)] = bar;
+            auto [binding§(1)] = bar;
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", ": A<float>");
@@ -795,7 +795,7 @@ TEST_CASE(Types) {
     run(R"c(
             template <typename T>
             void foo() {
-                auto var$(0) = 42;
+                auto var§(0) = 42;
             }
 
             template void foo<int>();
@@ -806,7 +806,7 @@ TEST_CASE(Types) {
 
     // Singly instantiated template
     run(R"c(
-            auto lambda$(0) = [](auto* param$(1), auto) { return 42; };
+            auto lambda§(0) = [](auto* param§(1), auto) { return 42; };
             int m = lambda("foo", 3);
         )c");
     EXPECT_HINT("0", ": (lambda)");
@@ -814,7 +814,7 @@ TEST_CASE(Types) {
 
     // No hint for packs, or auto params following packs
     run(R"c(
-            int x(auto a$(0), auto... b, auto c) { return 42; }
+            int x(auto a§(0), auto... b, auto c) { return 42; }
             int m = x<void*, char, float>(nullptr, 'c', 2.0, 2);
         )c");
     EXPECT_HINT("0", ": void *");
@@ -824,9 +824,9 @@ TEST_CASE(Designators, skip = true) {
     // Basic designator hints
     run(R"c(
             struct S { int x, y, z; };
-            S s {$(0)1, $(1)2+2};
+            S s {§(0)1, §(1)2+2};
 
-            int x[] = {$(2)0, $(3)1};
+            int x[] = {§(2)0, §(3)1};
         )c");
     EXPECT_SIZE(4);
     EXPECT_HINT("0", ".x=");
@@ -838,7 +838,7 @@ TEST_CASE(Designators, skip = true) {
     run(R"c(
             struct Inner { int x, y; };
             struct Outer { Inner a, b; };
-            Outer o{ $(0)a{ $(1)1, $(2)2 }, $(3)bx3 };
+            Outer o{ §(0)a{ §(1)1, §(2)2 }, §(3)bx3 };
         )c");
     EXPECT_SIZE(4);
     EXPECT_HINT("0", ".a=");
@@ -857,7 +857,7 @@ TEST_CASE(Designators, skip = true) {
                     } x;
                 };
             };
-            S s{$(0)xy42};
+            S s{§(0)xy42};
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", ".x.y=");
@@ -865,7 +865,7 @@ TEST_CASE(Designators, skip = true) {
     // Suppression
     run(R"c(
             struct Point { int a, b, c, d, e, f, g, h; };
-            Point p{/*a=*/1, .c=2, /* .d = */3, $(0)4};
+            Point p{/*a=*/1, .c=2, /* .d = */3, §(0)4};
         )c");
     EXPECT_SIZE(1);
     EXPECT_HINT("0", ".e=");
@@ -873,7 +873,7 @@ TEST_CASE(Designators, skip = true) {
     // Std array
     run(R"c(
             template <typename T, int N> struct Array { T __elements[N]; };
-            Array<int, 2> x = {$(0)0, $(1)1};
+            Array<int, 2> x = {§(0)0, §(1)1};
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", "[0]=");
@@ -894,7 +894,7 @@ TEST_CASE(Designators, skip = true) {
             struct A {};
             struct Foo {int a; int b;};
             void test() {
-                Foo f{A(), $(0)1};
+                Foo f{A(), §(0)1};
             }
         )c");
     EXPECT_SIZE(1);
@@ -906,7 +906,7 @@ TEST_CASE(BlockEnd, skip = true) {
     run(R"c(
             int foo() {
                 return 41;
-            $(0)}
+            §(0)}
 
             template<int X>
             int bar() {
@@ -915,7 +915,7 @@ TEST_CASE(BlockEnd, skip = true) {
                     return X;
                 };
                 return f();
-            $(1)}
+            §(1)}
 
             // No hint because this isn't a definition
             int buz();
@@ -923,7 +923,7 @@ TEST_CASE(BlockEnd, skip = true) {
             struct S{};
             bool operator==(S, S) {
                 return true;
-            $(2)}
+            §(2)}
         )c");
     EXPECT_SIZE(3);
     EXPECT_HINT("0", " // foo");
@@ -937,17 +937,17 @@ TEST_CASE(BlockEnd, skip = true) {
                 Test() = default;
 
                 ~Test() {
-                $(0)}
+                §(0)}
 
                 void method1() {
-                $(1)}
+                §(1)}
 
                 // No hint because this isn't a definition
                 void method2();
 
                 template <typename T>
                 void method3() {
-                $(2)}
+                §(2)}
 
                 // No hint because this isn't a definition
                 template <typename T>
@@ -955,22 +955,22 @@ TEST_CASE(BlockEnd, skip = true) {
 
                 Test operator+(int) const {
                     return *this;
-                $(3)}
+                §(3)}
 
                 operator bool() const {
                     return true;
-                $(4)}
+                §(4)}
 
                 // No hint because there's no function body
                 operator int() const = delete;
             } x;
 
             void Test::method2() {
-            $(5)}
+            §(5)}
 
             template <typename T>
             void Test::method4() {
-            $(6)}
+            §(6)}
         )c");
     EXPECT_SIZE(7);
     EXPECT_HINT("0", " // ~Test");
@@ -985,11 +985,11 @@ TEST_CASE(BlockEnd, skip = true) {
     run(R"c(
             namespace {
                 void foo();
-            $(0)}
+            §(0)}
 
             namespace ns {
                 void bar();
-            $(1)}
+            §(1)}
         )c");
     EXPECT_SIZE(2);
     EXPECT_HINT("0", " // namespace");
@@ -998,19 +998,19 @@ TEST_CASE(BlockEnd, skip = true) {
     // Types
     run(R"c(
             struct S {
-            $(0)};
+            §(0)};
 
             class C {
-            $(1)};
+            §(1)};
 
             union U {
-            $(2)};
+            §(2)};
 
             enum E1 {
-            $(3)};
+            §(3)};
 
             enum class E2 {
-            $(4)};
+            §(4)};
         )c");
     EXPECT_SIZE(5);
     EXPECT_HINT("0", " // struct S");
@@ -1026,27 +1026,27 @@ TEST_CASE(BlockEnd, skip = true) {
                     ;
 
                 if (cond) {
-                $(0)}
+                §(0)}
 
                 if (cond) {
                 } else {
-                $(1)}
+                §(1)}
 
                 if (cond) {
                 } else if (!cond) {
-                $(2)}
+                §(2)}
 
                 if (cond) {
                 } else {
                     if (!cond) {
-                    $(3)}
-                $(4)}
+                    §(3)}
+                §(4)}
 
                 if (auto X = cond) {
-                $(5)}
+                §(5)}
 
                 if (int i = 0; i > 10) {
-                $(6)}
+                §(6)}
             }
         )c");
     EXPECT_SIZE(7);
@@ -1065,20 +1065,20 @@ TEST_CASE(BlockEnd, skip = true) {
                     ;
 
                 while (true) {
-                $(0)}
+                §(0)}
 
                 do {
                 } while (true);
 
                 for (;true;) {
-                $(1)}
+                §(1)}
 
                 for (int I = 0; I < 10; ++I) {
-                $(2)}
+                §(2)}
 
                 int Vs[] = {1,2,3};
                 for (auto V : Vs) {
-                $(3)}
+                §(3)}
             }
         )c");
     EXPECT_SIZE(4);
@@ -1092,7 +1092,7 @@ TEST_CASE(BlockEnd, skip = true) {
             void foo(int I) {
                 switch (I) {
                     case 0: break;
-                $(0)}
+                §(0)}
             }
         )c");
     EXPECT_SIZE(1);
@@ -1102,19 +1102,19 @@ TEST_CASE(BlockEnd, skip = true) {
     run(R"c(
             void foo() {
                 while ("foo") {
-                $(0)}
+                §(0)}
 
                 while ("foo but this time it is very long") {
-                $(1)}
+                §(1)}
 
                 while (true) {
-                $(2)}
+                §(2)}
 
                 while (1) {
-                $(3)}
+                §(3)}
 
                 while (1.5) {
-                $(4)}
+                §(4)}
             }
         )c");
     EXPECT_SIZE(5);
@@ -1136,16 +1136,16 @@ TEST_CASE(BlockEnd, skip = true) {
             }
             void foo() {
                 while (ns::Var) {
-                $(0)}
+                §(0)}
 
                 while (ns::func()) {
-                $(1)}
+                §(1)}
 
                 while (ns::S{}.Field) {
-                $(2)}
+                §(2)}
 
                 while (ns::S{}.method()) {
-                $(3)}
+                §(3)}
             }
         )c");
     EXPECT_SIZE(4);
@@ -1163,13 +1163,13 @@ TEST_CASE(BlockEnd, skip = true) {
             };
             void foo(int I) {
                 while (float(I)) {
-                $(0)}
+                §(0)}
 
                 while (S(I)) {
-                $(1)}
+                §(1)}
 
                 while (S(I, I)) {
-                $(2)}
+                §(2)}
             }
         )c");
     EXPECT_SIZE(3);
@@ -1182,25 +1182,25 @@ TEST_CASE(BlockEnd, skip = true) {
             using Integer = int;
             void foo(Integer I) {
                 while(++I){
-                $(0)}
+                §(0)}
 
                 while(I++){
-                $(1)}
+                §(1)}
 
                 while(+(I + I)){
-                $(2)}
+                §(2)}
 
                 while(I < 0){
-                $(3)}
+                §(3)}
 
                 while((I + I) < I){
-                $(4)}
+                §(4)}
 
                 while(I < (I + I)){
-                $(5)}
+                §(5)}
 
                 while((I + I) < (I + I)){
-                $(6)}
+                §(6)}
             }
         )c");
     EXPECT_SIZE(7);
@@ -1216,12 +1216,12 @@ TEST_CASE(BlockEnd, skip = true) {
     run(R"c(
             // The hint is placed after the trailing ';'
             struct S1 {
-            $(0)}  ;
+            §(0)}  ;
 
             // The hint is always placed in the same line with the closing '}'.
             // So in this case where ';' is missing, it is attached to '}'.
             struct S2 {
-            $(1)}
+            §(1)}
 
             ;
 
@@ -1236,7 +1236,7 @@ TEST_CASE(BlockEnd, skip = true) {
             // Rare case, but yes we'll have a hint here.
             struct {
                 int x;
-            $(2)}
+            §(2)}
 
             s2;
         )c");
@@ -1248,7 +1248,7 @@ TEST_CASE(BlockEnd, skip = true) {
     // Trailing text
     run(R"c(
             struct S1 {
-            $(0)}      ;
+            §(0)}      ;
 
             // No hint for S2 because of the trailing comment
             struct S2 {
@@ -1257,7 +1257,7 @@ TEST_CASE(BlockEnd, skip = true) {
             struct S3 {
                 // No hint for S4 because of the trailing source code
                 struct S4 {
-                };$(1)};
+                };§(1)};
 
             // No hint for ns because of the trailing comment
             namespace ns {
@@ -1273,7 +1273,7 @@ TEST_CASE(BlockEnd, skip = true) {
             #define RBRACE }
 
             DECL_STRUCT(S1)
-            $(0)};
+            §(0)};
 
             // No hint because we require a '}'
             DECL_STRUCT(S2)
@@ -1288,7 +1288,7 @@ TEST_CASE(BlockEnd, skip = true) {
             using Predicate = bool(A::*)();
             void foo(A* a, Predicate p) {
                 if ((a->*p)()) {
-                $(0)}
+                §(0)}
             }
         )c");
     EXPECT_SIZE(1);
@@ -1299,10 +1299,10 @@ TEST_CASE(DefaultArguments, skip = true) {
     // Smoke test
     run(R"c(
             int foo(int A = 4) { return A; }
-            int bar(int A, int B = 1, bool C = foo($(0))) { return A; }
-            int A = bar($(1)2$(2));
+            int bar(int A, int B = 1, bool C = foo(§(0))) { return A; }
+            int A = bar(§(1)2§(2));
 
-            void baz(int = 5) { if (false) baz($(3)); };
+            void baz(int = 5) { if (false) baz(§(3)); };
         )c");
     EXPECT_SIZE(4);
     EXPECT_HINT("0", "A: 4");
@@ -1318,17 +1318,17 @@ TEST_CASE(DefaultArguments, skip = true) {
             };
             struct Foo {
                 Foo(int, Baz baz = //
-                        Baz{$(0)}
+                        Baz{§(0)}
 
                     //
                 ) {}
             };
 
             int main() {
-                Foo foo1(1$(1));
-                Foo foo2{2$(2)};
-                Foo foo3 = {3$(3)};
-                auto foo4 = Foo{4$(4)};
+                Foo foo1(1§(1));
+                Foo foo2{2§(2)};
+                Foo foo3 = {3§(3)};
+                auto foo4 = Foo{4§(4)};
             }
         )c");
     EXPECT_SIZE(5);
@@ -1355,7 +1355,7 @@ TEST_CASE(Special, skip = true) {
             #define PI 3.14
             void foo(double param);
             void bar() {
-                foo($(0)PI);
+                foo(§(0)PI);
             }
         )c");
     EXPECT_SIZE(1);
@@ -1366,7 +1366,7 @@ TEST_CASE(Special, skip = true) {
             #define ASSERT(expr) if (!(expr)) abort()
             int foo(int param);
             void bar() {
-                ASSERT(foo($(0)42) == 0);
+                ASSERT(foo(§(0)42) == 0);
             }
         )c");
     EXPECT_SIZE(1);
@@ -1435,10 +1435,10 @@ TEST_CASE(Special, skip = true) {
             int main() {
                 S s;
                 __builtin_dump_struct(&s, printf); // Not `Format: __builtin_dump_struct()`
-                printf($(0)"Hello, %d", 42); // Normal calls are not affected.
+                printf(§(0)"Hello, %d", 42); // Normal calls are not affected.
                 // This builds a PseudoObjectExpr, but here it's useful for showing the
                 // arguments from the semantic form.
-                return s.x[ $(1)1 ][ $(2)2 ]; // `x[y: 1][z: 2]`
+                return s.x[ §(1)1 ][ §(2)2 ]; // `x[y: 1][z: 2]`
             }
         )c");
     EXPECT_SIZE(3);
@@ -1460,16 +1460,16 @@ TEST_CASE(VariadicTemplate) {
             }
 
             template <typename... Args>
-            void baz(Args... args) { foo($(0)Foo{args...}, $(1)1); }
+            void baz(Args... args) { foo(§(0)Foo{args...}, §(1)1); }
 
             template <typename... Args>
-            void bax(Args... args) { foo($(2){args...}, args...); }
+            void bax(Args... args) { foo(§(2){args...}, args...); }
 
             void foo() {
-                bar($(3)Foo{}, $(4)42);
-                bar($(5)42, $(6)42);
-                baz($(7)42);
-                bax($(8)42);
+                bar(§(3)Foo{}, §(4)42);
+                bar(§(5)42, §(6)42);
+                baz(§(7)42);
+                bax(§(8)42);
             }
         )c");
     /// FIXME:
@@ -1489,7 +1489,7 @@ TEST_CASE(VariadicTemplate) {
             int id(int a, int b, int c);
             template <typename... Args>
             void bar(Args... args) {
-                foo(id($(0)args, $(1)1, $(2)args)...);
+                foo(id(§(0)args, §(1)1, §(2)args)...);
             }
             void foo() {
                 bar(1, 2); // FIXME: We could have `bar(a: 1, a: 2)` here.
@@ -1520,9 +1520,9 @@ TEST_CASE(Dependent, skip = true) {
             template <typename T>
             struct S {
                 void bar(A<T> a, T t) {
-                    nonmember($(0)t);
-                    a.member($(1)t);
-                    A<T>::static_member($(2)t);
+                    nonmember(§(0)t);
+                    a.member(§(1)t);
+                    A<T>::static_member(§(2)t);
                     // We don't want to arbitrarily pick between
                     // "anInt" or "aDouble", so just show no hint.
                     overload(T{});

--- a/tests/unit/feature/semantic_tokens_tests.cpp
+++ b/tests/unit/feature/semantic_tokens_tests.cpp
@@ -176,9 +176,9 @@ void EXPECT_TOKEN_AT(llvm::StringRef name, std::uint64_t line, std::uint64_t sta
 
 TEST_CASE(BasicLexicalKinds) {
     run_utf8(R"cpp(
-@d1[#define] @m0[FOO]
-@k0[int] main() { @k1[return] 0; }
-@c0[// comment]
+§(d1)⟦#define⟧ §(m0)⟦FOO⟧
+§(k0)⟦int⟧ main() { §(k1)⟦return⟧ 0; }
+§(c0)⟦// comment⟧
 )cpp");
 
     EXPECT_TOKEN("d1", SymbolKind::Directive);
@@ -191,7 +191,7 @@ TEST_CASE(BasicLexicalKinds) {
 TEST_CASE(IncludeDirective) {
     add_file("fake.h", "// fake header\n");
     add_main("main.cpp", R"cpp(
-@d0[#include] @h0["fake.h"]
+§(d0)⟦#include⟧ §(h0)⟦"fake.h"⟧
 int main() { return 0; }
 )cpp");
     ASSERT_TRUE(compile_with_pch());
@@ -205,9 +205,9 @@ int main() { return 0; }
 TEST_CASE(LegacyIncludeForms) {
     add_file("fake.h", "// fake header\n");
     add_main("main.cpp", R"cpp(
-@i0[#include] @h0["fake.h"]
-@i1[#include] @h1["fake.h"]
-@i2[#] @i3[include] @h2["fake.h"]
+§(i0)⟦#include⟧ §(h0)⟦"fake.h"⟧
+§(i1)⟦#include⟧ §(h1)⟦"fake.h"⟧
+§(i2)⟦#⟧ §(i3)⟦include⟧ §(h2)⟦"fake.h"⟧
 )cpp");
     ASSERT_TRUE(compile_with_pch());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -224,7 +224,7 @@ TEST_CASE(LegacyIncludeForms) {
 
 TEST_CASE(LegacyComment) {
     run_utf8(R"cpp(
-@line[/// line comment]
+§(line)⟦/// line comment⟧
 int x = 1;
 )cpp");
 
@@ -233,8 +233,8 @@ int x = 1;
 
 TEST_CASE(LegacyKeyword) {
     run_utf8(R"cpp(
-@k0[int] main() {
-    @k1[return] 0;
+§(k0)⟦int⟧ main() {
+    §(k1)⟦return⟧ 0;
 }
 )cpp");
 
@@ -244,7 +244,7 @@ TEST_CASE(LegacyKeyword) {
 
 TEST_CASE(LegacyMacro) {
     run_utf8(R"cpp(
-@directive[#define] @macro[FOO]
+§(directive)⟦#define⟧ §(macro)⟦FOO⟧
 )cpp");
 
     EXPECT_TOKEN("directive", SymbolKind::Directive);
@@ -253,18 +253,18 @@ TEST_CASE(LegacyMacro) {
 
 TEST_CASE(LegacyFinalAndOverride) {
     run_utf8(R"cpp(
-struct A @final[final] {};
+struct A §(final)⟦final⟧ {};
 
 struct B {
     virtual void foo();
 };
 
 struct C : B {
-    void foo() @override[override];
+    void foo() §(override)⟦override⟧;
 };
 
 struct D : C {
-    void foo() @final2[final];
+    void foo() §(final2)⟦final⟧;
 };
 )cpp");
 
@@ -275,17 +275,17 @@ struct D : C {
 
 TEST_CASE(DeclarationAndTemplateModifiers) {
     run_utf8(R"cpp(
-extern int @x1[x];
-int @x2[x] = 0;
+extern int §(x1)⟦x⟧;
+int §(x2)⟦x⟧ = 0;
 
 template <typename T>
-extern int @y1[y];
+extern int §(y1)⟦y⟧;
 
 template <typename T>
-int @y2[y] = 0;
+int §(y2)⟦y⟧ = 0;
 
 int main() {
-    @x3[x] = 1;
+    §(x3)⟦x⟧ = 1;
 }
 )cpp");
 
@@ -307,7 +307,7 @@ struct S {};
 S operator+(S lhs, S rhs);
 
 void use(S lhs, S rhs) {
-    (void)(lhs @plus[+] rhs);
+    (void)(lhs §(plus)⟦+⟧ rhs);
 }
 )cpp");
 
@@ -317,14 +317,14 @@ void use(S lhs, S rhs) {
 TEST_CASE(ConstructorAndDestructorNamesRemainHighlighted) {
     run_utf8(R"cpp(
 struct S {
-    @ctor_decl[S]();
-    @dtor_decl[~]S();
+    §(ctor_decl)⟦S⟧();
+    §(dtor_decl)⟦~⟧S();
 };
 
-S::@ctor_def[S]() {}
+S::§(ctor_def)⟦S⟧() {}
 
 void use(S* value) {
-    value->@dtor_ref[~]S();
+    value->§(dtor_ref)⟦~⟧S();
 }
 )cpp");
 
@@ -340,27 +340,27 @@ void use(S* value) {
 
 TEST_CASE(LegacyVarDeclTemplates) {
     run_utf8(R"cpp(
-extern int @x1[x];
+extern int §(x1)⟦x⟧;
 
-int @x2[x] = 1;
-
-template <typename T, typename U>
-extern int @y1[y];
+int §(x2)⟦x⟧ = 1;
 
 template <typename T, typename U>
-int @y2[y] = 2;
+extern int §(y1)⟦y⟧;
+
+template <typename T, typename U>
+int §(y2)⟦y⟧ = 2;
 
 template<typename T>
-extern int @y3[y]<T, int>;
+extern int §(y3)⟦y⟧<T, int>;
 
 template<typename T>
-int @y4[y]<T, int> = 4;
+int §(y4)⟦y⟧<T, int> = 4;
 
 template<>
-int @y5[y]<int, int> = 5;
+int §(y5)⟦y⟧<int, int> = 5;
 
 int main() {
-    @x3[x] = 6;
+    §(x3)⟦x⟧ = 6;
 }
 )cpp");
 
@@ -380,17 +380,17 @@ int main() {
 
 TEST_CASE(LegacyFunctionDecl) {
     run_utf8(R"cpp(
-extern int @foo1[foo]();
+extern int §(foo1)⟦foo⟧();
 
-int @foo2[foo]() {
+int §(foo2)⟦foo⟧() {
     return 0;
 }
 
 template <typename T>
-extern int @bar1[bar]();
+extern int §(bar1)⟦bar⟧();
 
 template <typename T>
-int @bar2[bar]() {
+int §(bar2)⟦bar⟧() {
     return 1;
 }
 )cpp");
@@ -407,17 +407,17 @@ int @bar2[bar]() {
 
 TEST_CASE(LegacyRecordDecl) {
     run_utf8(R"cpp(
-class @a1[A];
+class §(a1)⟦A⟧;
 
-class @a2[A] {};
+class §(a2)⟦A⟧ {};
 
-struct @b1[B];
+struct §(b1)⟦B⟧;
 
-struct @b2[B] {};
+struct §(b2)⟦B⟧ {};
 
-union @c1[C];
+union §(c1)⟦C⟧;
 
-union @c2[C] {};
+union §(c2)⟦C⟧ {};
 )cpp");
 
     auto declaration = modifier_mask({SymbolModifiers::Declaration});
@@ -434,7 +434,7 @@ union @c2[C] {};
 TEST_CASE(UTF16LengthDiffersFromUTF8) {
     add_main("main.cpp", R"cpp(
 int main() {
-@lit[u8"你"];
+§(lit)⟦u8"你"⟧;
 }
 )cpp");
     ASSERT_TRUE(compile_with_pch());
@@ -501,7 +501,7 @@ TEST_CASE(CodeAfterRawString) {
     run_utf8(R"cpp(
 const char* s = R"(line1
 line2
-)"; @k0[int] @x[x] = 1;
+)"; §(k0)⟦int⟧ §(x)⟦x⟧ = 1;
 )cpp");
 
     EXPECT_TOKENS_WITHIN_LINES();
@@ -513,7 +513,7 @@ line2
 TEST_CASE(CodeAfterMultilineComment) {
     run_utf8(R"cpp(
     /* first
-second */ @k0[int] @x[x] = 1;
+second */ §(k0)⟦int⟧ §(x)⟦x⟧ = 1;
 )cpp");
 
     EXPECT_TOKENS_WITHIN_LINES();
@@ -524,7 +524,7 @@ second */ @k0[int] @x[x] = 1;
 
 TEST_CASE(ModuleDeclaration) {
     add_main("main.cpp", R"cpp(
-export @kw[module] @mod[foo];
+export §(kw)⟦module⟧ §(mod)⟦foo⟧;
 )cpp");
     ASSERT_TRUE(compile("-std=c++20"));
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -536,7 +536,7 @@ export @kw[module] @mod[foo];
 
 TEST_CASE(ModuleDeclarationDotted) {
     add_main("main.cpp", R"cpp(
-export @kw[module] @m0[foo].@m1[bar];
+export §(kw)⟦module⟧ §(m0)⟦foo⟧.§(m1)⟦bar⟧;
 )cpp");
     ASSERT_TRUE(compile("-std=c++20"));
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -554,7 +554,7 @@ export module foo;
 export int x = 42;
 
 #[main.cpp]
-@kw[import] @mod[foo];
+§(kw)⟦import⟧ §(mod)⟦foo⟧;
 int y = x;
 )");
     ASSERT_TRUE(compile_with_modules());
@@ -567,7 +567,7 @@ int y = x;
 
 TEST_CASE(ModulePartition) {
     add_main("main.cpp", R"cpp(
-export module @m0[foo]:@m1[bar];
+export module §(m0)⟦foo⟧:§(m1)⟦bar⟧;
 )cpp");
     ASSERT_TRUE(compile("-std=c++20"));
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -585,7 +585,7 @@ export int x = 42;
 
 #[main.cppm]
 export module bar;
-export @kw[import] @mod[foo];
+export §(kw)⟦import⟧ §(mod)⟦foo⟧;
 )");
     ASSERT_TRUE(compile_with_modules());
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -598,7 +598,7 @@ export @kw[import] @mod[foo];
 TEST_CASE(GlobalModuleFragment) {
     add_main("main.cpp", R"cpp(
 module;
-export module @mod[foo];
+export module §(mod)⟦foo⟧;
 )cpp");
     ASSERT_TRUE(compile("-std=c++20"));
     tokens = feature::semantic_tokens(*unit, feature::PositionEncoding::UTF8);
@@ -609,7 +609,7 @@ export module @mod[foo];
 
 TEST_CASE(PrivateModuleFragment) {
     add_main("main.cpp", R"cpp(
-export module @mod[foo];
+export module §(mod)⟦foo⟧;
 module :private;
 int x = 1;
 )cpp");
@@ -623,10 +623,10 @@ int x = 1;
 TEST_CASE(ModuleKeywordAsIdentifier) {
     run_utf8(R"cpp(
 void f() {
-    struct @s0[module] {};
-    @s1[module] @v0[m];
-    int @v1[import] = 1;
-    int @v2[module] = 2;
+    struct §(s0)⟦module⟧ {};
+    §(s1)⟦module⟧ §(v0)⟦m⟧;
+    int §(v1)⟦import⟧ = 1;
+    int §(v2)⟦module⟧ = 2;
 }
 )cpp");
 

--- a/tests/unit/feature/signature_help_tests.cpp
+++ b/tests/unit/feature/signature_help_tests.cpp
@@ -32,7 +32,7 @@ void foo(int x);
 void foo(int x, int y);
 
 int main() {
-    foo($);
+    foo(§);
 }
 )cpp");
 

--- a/tests/unit/index/index_query_tests.cpp
+++ b/tests/unit/index/index_query_tests.cpp
@@ -113,12 +113,12 @@ std::vector<index::Relation> find_relations(index::SymbolHash symbol, RelationKi
 TEST_CASE(GoToDefinition) {
     reset();
     build_and_merge(R"(
-        int $(decl)foo();
+        int §(decl)foo();
 
-        int @def[$(def)foo]() { return 42; }
+        int §(def)⟦§(def)foo⟧() { return 42; }
 
         int main() {
-            return $(use)foo();
+            return §(use)foo();
         }
     )");
 
@@ -135,12 +135,12 @@ TEST_CASE(GoToDefinition) {
 TEST_CASE(FindReferences) {
     reset();
     build_and_merge(R"(
-        int $(decl)foo();
+        int §(decl)foo();
 
-        int $(def)foo() { return 42; }
+        int §(def)foo() { return 42; }
 
         int bar() {
-            return $(ref1)foo() + $(ref2)foo();
+            return §(ref1)foo() + §(ref2)foo();
         }
     )");
 
@@ -154,8 +154,8 @@ TEST_CASE(FindReferences) {
 TEST_CASE(DeclAndDef) {
     reset();
     build_and_merge(R"(
-        int $(decl)foo();
-        int @def[$(def)foo]() { return 42; }
+        int §(decl)foo();
+        int §(def)⟦§(def)foo⟧() { return 42; }
     )");
 
     auto hash = lookup_symbol("decl");
@@ -174,10 +174,10 @@ TEST_CASE(DeclAndDef) {
 TEST_CASE(CallerCallee) {
     reset();
     build_and_merge(R"(
-        void $(callee_def)callee() {}
+        void §(callee_def)callee() {}
 
-        void $(caller_def)caller() {
-            $(call_site)callee();
+        void §(caller_def)caller() {
+            §(call_site)callee();
         }
     )");
 
@@ -198,11 +198,11 @@ TEST_CASE(OverrideRelation) {
     reset();
     build_and_merge(R"(
         struct Base {
-            virtual void $(base_method)method() {}
+            virtual void §(base_method)method() {}
         };
 
         struct Derived : Base {
-            void $(derived_method)method() override {}
+            void §(derived_method)method() override {}
         };
     )");
 
@@ -224,11 +224,11 @@ TEST_CASE(OverrideRelation) {
 TEST_CASE(BaseAndDerived) {
     reset();
     build_and_merge(R"(
-        struct $(base_cls)Animal {
+        struct §(base_cls)Animal {
             virtual void speak() {}
         };
 
-        struct $(derived_cls)Dog : $(base_ref)Animal {
+        struct §(derived_cls)Dog : §(base_ref)Animal {
             void speak() override {}
         };
     )");
@@ -251,9 +251,9 @@ TEST_CASE(ClassTemplate) {
     reset();
     build_and_merge(R"(
         template <typename T>
-        struct @primary[$(primary)foo] {};
+        struct §(primary)⟦§(primary)foo⟧ {};
 
-        $(use)foo<int> x;
+        §(use)foo<int> x;
     )");
 
     auto hash = lookup_symbol("use");
@@ -266,9 +266,9 @@ TEST_CASE(ClassTemplate) {
 TEST_CASE(SymbolKinds) {
     reset();
     build_and_merge(R"(
-        struct $(cls)MyClass {};
-        void $(func)myFunc() {}
-        int $(var)myVar = 0;
+        struct §(cls)MyClass {};
+        void §(func)myFunc() {}
+        int §(var)myVar = 0;
     )");
 
     auto cls_hash = lookup_symbol("cls");
@@ -292,8 +292,8 @@ TEST_CASE(SymbolKinds) {
 TEST_CASE(ReferenceFiles) {
     reset();
     build_and_merge(R"(
-        int $(target)target = 42;
-        int a = $(ref)target + 1;
+        int §(target)target = 42;
+        int a = §(ref)target + 1;
     )");
 
     auto hash = lookup_symbol("target");
@@ -311,13 +311,13 @@ TEST_CASE(CrossFileQuery) {
 
     add_file("header.h", R"(
         #pragma once
-        int $(hdr_decl)helper();
+        int §(hdr_decl)helper();
     )");
     add_main("main.cpp", R"(
         #include "header.h"
 
         int main() {
-            return $(use_helper)helper();
+            return §(use_helper)helper();
         }
     )");
     ASSERT_TRUE(compile());
@@ -372,13 +372,13 @@ TEST_CASE(ImplementationDirection) {
     reset();
     build_and_merge(R"(
         struct Base {
-            virtual void $(base)draw();
+            virtual void §(base)draw();
         };
         struct Circle : Base {
-            void $(circle)draw() override;
+            void §(circle)draw() override;
         };
         struct Square : Circle {
-            void $(square)draw() override;
+            void §(square)draw() override;
         };
     )");
 
@@ -413,12 +413,12 @@ TEST_CASE(TypeDefinitionTargets) {
     /// relations at variable declarations carry the type's symbol hash.
     reset();
     build_and_merge(R"(
-        struct $(widget)Widget {};
-        using $(alias)Alias = Widget;
+        struct §(widget)Widget {};
+        using §(alias)Alias = Widget;
 
-        Widget $(plain)w;
-        Alias $(aliased)a;
-        auto $(deduced)b = Widget{};
+        Widget §(plain)w;
+        Alias §(aliased)a;
+        auto §(deduced)b = Widget{};
     )");
 
     auto widget = lookup_symbol("widget");

--- a/tests/unit/index/merged_index_tests.cpp
+++ b/tests/unit/index/merged_index_tests.cpp
@@ -110,8 +110,8 @@ TEST_CASE(RevisionAndFlipBack) {
 
 TEST_CASE(LookupByOffset) {
     build_index(R"(
-            int @func[$(func)foo]() { return 42; }
-            int bar() { return @ref[$(ref)foo](); }
+            int §(func)⟦§(func)foo⟧() { return 42; }
+            int bar() { return §(ref)⟦§(ref)foo⟧(); }
         )");
 
     // Merge the main file index into a MergedIndex.
@@ -133,8 +133,8 @@ TEST_CASE(LookupByOffset) {
 
 TEST_CASE(LookupBySymbolAndKind) {
     build_index(R"(
-            void $(target)target_func() {}
-            void caller() { $(call)target_func(); }
+            void §(target)target_func() {}
+            void caller() { §(call)target_func(); }
         )");
 
     index::MergedIndex merged;
@@ -392,7 +392,7 @@ TEST_CASE(RemergePreservesOtherTus) {
 
 TEST_CASE(CompactionDropsMasked) {
     build_index(R"(
-            int $(target)foo() { return 42; }
+            int §(target)foo() { return 42; }
         )");
 
     // Merge as compilation context, then remove: the rows are masked.
@@ -455,7 +455,7 @@ TEST_CASE(HasContributionTracking) {
 
 TEST_CASE(LookupFiltersRemoved) {
     build_index(R"(
-            int $(target)foo() { return 42; }
+            int §(target)foo() { return 42; }
         )");
 
     // Merge as compilation context.
@@ -487,7 +487,7 @@ TEST_CASE(LookupFiltersRemoved) {
 
 TEST_CASE(CacheInvalidatedAfterMerge) {
     build_index(R"(
-            int $(first)foo() { return 42; }
+            int §(first)foo() { return 42; }
         )");
 
     // Merge first TU as header context.
@@ -507,7 +507,7 @@ TEST_CASE(CacheInvalidatedAfterMerge) {
 
     // Build a second TU with different content.
     build_index(R"(
-            int $(second)bar() { return 99; }
+            int §(second)bar() { return 99; }
         )");
 
     // Merge second TU.

--- a/tests/unit/index/preamble_state_tests.cpp
+++ b/tests/unit/index/preamble_state_tests.cpp
@@ -58,7 +58,7 @@ index::SymbolHash hash_of(llvm::StringRef name,
 }
 
 TEST_CASE(ForcedIncludeServed) {
-    add_file("forced.h", R"(int @def[forced_value] = 1;)");
+    add_file("forced.h", R"(int §(def)⟦forced_value⟧ = 1;)");
     add_main("main.cpp", R"(int x = forced_value;)");
 
     // A compile-command forced include: clang records its include edge in
@@ -99,12 +99,12 @@ TEST_CASE(ForcedIncludeServed) {
 
 TEST_CASE(HeaderRelationLookup) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
-inline void bar() { @href[foo](); }
+inline void §(def)⟦foo⟧() {}
+inline void bar() { §(href)⟦foo⟧(); }
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[foo](); return 0; }
+int main() { §(ref)⟦foo⟧(); return 0; }
 )");
     build_state();
 
@@ -141,11 +141,11 @@ int main() { @ref[foo](); return 0; }
 
 TEST_CASE(PreambleLookup) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
+inline void §(def)⟦foo⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[$(ref)foo](); return 0; }
+int main() { §(ref)⟦§(ref)foo⟧(); return 0; }
 )");
     build_state();
 
@@ -173,11 +173,11 @@ int main() { @ref[$(ref)foo](); return 0; }
 
 TEST_CASE(SymbolTableLookup) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
+inline void §(def)⟦foo⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[foo](); return 0; }
+int main() { §(ref)⟦foo⟧(); return 0; }
 )");
     build_state();
 

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -102,10 +102,10 @@ void GO_TO_DEFINITION(llvm::StringRef pos,
 
 TEST_CASE(Basic) {
     build_index(R"(
-            int @1[f$(1)oo]();
+            int §(1)⟦f§(1)oo⟧();
 
-            int @2[b$(2)ar]() {
-                return @3[fo$(3)o]() + 1;
+            int §(2)⟦b§(2)ar⟧() {
+                return §(3)⟦fo§(3)o⟧() + 1;
             }
         )");
 
@@ -121,33 +121,33 @@ TEST_CASE(Basic) {
 TEST_CASE(ClassTemplate) {
     build_index(R"(
             template <typename T, typename U>
-            struct $(primary_decl)foo;
+            struct §(primary_decl)foo;
 
-            /// using type = $(forward_full)foo<int, int>;
+            /// using type = §(forward_full)foo<int, int>;
 
             template <typename T, typename U>
-            struct @primary[foo] {};
+            struct §(primary)⟦foo⟧ {};
 
             template <typename T>
-            struct $(partial_spec_decl)foo<T, T>;
+            struct §(partial_spec_decl)foo<T, T>;
 
             template <typename T>
-            struct @partial_spec[foo]<T, T> {};
+            struct §(partial_spec)⟦foo⟧<T, T> {};
 
             template <>
-            struct $(full_spec_decl)foo<int, int>;
+            struct §(full_spec_decl)foo<int, int>;
 
             template <>
-            struct @full_spec[foo]<int, int> {};
+            struct §(full_spec)⟦foo⟧<int, int> {};
 
-            template struct $(explicit_primary)foo<char, int>;
+            template struct §(explicit_primary)foo<char, int>;
 
-            template struct $(explicit_partial)foo<char, char>;
+            template struct §(explicit_partial)foo<char, char>;
 
-            $(implicit_primary_1)foo<int, char> b;
-            $(implicit_primary_2)foo<char, int> c;
-            $(implicit_partial)foo<char, char> d;
-            $(implicit_full)foo<int, int> a;
+            §(implicit_primary_1)foo<int, char> b;
+            §(implicit_primary_2)foo<char, int> c;
+            §(implicit_partial)foo<char, char> d;
+            §(implicit_full)foo<int, int> a;
         )");
 
     GO_TO_DEFINITION("primary_decl", "primary");
@@ -165,19 +165,19 @@ TEST_CASE(ClassTemplate) {
 
 TEST_CASE(FunctionTemplate) {
     build_index(R"(
-            template <typename T> void $(primary_decl)foo();
+            template <typename T> void §(primary_decl)foo();
 
-            template <typename T> void @primary[foo]() {}
+            template <typename T> void §(primary)⟦foo⟧() {}
 
-            template <> void $(spec_decl)foo<int>();
+            template <> void §(spec_decl)foo<int>();
 
-            template <> void @spec[foo]<int>() {}
+            template <> void §(spec)⟦foo⟧<int>() {}
 
-            template void $(explicit_primary)foo<char>();
+            template void §(explicit_primary)foo<char>();
 
             int main() {
-                $(implicit_primary)foo<char>();
-                $(implicit_spec)foo<int>();
+                §(implicit_primary)foo<char>();
+                §(implicit_spec)foo<int>();
             }
         )");
 
@@ -193,9 +193,9 @@ TEST_CASE(FunctionTemplate) {
 TEST_CASE(AliasTemplate) {
     build_index(R"(
             template <typename T>
-            using @primary[foo] = T;
+            using §(primary)⟦foo⟧ = T;
 
-            $(implicit_primary)foo<int> a;
+            §(implicit_primary)foo<int> a;
         )");
 
     GO_TO_DEFINITION("implicit_primary", "primary");
@@ -204,29 +204,29 @@ TEST_CASE(AliasTemplate) {
 TEST_CASE(VarTemplate) {
     build_index(R"(
             template <typename T, typename U>
-            extern int $(primary_decl)foo;
+            extern int §(primary_decl)foo;
 
             template <typename T, typename U>
-            int @primary[foo] = 1;
+            int §(primary)⟦foo⟧ = 1;
 
             template <typename T>
-            extern int $(partial_spec_decl)foo<T, T>;
+            extern int §(partial_spec_decl)foo<T, T>;
 
             template <typename T>
-            int @partial_spec[foo]<T, T> = 2;
+            int §(partial_spec)⟦foo⟧<T, T> = 2;
 
             template <>
-            float @full_spec[foo]<int, int> = 1.0f;
+            float §(full_spec)⟦foo⟧<int, int> = 1.0f;
 
-            template int $(explicit_primary)foo<char, int>;
+            template int §(explicit_primary)foo<char, int>;
 
-            template int $(explicit_partial)foo<char, char>;
+            template int §(explicit_partial)foo<char, char>;
 
             int main() {
-                $(implicit_primary_1)foo<int, char> = 1;
-                $(implicit_primary_2)foo<char, int> = 2;
-                $(implicit_partial)foo<char, char> = 3;
-                $(implicit_full)foo<int, int> = 4;
+                §(implicit_primary_1)foo<int, char> = 1;
+                §(implicit_primary_2)foo<char, int> = 2;
+                §(implicit_partial)foo<char, char> = 3;
+                §(implicit_full)foo<int, int> = 4;
                 return 0;
             }
         )");
@@ -244,11 +244,11 @@ TEST_CASE(VarTemplate) {
 TEST_CASE(Concept) {
     build_index(R"(
             template <typename T>
-            concept @primary[$(primary)foo] = true;
+            concept §(primary)⟦§(primary)foo⟧ = true;
 
-            static_assert($(implicit)foo<int>);
+            static_assert(§(implicit)foo<int>);
 
-            $(implicit2)foo auto bar = 1;
+            §(implicit2)foo auto bar = 1;
         )");
 
     GO_TO_DEFINITION("primary", "primary");
@@ -258,10 +258,10 @@ TEST_CASE(Concept) {
 
 TEST_CASE(Reference) {
     build_index(R"(
-            int $(decl)foo = 42;
+            int §(decl)foo = 42;
 
             int bar() {
-                return $(ref)foo + 1;
+                return §(ref)foo + 1;
             }
         )");
 
@@ -324,10 +324,10 @@ TEST_CASE(BaseAndDerived) {
 
 TEST_CASE(CallerAndCallee) {
     build_index(R"(
-            void $(callee_def)callee() {}
+            void §(callee_def)callee() {}
 
-            void $(caller_def)caller() {
-                $(call_site)callee();
+            void §(caller_def)caller() {
+                §(call_site)callee();
             }
         )");
 
@@ -408,9 +408,9 @@ TEST_CASE(OverrideRelation) {
 
 TEST_CASE(DeclarationAndDefinition) {
     build_index(R"(
-            int $(decl)foo();
+            int §(decl)foo();
 
-            int @def[$(def)foo]() { return 42; }
+            int §(def)⟦§(def)foo⟧() { return 42; }
         )");
 
     auto& index = tu_index.main_file_index;
@@ -440,13 +440,13 @@ TEST_CASE(DeclarationAndDefinition) {
 TEST_CASE(CrossFileHeaderIndex) {
     add_file("header.h", R"(
             #pragma once
-            int @hdr_func[$(hdr_func)helper]();
+            int §(hdr_func)⟦§(hdr_func)helper⟧();
         )");
     add_main("main.cpp", R"(
             #include "header.h"
 
             int main() {
-                return $(use_helper)helper();
+                return §(use_helper)helper();
             }
         )");
     ASSERT_TRUE(compile());
@@ -489,11 +489,11 @@ TEST_CASE(CrossFileHeaderIndex) {
 
 TEST_CASE(SymbolKinds) {
     build_index(R"(
-            struct $(cls)MyClass {};
-            enum $(enm)MyEnum { A, B };
-            void $(func)myFunc() {}
-            int $(var)myVar = 0;
-            namespace $(ns)MyNS {}
+            struct §(cls)MyClass {};
+            enum §(enm)MyEnum { A, B };
+            void §(func)myFunc() {}
+            int §(var)myVar = 0;
+            namespace §(ns)MyNS {}
         )");
 
     auto check_kind = [&](llvm::StringRef name, SymbolKind expected) {
@@ -575,8 +575,8 @@ TEST_CASE(snapshot) {
 
 TEST_CASE(LookupOccurrence) {
     build_index(R"(
-        int @x[fo$(x)o]();
-        int @ref[fo$(ref)o]() { return 0; }
+        int §(x)⟦fo§(x)o⟧();
+        int §(ref)⟦fo§(ref)o⟧() { return 0; }
     )");
 
     auto& fi = tu_index.main_file_index;
@@ -610,8 +610,8 @@ TEST_CASE(LookupOccurrence) {
 
 TEST_CASE(LookupRelation) {
     build_index(R"(
-        void @decl[fo$(decl)o]();
-        void @def[fo$(def)o]() {}
+        void §(decl)⟦fo§(decl)o⟧();
+        void §(def)⟦fo§(def)o⟧() {}
     )");
 
     auto& fi = tu_index.main_file_index;
@@ -717,7 +717,7 @@ struct Foo {
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int Foo::@def[$(1)find](int x) const { return 0; }
+int Foo::§(def)⟦§(1)find⟧(int x) const { return 0; }
 )");
     ASSERT_TRUE(compile_with_pch());
 
@@ -778,7 +778,7 @@ TEST_CASE(HeaderMacroDropped) {
 )");
     add_main("main.cpp", R"(
 #include "baz.h"
-int x = $(1)BAZ;
+int x = §(1)BAZ;
 )");
     ASSERT_TRUE(compile());
 

--- a/tests/unit/index/usr_tests.cpp
+++ b/tests/unit/index/usr_tests.cpp
@@ -81,13 +81,13 @@ TEST_SUITE(USR) {
 /// template <typename T> struct A;
 ///
 /// template <typename T> requires (__is_same(T, float))
-/// struct $(1)A<T>;
+/// struct §(1)A<T>;
 ///
 /// template <typename T> requires (__is_same(T, int))
-/// struct $(2)A<T>;
+/// struct §(2)A<T>;
 ///
 /// template <typename T> requires (std::same_as<T, double>)
-/// struct $(3)A<T> {};
+/// struct §(3)A<T> {};
 /// )cpp";
 ///
 ///     USRTester tester("main.cpp", content);
@@ -107,18 +107,18 @@ TEST_CASE(USRTemplateClassRequireClauseComplex) {
 template <typename T> struct A;
 
 template <typename T> requires (__is_same(T, float))
-struct $(1)A<T>;
+struct §(1)A<T>;
 
 using FLOAT = float;
 template <typename T> requires (__is_same(T, FLOAT))
-struct $(2)A<T>;
+struct §(2)A<T>;
 
 template <typename T> requires (__is_same(T, A<int>))
-struct $(11)A<T>;
+struct §(11)A<T>;
 template <typename T> requires (__is_same(T, A<float>))
-struct $(12)A<T>;
+struct §(12)A<T>;
 template <typename T> requires (__is_same(T, A<FLOAT>))
-struct $(13)A<T>;
+struct §(13)A<T>;
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -145,10 +145,10 @@ template<typename T, typename U>
 struct A;
 
 template<typename T, C U>
-struct $(1)A<T, U>;
+struct §(1)A<T, U>;
 
 template<C T, typename U>
-struct $(2)A<T, U>;
+struct §(2)A<T, U>;
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -163,14 +163,14 @@ struct $(2)A<T, U>;
 TEST_CASE(USRTemplateClassConceptConstraintPack) {
     llvm::StringRef content1 = R"cpp(
 template<typename... Ts>
-struct $(1)A;
+struct §(1)A;
 )cpp";
 
     llvm::StringRef content2 = R"cpp(
 template<typename T>
 concept C = requires(T t) { true; };
 template<C... Ts>
-struct $(2)A;
+struct §(2)A;
 )cpp";
 
     USRTester tester1("main.cpp", content1);
@@ -188,9 +188,9 @@ TEST_CASE(USRTemplateArgumentExpr) {
     llvm::StringRef content = R"cpp(
 template <typename T, int N> struct C;
 
-template <int N> struct $(1)C<float, N>;
-template <int M> struct $(2)C<float, M>;
-template <char c> struct $(3)C<float, c>;
+template <int N> struct §(1)C<float, N>;
+template <int M> struct §(2)C<float, M>;
+template <char c> struct §(3)C<float, c>;
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -207,10 +207,10 @@ template <char c> struct $(3)C<float, c>;
 TEST_CASE(USRTemplateFunctionRequireClause) {
     llvm::StringRef content = R"cpp(
 template<typename T>
-void $(1)func(T t) requires (sizeof(T) == 4) {};
+void §(1)func(T t) requires (sizeof(T) == 4) {};
 
 template<typename T>
-void $(2)func(T t) requires (sizeof(T) == 8) {};
+void §(2)func(T t) requires (sizeof(T) == 8) {};
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -225,14 +225,14 @@ void $(2)func(T t) requires (sizeof(T) == 8) {};
 TEST_CASE(USRTemplateVarConceptConstraint) {
     llvm::StringRef content1 = R"cpp(
 template <typename T>
-constexpr T $(1)pi = 3.14;
+constexpr T §(1)pi = 3.14;
 )cpp";
 
     llvm::StringRef content2 = R"cpp(
 template <typename T>
 concept integral = requires (T t) { t + 1; };
 template <integral T>
-constexpr T $(2)pi = 3;
+constexpr T §(2)pi = 3;
 )cpp";
 
     USRTester tester1("main.cpp", content1);
@@ -251,7 +251,7 @@ TEST_CASE(USRCTAD) {
 template<typename T>
 struct array {};
 template<typename U, array arr>
-struct $(1)L;
+struct §(1)L;
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -269,8 +269,8 @@ template<typename T> struct array {
   int x;
 };
 template<array U> struct L;
-template<> struct $(1)L<{1}>;
-template<> struct $(2)L<{2}>;
+template<> struct §(1)L<{1}>;
+template<> struct §(2)L<{2}>;
 )cpp";
 
     USRTester tester("main.cpp", content);
@@ -284,12 +284,12 @@ template<> struct $(2)L<{2}>;
 
 TEST_CASE(USRNTTPConstraint) {
     llvm::StringRef content1 = R"cpp(
-template<auto N> struct $(1)M;
+template<auto N> struct §(1)M;
 )cpp";
 
     llvm::StringRef content2 = R"cpp(
 template<typename T> concept C = requires {requires true;};
-template<C auto N> struct $(2)M;
+template<C auto N> struct §(2)M;
 )cpp";
 
     USRTester tester1("main.cpp", content1);
@@ -311,10 +311,10 @@ struct X {
     class Y;
 
     template <>
-    class $(1)Y<MetaFun::template apply>;
+    class §(1)Y<MetaFun::template apply>;
 
     template <>
-    class $(2)Y<MetaFun::template apply2>;
+    class §(2)Y<MetaFun::template apply2>;
 };
 )cpp";
 
@@ -332,10 +332,10 @@ TEST_CASE(USRDeducingThis) {
 class A {
 public:
     template <typename Self>
-    void $(1)foo(this Self&& s);
+    void §(1)foo(this Self&& s);
 
     template <typename Self>
-    void $(2)foo(Self&& s);
+    void §(2)foo(Self&& s);
 };
 )cpp";
 

--- a/tests/unit/semantic/selection_tests.cpp
+++ b/tests/unit/semantic/selection_tests.cpp
@@ -266,43 +266,43 @@ void EXPECT_SELECT(llvm::StringRef code, const char* kind) {
 TEST_CASE(Expressions) {
     EXPECT_SELECT(R"(
         struct AAA { struct BBB { static int ccc(); };};
-        int x = @[AAA::BBB::c$c$c]();
+        int x = §⟦AAA::BBB::c§c§c⟧();
     )",
                   "DeclRefExpr");
 
     EXPECT_SELECT(R"(
         struct AAA { struct BBB { static int ccc(); };};
-        int x = @[AAA::BBB::ccc($)];
+        int x = §⟦AAA::BBB::ccc(§)⟧;
     )",
                   "CallExpr");
 
     EXPECT_SELECT(R"(
         struct S {
           int foo() const;
-          int bar() { return @[f$oo](); }
+          int bar() { return §⟦f§oo⟧(); }
         };
     )",
                   "MemberExpr");
 
-    EXPECT_SELECT(R"(void foo() { @[$foo](); })", "DeclRefExpr");
-    EXPECT_SELECT(R"(void foo() { @[f$oo](); })", "DeclRefExpr");
-    EXPECT_SELECT(R"(void foo() { @[fo$o](); })", "DeclRefExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦§foo⟧(); })", "DeclRefExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦f§oo⟧(); })", "DeclRefExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦fo§o⟧(); })", "DeclRefExpr");
 
-    EXPECT_SELECT(R"(void foo() { @[foo$] (); })", "DeclRefExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦foo§⟧ (); })", "DeclRefExpr");
 
-    EXPECT_SELECT(R"(void foo() { @[foo$()]; })", "CallExpr");
-    EXPECT_SELECT(R"(void foo() { @[foo$()]; /*comment*/$})", "CallExpr");
-    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[ @[$x] ][10][y];)", "DeclRefExpr");
-    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[x][10][ @[$y] ];)", "DeclRefExpr");
-    EXPECT_SELECT(R"(void func(int x) { int v_array[ @[$x] ][10]; })", "DeclRefExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦foo§()()⟧; })", "CallExpr");
+    EXPECT_SELECT(R"(void foo() { §⟦foo§()()⟧; /*comment*/§})", "CallExpr");
+    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[ §⟦§x⟧ ][10][y];)", "DeclRefExpr");
+    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[x][10][ §⟦§y⟧ ];)", "DeclRefExpr");
+    EXPECT_SELECT(R"(void func(int x) { int v_array[ §⟦§x⟧ ][10]; })", "DeclRefExpr");
     EXPECT_SELECT(R"(
         int a;
-        decltype(@[$a] + a) b;
+        decltype(§⟦§a⟧ + a) b;
     )",
                   "DeclRefExpr");
 
     EXPECT_SELECT(R"(
-        void func() { @[__$func__]; }
+        void func() { §⟦__§func__⟧; }
     )",
                   "PredefinedExpr");
 }
@@ -310,33 +310,33 @@ TEST_CASE(Expressions) {
 TEST_CASE(Literals) {
     EXPECT_SELECT(R"(
         auto lambda = [](const char*){ return 0; };
-        int x = lambda(@["y$"]);
+        int x = lambda(§⟦"y§"⟧);
     )",
                   "StringLiteral");
 
-    EXPECT_SELECT(R"(int x = @[42]$;)", "IntegerLiteral");
-    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[x][ @[$10] ][y];)", "IntegerLiteral");
+    EXPECT_SELECT(R"(int x = §⟦42⟧§;)", "IntegerLiteral");
+    EXPECT_SELECT(R"(const int x = 1, y = 2; int array[x][ §⟦§10⟧ ][y];)", "IntegerLiteral");
 
     EXPECT_SELECT(R"(
         struct Foo{};
         Foo operator""_ud(unsigned long long);
-        Foo x = @[$12_ud];
+        Foo x = §⟦§12_ud⟧;
     )",
                   "UserDefinedLiteral");
 }
 
 TEST_CASE(ControlFlow) {
     EXPECT_SELECT(R"(
-        void foo() { @[if (1$11) { return; } else {$ }]} }
+        void foo() { §⟦if (1§11) { return; } else {§ }⟧} }
     )",
                   "IfStmt");
 
-    EXPECT_SELECT(R"(int bar; void foo() @[{ foo (); }]$)", "CompoundStmt");
+    EXPECT_SELECT(R"(int bar; void foo() §⟦{ foo (); }⟧§)", "CompoundStmt");
 
     /// FIXME:
     /// EXPECT_SELECT(R"(
     ///     /*error-ok*/
-    ///     void func() @[{^])",
+    ///     void func() §⟦{^⟧)",
     ///               "CompoundStmt");
 
     EXPECT_SELECT(R"(
@@ -346,7 +346,7 @@ TEST_CASE(ControlFlow) {
         };
         Str makeStr(const char*);
         void loop() {
-          for (const char C : @[mak$eStr("foo"$)])
+          for (const char C : §⟦mak§eStr("foo"§)⟧)
             ;
         }
     )",
@@ -357,39 +357,39 @@ TEST_CASE(Declarations) {
     /// FIXME: how to handle this?
     /// EXPECT_SELECT(R"(
     ///      #define TARGET void foo()
-    ///      @[TAR$GET{ return; }]
+    ///      §⟦TAR§GET{ return; }⟧
     ///      )",
     ///              "FunctionDecl");
 
-    EXPECT_SELECT(R"(@[$void foo$()];)", "FunctionDecl");
-    EXPECT_SELECT(R"(@[void $foo()];)", "FunctionDecl");
+    EXPECT_SELECT(R"(§⟦§void foo§()()⟧;)", "FunctionDecl");
+    EXPECT_SELECT(R"(§⟦void §foo()⟧;)", "FunctionDecl");
 
     EXPECT_SELECT(R"(
         struct S { S(const char*); };
-        @[S s $= "foo"];
+        §⟦S s §= "foo"⟧;
     )",
                   "VarDecl");
 
     EXPECT_SELECT(R"(
         struct S { S(const char*); };
-        @[S $s = "foo"];
+        §⟦S §s = "foo"⟧;
     )",
                   "VarDecl");
 
     EXPECT_SELECT(R"(
-        @[void (*$S)(int) = nullptr];
+        §⟦void (*§S)(int) = nullptr⟧;
     )",
                   "VarDecl");
 
-    EXPECT_SELECT(R"(@[int $a], b;)", "VarDecl");
-    EXPECT_SELECT(R"(@[int a, $b];)", "VarDecl");
-    EXPECT_SELECT(R"(@[struct {int x;} $y];)", "VarDecl");
-    EXPECT_SELECT(R"(struct foo { @[int has$h<:32:>]; };)", "FieldDecl");
-    EXPECT_SELECT(R"(struct {@[int $x];} y;)", "FieldDecl");
+    EXPECT_SELECT(R"(§⟦int §a⟧, b;)", "VarDecl");
+    EXPECT_SELECT(R"(§⟦int a, §b⟧;)", "VarDecl");
+    EXPECT_SELECT(R"(§⟦struct {int x;} §y⟧;)", "VarDecl");
+    EXPECT_SELECT(R"(struct foo { §⟦int has§h<:32:>⟧; };)", "FieldDecl");
+    EXPECT_SELECT(R"(struct {§⟦int §x⟧;} y;)", "FieldDecl");
 
     EXPECT_SELECT(R"(
         void test(int bar) {
-        auto l = [ $@[foo = bar] ] { };
+        auto l = [ §§⟦foo = bar⟧ ] { };
     })",
                   "VarDecl");
 }
@@ -397,44 +397,44 @@ TEST_CASE(Declarations) {
 TEST_CASE(Types) {
     EXPECT_SELECT(R"(
         struct AAA { struct BBB { static int ccc(); };};
-        int x = AAA::@[B$B$B]::ccc();
+        int x = AAA::§⟦B§B§B⟧::ccc();
     )",
                   "RecordTypeLoc");
     EXPECT_SELECT(R"(
         struct AAA { struct BBB { static int ccc(); };};
-        int x = AAA::@[B$BB$]::ccc();
+        int x = AAA::§⟦B§BB§⟧::ccc();
     )",
                   "RecordTypeLoc");
     EXPECT_SELECT(R"(
         struct Foo {};
-        struct Bar : private @[Fo$o] {};
+        struct Bar : private §⟦Fo§o⟧ {};
     )",
                   "RecordTypeLoc");
     EXPECT_SELECT(R"(
         struct Foo {};
-        struct Bar : @[Fo$o] {};
+        struct Bar : §⟦Fo§o⟧ {};
     )",
                   "RecordTypeLoc");
-    EXPECT_SELECT(R"(@[$void] (*S)(int) = nullptr;)", "BuiltinTypeLoc");
-    /// EXPECT_SELECT(R"(@[void (*S)$(int)] = nullptr;)", "FunctionProtoTypeLoc");
-    EXPECT_SELECT(R"(@[void ($*S)(int)] = nullptr;)", "PointerTypeLoc");
-    /// EXPECT_SELECT(R"(@[void $(*S)(int)] = nullptr;)", "ParenTypeLoc");
-    EXPECT_SELECT(R"(@[$void] foo();)", "BuiltinTypeLoc");
-    EXPECT_SELECT(R"(@[void foo$()];)", "FunctionProtoTypeLoc");
-    EXPECT_SELECT(R"(const int x = 1, y = 2; @[i$nt] array[x][10][y];)", "BuiltinTypeLoc");
-    EXPECT_SELECT(R"(int (*getFunc(@[do$uble]))(int);)", "BuiltinTypeLoc");
-    EXPECT_SELECT(R"(class X{}; @[int X::$*]y[10];)", "MemberPointerTypeLoc");
-    EXPECT_SELECT(R"(const @[a$uto] x = 42;)", "AutoTypeLoc");
-    /// EXPECT_SELECT(R"(@[decltype$(1)] b;)", "DecltypeTypeLoc");
-    EXPECT_SELECT(R"(@[de$cltype(a$uto)] a = 1;)", "AutoTypeLoc");
+    EXPECT_SELECT(R"(§⟦§void⟧ (*S)(int) = nullptr;)", "BuiltinTypeLoc");
+    /// EXPECT_SELECT(R"(§⟦void (*S)§()(int)⟧ = nullptr;)", "FunctionProtoTypeLoc");
+    EXPECT_SELECT(R"(§⟦void (§*S)(int)⟧ = nullptr;)", "PointerTypeLoc");
+    /// EXPECT_SELECT(R"(§⟦void §()(*S)(int)⟧ = nullptr;)", "ParenTypeLoc");
+    EXPECT_SELECT(R"(§⟦§void⟧ foo();)", "BuiltinTypeLoc");
+    EXPECT_SELECT(R"(§⟦void foo§()()⟧;)", "FunctionProtoTypeLoc");
+    EXPECT_SELECT(R"(const int x = 1, y = 2; §⟦i§nt⟧ array[x][10][y];)", "BuiltinTypeLoc");
+    EXPECT_SELECT(R"(int (*getFunc(§⟦do§uble⟧))(int);)", "BuiltinTypeLoc");
+    EXPECT_SELECT(R"(class X{}; §⟦int X::§*⟧y[10];)", "MemberPointerTypeLoc");
+    EXPECT_SELECT(R"(const §⟦a§uto⟧ x = 42;)", "AutoTypeLoc");
+    /// EXPECT_SELECT(R"(§⟦decltype§()(1)⟧ b;)", "DecltypeTypeLoc");
+    EXPECT_SELECT(R"(§⟦de§cltype(a§uto)⟧ a = 1;)", "AutoTypeLoc");
     EXPECT_SELECT(R"(
         typedef int Foo;
-        enum Bar : @[Fo$o] {};
+        enum Bar : §⟦Fo§o⟧ {};
     )",
                   "TypedefTypeLoc");
     EXPECT_SELECT(R"(
         typedef int Foo;
-        enum Bar : @[Fo$o];
+        enum Bar : §⟦Fo§o⟧;
     )",
                   "TypedefTypeLoc");
 }
@@ -442,32 +442,32 @@ TEST_CASE(Types) {
 TEST_CASE(CXXFeatures) {
     EXPECT_SELECT(R"(
           template <typename T>
-          int x = @[T::$U::]ccc();
+          int x = §⟦T::§U::⟧ccc();
           )",
                   "NestedNameSpecifierLoc");
     EXPECT_SELECT(R"(
           struct Foo {};
-          struct Bar : @[v$ir$tual private Foo] {};
+          struct Bar : §⟦v§ir§tual private Foo⟧ {};
           )",
                   "CXXBaseSpecifier");
     EXPECT_SELECT(R"(
           struct X { X(int); };
           class Y {
             X x;
-            Y() : @[$x(4)] {}
+            Y() : §⟦§x(4)⟧ {}
           };
           )",
                   "CXXCtorInitializer");
-    EXPECT_SELECT(R"(@[st$ruct {int x;}] y;)", "CXXRecordDecl");
-    EXPECT_SELECT(R"(struct foo { @[op$erator int()]; };)", "CXXConversionDecl");
-    EXPECT_SELECT(R"(struct foo { @[$~foo()]; };)", "CXXDestructorDecl");
-    EXPECT_SELECT(R"(struct foo { @[~$foo()]; };)", "CXXDestructorDecl");
-    EXPECT_SELECT(R"(struct foo { @[fo$o(){}] };)", "CXXConstructorDecl");
+    EXPECT_SELECT(R"(§⟦st§ruct {int x;}⟧ y;)", "CXXRecordDecl");
+    EXPECT_SELECT(R"(struct foo { §⟦op§erator int()⟧; };)", "CXXConversionDecl");
+    EXPECT_SELECT(R"(struct foo { §⟦§~foo()⟧; };)", "CXXDestructorDecl");
+    EXPECT_SELECT(R"(struct foo { §⟦~§foo()⟧; };)", "CXXDestructorDecl");
+    EXPECT_SELECT(R"(struct foo { §⟦fo§o(){}⟧ };)", "CXXConstructorDecl");
     EXPECT_SELECT(R"(
         struct S1 { void f(); };
         struct S2 { S1 * operator->(); };
         void test(S2 s2) {
-          s2@[-$>]f();
+          s2§⟦-§>⟧f();
         }
       )",
                   "DeclRefExpr");  // Test for overloaded operator->
@@ -476,47 +476,47 @@ TEST_CASE(CXXFeatures) {
 TEST_CASE(UsingEnum) {
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
-        using enum ns::@[$A];
+        using enum ns::§⟦§A⟧;
         )",
                   "EnumTypeLoc");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; using B = A; };
-        using enum ns::@[$B];
+        using enum ns::§⟦§B⟧;
         )",
                   "TypedefTypeLoc");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
-        using enum @[$ns::]A;
+        using enum §⟦§ns::⟧A;
         )",
                   "NestedNameSpecifierLoc");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
-        @[using $enum ns::A];
+        §⟦using §enum ns::A⟧;
         )",
                   "UsingEnumDecl");
     EXPECT_SELECT(R"(
         namespace ns { enum class A {}; };
-        @[$using enum ns::A];
+        §⟦§using enum ns::A⟧;
         )",
                   "UsingEnumDecl");
 }
 
 TEST_CASE(Templates) {
-    EXPECT_SELECT(R"(template<typename ...T> void foo(@[T*$...]x);)", "PackExpansionTypeLoc");
-    EXPECT_SELECT(R"(template<typename ...T> void foo(@[$T]*...x);)", "TemplateTypeParmTypeLoc");
-    EXPECT_SELECT(R"(template <typename T> void foo() { @[$T] t; })", "TemplateTypeParmTypeLoc");
+    EXPECT_SELECT(R"(template<typename ...T> void foo(§⟦T*§...⟧x);)", "PackExpansionTypeLoc");
+    EXPECT_SELECT(R"(template<typename ...T> void foo(§⟦§T⟧*...x);)", "TemplateTypeParmTypeLoc");
+    EXPECT_SELECT(R"(template <typename T> void foo() { §⟦§T⟧ t; })", "TemplateTypeParmTypeLoc");
     EXPECT_SELECT(R"(
           template <class T> struct Foo {};
-          template <@[template<class> class /*cursor here*/$U]>
+          template <§⟦template<class> class /*cursor here*/§U⟧>
             struct Foo<U<int>*> {};
           )",
                   "TemplateTemplateParmDecl");
-    EXPECT_SELECT(R"(template <class T> struct foo { ~foo<@[$T]>(){} };)",
+    EXPECT_SELECT(R"(template <class T> struct foo { ~foo<§⟦§T⟧>(){} };)",
                   "TemplateTypeParmTypeLoc");
     EXPECT_SELECT(R"(
         template <typename> class Vector {};
         template <template <typename> class Container> class A {};
-        A<@[V$ector]> a;
+        A<§⟦V§ector⟧> a;
       )",
                   "TemplateArgumentLoc");
 }
@@ -524,45 +524,45 @@ TEST_CASE(Templates) {
 TEST_CASE(Concepts) {
     EXPECT_SELECT(R"(
         template <class> concept C = true;
-        auto x = @[$C<int>];
+        auto x = §⟦§C<int>⟧;
       )",
                   "ConceptReference");
     EXPECT_SELECT(R"(
         template <class> concept C = true;
-        @[$C] auto x = 0;
+        §⟦§C⟧ auto x = 0;
       )",
                   "ConceptReference");
     EXPECT_SELECT(R"(
         template <class> concept C = true;
-        void foo(@[$C] auto x) {}
+        void foo(§⟦§C⟧ auto x) {}
       )",
                   "ConceptReference");
     EXPECT_SELECT(R"(
         template <class> concept C = true;
-        template <@[$C] x> int i = 0;
+        template <§⟦§C⟧ x> int i = 0;
       )",
                   "ConceptReference");
     EXPECT_SELECT(R"(
         namespace ns { template <class> concept C = true; }
-        auto x = @[ns::$C<int>];
+        auto x = §⟦ns::§C<int>⟧;
       )",
                   "ConceptReference");
     EXPECT_SELECT(R"(
         template <typename T, typename K>
         concept D = true;
-        template <typename T> void g(D<@[$T]> auto abc) {}
+        template <typename T> void g(D<§⟦§T⟧> auto abc) {}
       )",
                   "TemplateTypeParmTypeLoc");
 }
 
 TEST_CASE(Attributes) {
     EXPECT_SELECT(R"(
-        void f(int * __attribute__((@[no$nnull])) );
+        void f(int * __attribute__((§⟦no§nnull⟧)) );
       )",
                   "NonNullAttr");
     EXPECT_SELECT(R"(
         // Digraph syntax for attributes to avoid accidental annotations.
-        class [[gsl::Owner( @[in$t] )]] X{};
+        class [[gsl::Owner( §⟦in§t⟧ )]] X{};
       )",
                   "BuiltinTypeLoc");
 }
@@ -572,25 +572,25 @@ TEST_CASE(Macros) {
             int x(int);
             #define M(foo) x(foo)
             int a = 42;
-            int b = M(@[$a]);
+            int b = M(§⟦§a⟧);
             )",
                   "DeclRefExpr");
     EXPECT_SELECT(R"(
             void foo();
             #define CALL_FUNCTION(X) X()
-            void bar() { CALL_FUNCTION(@[f$o$o]); }
+            void bar() { CALL_FUNCTION(§⟦f§o§o⟧); }
             )",
                   "DeclRefExpr");
     EXPECT_SELECT(R"(
             void foo();
             #define CALL_FUNCTION(X) X()
-            void bar() { @[CALL_FUNC$TION(fo$o)]; }
+            void bar() { §⟦CALL_FUNC§TION(fo§o)⟧; }
             )",
                   "CallExpr");
     EXPECT_SELECT(R"(
             void foo();
             #define CALL_FUNCTION(X) X()
-            void bar() { @[C$ALL_FUNC$TION(foo)]; }
+            void bar() { §⟦C§ALL_FUNC§TION(foo)⟧; }
             )",
                   "CallExpr");
 }
@@ -598,34 +598,34 @@ TEST_CASE(Macros) {
 TEST_CASE(NullOrInvalid) {
     EXPECT_SELECT(R"(
               void foo();
-              #$define CALL_FUNCTION(X) X($)
+              #§define CALL_FUNCTION(X) X(§)
               void bar() { CALL_FUNCTION(foo); }
               )",
                   nullptr);
     EXPECT_SELECT(R"(
               void foo();
               #define CALL_FUNCTION(X) X()
-              void bar() { CALL_FUNCTION(foo$)$; }
+              void bar() { CALL_FUNCTION(foo§)§; }
               )",
                   nullptr);
     EXPECT_SELECT(R"(
               namespace ns {
               #if 0
-              void fo$o() {}
+              void fo§o() {}
               #endif
               }
               )",
                   nullptr);
-    EXPECT_SELECT(R"(co$nst auto x = 42;)", nullptr);
-    EXPECT_SELECT(R"($)", nullptr);
-    EXPECT_SELECT(R"(int x = 42;$)", nullptr);
-    EXPECT_SELECT(R"($int x; int y;$)", nullptr);
-    EXPECT_SELECT(R"(void foo() { @[foo$] (); })",
+    EXPECT_SELECT(R"(co§nst auto x = 42;)", nullptr);
+    EXPECT_SELECT(R"(§)", nullptr);
+    EXPECT_SELECT(R"(int x = 42;§)", nullptr);
+    EXPECT_SELECT(R"(§int x; int y;§)", nullptr);
+    EXPECT_SELECT(R"(void foo() { §⟦foo§⟧ (); })",
                   "DeclRefExpr");  // Technically valid, but tricky
 }
 
 TEST_CASE(InjectedClassName) {
-    llvm::StringRef code = "struct $X { int x; };";
+    llvm::StringRef code = "struct §X { int x; };";
     select_right(code, [&](SelectionTree& tree) {
         auto ancestor = tree.common_ancestor();
         ASSERT_EQ(ancestor->kind(), llvm::StringRef("CXXRecordDecl"));
@@ -661,7 +661,7 @@ while (0)
 
 #[main.cpp]
 void test() {
-#include "exp$and.inc"
+#include "exp§and.inc"
   break;
 }
 )";
@@ -681,7 +681,7 @@ TEST_CASE(Implicit) {
     llvm::StringRef code = R"cpp(
     struct S { S(const char*); };
     int f(S);
-    int x = f("$");
+    int x = f("§");
   )cpp";
 
     select_right(code, [&](SelectionTree& tree) {
@@ -701,7 +701,7 @@ TEST_CASE(Implicit) {
 TEST_CASE(DeclContextIsLexical) {
     llvm::StringRef code = R"cpp(
 namespace a {
-    void f$oo();
+    void f§oo();
 }
 
 void a::foo() { }
@@ -717,7 +717,7 @@ namespace a {
     void foo();
 }
 
-void a::f$oo() { }
+void a::f§oo() { }
   )cpp";
 
     select_right(code, [&](SelectionTree& tree) {
@@ -730,7 +730,7 @@ TEST_CASE(DeclContextLambda) {
     llvm::StringRef code = R"cpp(
 void foo();
 auto lambda = [] {
-  return $foo();
+  return §foo();
 };
   )cpp";
 
@@ -749,9 +749,9 @@ concept Foo = true;
 
 using ns::Foo;
 
-template <Fo$o... T, Fo$o auto U>
-auto Func(Fo$o auto V) -> Fo$o decltype(auto) {
-  Fo$o auto W = V;
+template <Fo§o... T, Fo§o auto U>
+auto Func(Fo§o auto V) -> Fo§o decltype(auto) {
+  Fo§o auto W = V;
   return W;
 }
   )cpp";

--- a/tests/unit/server/query_freshness_tests.cpp
+++ b/tests/unit/server/query_freshness_tests.cpp
@@ -117,7 +117,7 @@ TEST_CASE(PendingGateSplitsRows) {
     add_main("main.cpp", R"(
         #include "header.h"
         int main() {
-            return $(use)helper();
+            return §(use)helper();
         }
     )");
     ASSERT_TRUE(compile());

--- a/tests/unit/server/query_overlay_tests.cpp
+++ b/tests/unit/server/query_overlay_tests.cpp
@@ -140,11 +140,11 @@ protocol::Position position_of(llvm::StringRef name) {
 
 TEST_CASE(DefinitionFromOverlayOnly) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
+inline void §(def)⟦foo⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[$(ref)foo](); return 0; }
+int main() { §(ref)⟦§(ref)foo⟧(); return 0; }
 )");
     open_with_overlay();
 
@@ -160,12 +160,12 @@ int main() { @ref[$(ref)foo](); return 0; }
 
 TEST_CASE(ReferencesUnionWithDedup) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
-inline void bar() { @href[$(href)foo](); }
+inline void §(def)⟦foo⟧() {}
+inline void bar() { §(href)⟦§(href)foo⟧(); }
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[$(ref)foo](); return 0; }
+int main() { §(ref)⟦§(ref)foo⟧(); return 0; }
 )");
     open_with_overlay();
     // The header's disk shard and the overlay now both carry the
@@ -191,7 +191,7 @@ int main() { @ref[$(ref)foo](); return 0; }
 }
 
 TEST_CASE(PreambleMacroCursor) {
-    add_main("main.cpp", R"(#define @macro[$(macro)FOO] 1
+    add_main("main.cpp", R"(#define §(macro)⟦§(macro)FOO⟧ 1
 int main() { return 0; }
 )");
     open_with_overlay();
@@ -210,12 +210,12 @@ int main() { return 0; }
 
 TEST_CASE(OverlaySymbolInfo) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
-inline void @bardef[bar]() { foo(); }
+inline void §(def)⟦foo⟧() {}
+inline void §(bardef)⟦bar⟧() { foo(); }
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[foo](); return 0; }
+int main() { §(ref)⟦foo⟧(); return 0; }
 )");
     open_with_overlay();
 
@@ -236,12 +236,12 @@ int main() { @ref[foo](); return 0; }
 
 TEST_CASE(OpenHeaderExcluded) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
-inline void bar() { @href[foo](); }
+inline void §(def)⟦foo⟧() {}
+inline void bar() { §(href)⟦foo⟧(); }
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[$(ref)foo](); return 0; }
+int main() { §(ref)⟦§(ref)foo⟧(); return 0; }
 )");
     open_with_overlay();
 
@@ -260,12 +260,12 @@ int main() { @ref[$(ref)foo](); return 0; }
 
 TEST_CASE(IncomingCallsDedup) {
     add_file("foo.h", R"(
-inline void @def[callee]() {}
-inline void caller() { @call[callee](); }
+inline void §(def)⟦callee⟧() {}
+inline void caller() { §(call)⟦callee⟧(); }
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @mcall[$(mcall)callee](); return 0; }
+int main() { §(mcall)⟦§(mcall)callee⟧(); return 0; }
 )");
     open_with_overlay();
     // The header call site now exists in both its disk shard and the
@@ -281,11 +281,11 @@ int main() { @mcall[$(mcall)callee](); return 0; }
 
 TEST_CASE(OpenHeaderTargetsExcluded) {
     add_file("base.h", R"(
-struct @b[Base] {};
+struct §(b)⟦Base⟧ {};
 )");
     add_file("derived.h", R"(
 #include "base.h"
-struct @d[Derived] : Base {};
+struct §(d)⟦Derived⟧ : Base {};
 )");
     add_main("main.cpp", R"(
 #include "derived.h"
@@ -307,11 +307,11 @@ Derived instance;
 
 TEST_CASE(StaleHeaderSuppressed) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
+inline void §(def)⟦foo⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[foo](); return 0; }
+int main() { §(ref)⟦foo⟧(); return 0; }
 )");
     open_with_overlay();
 
@@ -326,7 +326,7 @@ int main() { @ref[foo](); return 0; }
 }
 
 TEST_CASE(MacroDefinitionText) {
-    add_main("main.cpp", R"(#define @macro[FOO] 1
+    add_main("main.cpp", R"(#define §(macro)⟦FOO⟧ 1
 int main() { return 0; }
 )");
     ASSERT_TRUE(compile());
@@ -341,7 +341,7 @@ int main() { return 0; }
 }
 
 TEST_CASE(SharedPreambleScoped) {
-    add_main("main.cpp", R"(#define @macro[$(macro)FOO] 1
+    add_main("main.cpp", R"(#define §(macro)⟦§(macro)FOO⟧ 1
 #if FOO
 #endif
 int main() { return 0; }
@@ -370,7 +370,7 @@ int main() { return 0; }
 }
 
 TEST_CASE(DirtyPreambleServed) {
-    add_main("main.cpp", R"(#define @macro[FOO] 1
+    add_main("main.cpp", R"(#define §(macro)⟦FOO⟧ 1
 int main() { return 0; }
 )");
     open_with_overlay();
@@ -387,7 +387,7 @@ int main() { return 0; }
 }
 
 TEST_CASE(PreambleDriftSkipped) {
-    add_main("main.cpp", R"(#define @macro[FOO] 1
+    add_main("main.cpp", R"(#define §(macro)⟦FOO⟧ 1
 int main() { return 0; }
 )");
     open_with_overlay();
@@ -404,11 +404,11 @@ int main() { return 0; }
 
 TEST_CASE(OverlayOutranksDisk) {
     add_file("foo.h", R"(
-inline void @def[foo]() {}
+inline void §(def)⟦foo⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "foo.h"
-int main() { @ref[foo](); return 0; }
+int main() { §(ref)⟦foo⟧(); return 0; }
 )");
     open_with_overlay();
 
@@ -434,11 +434,11 @@ int main() { @ref[foo](); return 0; }
 TEST_CASE(SynthesizedArtifactSkipped) {
     workspace.config.project.cache_dir = TestVFS::root();
     add_file("header_context/gen.h", R"(
-inline void @def[gen]() {}
+inline void §(def)⟦gen⟧() {}
 )");
     add_main("main.cpp", R"(
 #include "header_context/gen.h"
-int main() { @ref[gen](); return 0; }
+int main() { §(ref)⟦gen⟧(); return 0; }
 )");
     open_with_overlay();
 

--- a/tests/unit/test/annotation.cpp
+++ b/tests/unit/test/annotation.cpp
@@ -2,6 +2,8 @@
 
 #include <cctype>
 
+#include "support/logging.h"
+
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -51,17 +53,23 @@ AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
             llvm::StringRef key;
             if(i < content.size() && content[i] == '(') {
                 std::size_t key_end = content.find(')', i + 1);
-                assert(key_end != llvm::StringRef::npos && "Unterminated §(name).");
+                // Malformed annotations abort in every build mode: an
+                // assert-only guard would let NDEBUG wrap `i` past npos
+                // and loop forever.
+                if(key_end == llvm::StringRef::npos) {
+                    LOG_FATAL("Unterminated §(name) in annotated source.");
+                }
                 key = content.slice(i + 1, key_end);
                 // A name must be a plain identifier (or empty): `§` directly
                 // before a real parenthesized expression is ambiguous — write
                 // the explicit nameless form `§()` in front of it instead.
-                assert(llvm::all_of(key,
-                                    [](char c) {
-                                        return std::isalnum(static_cast<unsigned char>(c)) ||
-                                               c == '_';
-                                    }) &&
-                       "§(name) requires an identifier name; use §() for a nameless point.");
+                if(!llvm::all_of(key, [](char c) {
+                       return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+                   })) {
+                    LOG_FATAL(
+                        "§({}) is not an identifier name; use §() for a nameless " "point before real parentheses.",
+                        key);
+                }
                 i = static_cast<std::uint32_t>(key_end) + 1;
             }
 
@@ -77,21 +85,27 @@ AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
         }
 
         if(rest.starts_with(close_mark)) {
-            assert(!stack.empty() && "`⟧` without a matching `§⟦`.");
+            if(stack.empty()) {
+                LOG_FATAL("`⟧` without a matching `§⟦` in annotated source.");
+            }
             OpenSpan span = stack.pop_back_val();
             ranges.try_emplace(span.key, LocalSourceRange{span.begin, offset});
             i += close_mark.size();
             continue;
         }
 
-        assert(!rest.starts_with(open_mark) && "`⟦` must follow `§` or `§(name)`.");
+        if(rest.starts_with(open_mark)) {
+            LOG_FATAL("`⟦` must follow `§` or `§(name)`.");
+        }
 
         source += content[i];
         offset += 1;
         i += 1;
     }
 
-    assert(stack.empty() && "Unclosed `§⟦` annotation at end of input.");
+    if(!stack.empty()) {
+        LOG_FATAL("Unclosed `§⟦` annotation at end of input.");
+    }
 
     return AnnotatedSource{
         std::move(source),

--- a/tests/unit/test/annotation.cpp
+++ b/tests/unit/test/annotation.cpp
@@ -2,8 +2,24 @@
 
 #include <cctype>
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
 namespace clice::testing {
 
+/// The annotation grammar reserves no ASCII character: the sigil is `§`
+/// (U+00A7) and range bodies are delimited by `⟦` / `⟧` (U+27E6 / U+27E7),
+/// none of which occur in real C++, Doxygen, Markdown, CMake or LSP
+/// snippet content. ASCII parentheses are safe for names because they only
+/// have meaning directly after the sigil:
+///
+///   §              nameless point       §(name)          named point
+///   §⟦...⟧         nameless range       §(name)⟦...⟧     named range
+///
+/// Ranges may nest. Everything else — Doxygen tags, array subscripts,
+/// `${1:...}` snippet placeholders — is ordinary source text and passes
+/// through untouched. A stray `⟦` or `⟧` is a hard error so that typos
+/// fail loudly instead of silently shifting offsets.
 AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
     std::string source;
     source.reserve(content.size());
@@ -12,95 +28,70 @@ AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
     llvm::StringMap<LocalSourceRange> ranges;
     std::vector<std::uint32_t> nameless_offsets;
 
+    constexpr llvm::StringRef sigil = "§";
+    constexpr llvm::StringRef open_mark = "⟦";
+    constexpr llvm::StringRef close_mark = "⟧";
+
+    struct OpenSpan {
+        llvm::StringRef key;
+        std::uint32_t begin;
+    };
+
+    llvm::SmallVector<OpenSpan, 4> stack;
+
     std::uint32_t offset = 0;
     std::uint32_t i = 0;
 
-    auto try_parse_point_annotation = [&]() -> bool {
-        if(content[i] != '$') {
-            return false;
-        }
+    while(i < content.size()) {
+        llvm::StringRef rest = content.substr(i);
 
-        if(i + 1 < content.size() && content[i + 1] == '(') {
-            std::uint32_t key_start = i + 2;
-            std::size_t key_end = content.find(')', key_start);
+        if(rest.starts_with(sigil)) {
+            i += sigil.size();
 
-            if(key_end == llvm::StringRef::npos) {
-                return false;
+            llvm::StringRef key;
+            if(i < content.size() && content[i] == '(') {
+                std::size_t key_end = content.find(')', i + 1);
+                assert(key_end != llvm::StringRef::npos && "Unterminated §(name).");
+                key = content.slice(i + 1, key_end);
+                // A name must be a plain identifier (or empty): `§` directly
+                // before a real parenthesized expression is ambiguous — write
+                // the explicit nameless form `§()` in front of it instead.
+                assert(llvm::all_of(key,
+                                    [](char c) {
+                                        return std::isalnum(static_cast<unsigned char>(c)) ||
+                                               c == '_';
+                                    }) &&
+                       "§(name) requires an identifier name; use §() for a nameless point.");
+                i = static_cast<std::uint32_t>(key_end) + 1;
             }
 
-            llvm::StringRef key = content.slice(key_start, key_end);
-            if(key.empty()) {
+            if(content.substr(i).starts_with(open_mark)) {
+                stack.push_back({key, offset});
+                i += open_mark.size();
+            } else if(key.empty()) {
                 nameless_offsets.emplace_back(offset);
-                i += 1;
             } else {
                 offsets.try_emplace(key, offset);
-                i = key_end + 1;
             }
-            return true;
-        } else {
-            nameless_offsets.emplace_back(offset);
-            i += 1;
-            return true;
-        }
-    };
-
-    while(i < content.size()) {
-        if(try_parse_point_annotation()) {
             continue;
         }
 
-        char c = content[i];
-
-        if(c == '@') {
-            i += 1;
-
-            const char open_bracket = '[';
-            const char close_bracket = ']';
-
-            llvm::StringRef key = content.substr(i).take_until(
-                [&](char ch) { return isspace(ch) || ch == open_bracket; });
-            i += key.size();
-
-            while(i < content.size() && isspace(content[i])) {
-                i++;
-            }
-
-            assert(i < content.size() && content[i] == open_bracket &&
-                   "Expect @key[...] for ranges.");
-            i += 1;
-
-            std::uint32_t begin_offset = offset;
-            int bracket_level = 1;
-
-            while(i < content.size() && bracket_level > 0) {
-                if(try_parse_point_annotation()) {
-                    continue;
-                }
-
-                char inner_c = content[i];
-                if(inner_c == open_bracket) {
-                    bracket_level++;
-                } else if(inner_c == close_bracket) {
-                    bracket_level--;
-                }
-
-                if(bracket_level > 0) {
-                    source += inner_c;
-                    offset += 1;
-                    i += 1;
-                } else {
-                    i += 1;
-                }
-            }
-
-            ranges.try_emplace(key, LocalSourceRange{begin_offset, offset});
+        if(rest.starts_with(close_mark)) {
+            assert(!stack.empty() && "`⟧` without a matching `§⟦`.");
+            OpenSpan span = stack.pop_back_val();
+            ranges.try_emplace(span.key, LocalSourceRange{span.begin, offset});
+            i += close_mark.size();
             continue;
         }
 
-        source += c;
+        assert(!rest.starts_with(open_mark) && "`⟦` must follow `§` or `§(name)`.");
+
+        source += content[i];
         offset += 1;
         i += 1;
     }
+
+    assert(stack.empty() && "Unclosed `§⟦` annotation at end of input.");
 
     return AnnotatedSource{
         std::move(source),

--- a/tests/unit/test/annotation.cpp
+++ b/tests/unit/test/annotation.cpp
@@ -78,8 +78,8 @@ AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
                 i += open_mark.size();
             } else if(key.empty()) {
                 nameless_offsets.emplace_back(offset);
-            } else {
-                offsets.try_emplace(key, offset);
+            } else if(!offsets.try_emplace(key, offset).second) {
+                LOG_FATAL("Duplicate point annotation §({}).", key);
             }
             continue;
         }
@@ -89,7 +89,12 @@ AnnotatedSource AnnotatedSource::from(llvm::StringRef content) {
                 LOG_FATAL("`⟧` without a matching `§⟦` in annotated source.");
             }
             OpenSpan span = stack.pop_back_val();
-            ranges.try_emplace(span.key, LocalSourceRange{span.begin, offset});
+            if(!ranges.try_emplace(span.key, LocalSourceRange{span.begin, offset}).second) {
+                if(span.key.empty()) {
+                    LOG_FATAL("Multiple nameless ranges in one source; name them instead.");
+                }
+                LOG_FATAL("Duplicate range annotation §({})⟦...⟧.", span.key);
+            }
             i += close_mark.size();
             continue;
         }

--- a/tests/unit/test/annotation_tests.cpp
+++ b/tests/unit/test/annotation_tests.cpp
@@ -116,6 +116,32 @@ TEST_CASE(doxygen_passthrough) {
     EXPECT_TRUE(src.nameless_offsets.empty());
 }
 
+TEST_CASE(digit_names) {
+    // The migration leans on numeric names heavily (§(0), §(1)⟦...⟧).
+    auto src = AnnotatedSource::from("f(§(0)42);\n§(1)⟦int⟧ x;");
+    EXPECT_EQ(src.content, "f(42);\nint x;");
+    EXPECT_EQ(src.offsets.lookup("0"), 2u);
+    auto r = src.ranges.lookup("1");
+    EXPECT_EQ(r.begin, 7u);
+    EXPECT_EQ(r.end, 10u);
+}
+
+TEST_CASE(point_at_eof) {
+    auto src = AnnotatedSource::from("x§");
+    EXPECT_EQ(src.content, "x");
+    EXPECT_EQ(src.nameless_offsets, (std::vector<std::uint32_t>{1}));
+}
+
+TEST_CASE(empty_range_body) {
+    // `§⟦⟧` is a zero-width nameless range, distinct from the `§` point.
+    auto src = AnnotatedSource::from("a§⟦⟧b");
+    EXPECT_EQ(src.content, "ab");
+    auto r = src.ranges.lookup("");
+    EXPECT_EQ(r.begin, 1u);
+    EXPECT_EQ(r.end, 1u);
+    EXPECT_TRUE(src.nameless_offsets.empty());
+}
+
 TEST_CASE(empty_input) {
     auto src = AnnotatedSource::from("");
     EXPECT_TRUE(src.content.empty());
@@ -188,6 +214,22 @@ TEST_CASE(mid_line_ignored) {
     auto regions =
         extract_snap_regions("int x; // /// <snap:begin>\n// see /// <snap:begin> docs\nint y;\n");
     EXPECT_TRUE(regions.empty());
+}
+
+TEST_CASE(eof_marker_no_newline) {
+    // The end marker as the final line without a trailing newline exercises
+    // the last-line offset branch.
+    auto regions = extract_snap_regions("/// <snap:begin>\nxy\n/// <snap:end>");
+    ASSERT_EQ(regions.size(), 1u);
+    EXPECT_EQ(regions[0].begin, 17u);
+    EXPECT_EQ(regions[0].end, 20u);
+}
+
+TEST_CASE(empty_region_body) {
+    auto regions = extract_snap_regions("/// <snap:begin>\n/// <snap:end>\n");
+    ASSERT_EQ(regions.size(), 1u);
+    EXPECT_EQ(regions[0].begin, 17u);
+    EXPECT_EQ(regions[0].end, 17u);
 }
 
 TEST_CASE(filter_containment) {

--- a/tests/unit/test/annotation_tests.cpp
+++ b/tests/unit/test/annotation_tests.cpp
@@ -1,0 +1,211 @@
+#include <vector>
+
+#include "test/annotation.h"
+#include "test/snap_region.h"
+#include "test/test.h"
+
+namespace clice::testing {
+namespace {
+
+// Every offset and range asserted below is computed by hand from the byte
+// layout of the stripped source; annotation sigils (`§`, `⟦`, `⟧`) and any
+// `§(name)` markers contribute no bytes to `content`.
+TEST_SUITE(annotation) {
+
+TEST_CASE(single_named_point) {
+    auto src = AnnotatedSource::from("int §(a)x;");
+    EXPECT_EQ(src.content, "int x;");
+    EXPECT_EQ(src.offsets.count("a"), 1u);
+    EXPECT_EQ(src.offsets.lookup("a"), 4u);
+    EXPECT_TRUE(src.ranges.empty());
+    EXPECT_TRUE(src.nameless_offsets.empty());
+}
+
+TEST_CASE(single_nameless_point) {
+    auto src = AnnotatedSource::from("int §x;");
+    EXPECT_EQ(src.content, "int x;");
+    EXPECT_EQ(src.nameless_offsets, (std::vector<std::uint32_t>{4}));
+    EXPECT_TRUE(src.offsets.empty());
+    EXPECT_TRUE(src.ranges.empty());
+}
+
+TEST_CASE(multiple_points) {
+    auto src = AnnotatedSource::from("x§y§z");
+    EXPECT_EQ(src.content, "xyz");
+    EXPECT_EQ(src.nameless_offsets, (std::vector<std::uint32_t>{1, 2}));
+}
+
+TEST_CASE(named_range) {
+    auto src = AnnotatedSource::from("int §(r)⟦x⟧;");
+    EXPECT_EQ(src.content, "int x;");
+    EXPECT_EQ(src.ranges.count("r"), 1u);
+    auto r = src.ranges.lookup("r");
+    EXPECT_EQ(r.begin, 4u);
+    EXPECT_EQ(r.end, 5u);
+    EXPECT_TRUE(src.offsets.empty());
+}
+
+TEST_CASE(nameless_range) {
+    auto src = AnnotatedSource::from("int §⟦x⟧;");
+    EXPECT_EQ(src.content, "int x;");
+    EXPECT_EQ(src.ranges.count(""), 1u);
+    auto r = src.ranges.lookup("");
+    EXPECT_EQ(r.begin, 4u);
+    EXPECT_EQ(r.end, 5u);
+}
+
+TEST_CASE(nested_ranges) {
+    auto src = AnnotatedSource::from("§(out)⟦ab§(in)⟦cd⟧ef⟧");
+    EXPECT_EQ(src.content, "abcdef");
+    auto out = src.ranges.lookup("out");
+    EXPECT_EQ(out.begin, 0u);
+    EXPECT_EQ(out.end, 6u);
+    auto in = src.ranges.lookup("in");
+    EXPECT_EQ(in.begin, 2u);
+    EXPECT_EQ(in.end, 4u);
+}
+
+TEST_CASE(point_inside_range) {
+    auto src = AnnotatedSource::from("§(r)⟦ab§(p)cd⟧");
+    EXPECT_EQ(src.content, "abcd");
+    EXPECT_EQ(src.offsets.lookup("p"), 2u);
+    auto r = src.ranges.lookup("r");
+    EXPECT_EQ(r.begin, 0u);
+    EXPECT_EQ(r.end, 4u);
+}
+
+TEST_CASE(explicit_nameless_parens) {
+    // `§()` is the explicit nameless point; the real `()` that follows stays
+    // in the stripped source.
+    auto src = AnnotatedSource::from("foo§()();");
+    EXPECT_EQ(src.content, "foo();");
+    EXPECT_EQ(src.nameless_offsets, (std::vector<std::uint32_t>{3}));
+}
+
+TEST_CASE(adjacent_annotations) {
+    auto src = AnnotatedSource::from("§(a)§(b)⟦x⟧");
+    EXPECT_EQ(src.content, "x");
+    EXPECT_EQ(src.offsets.lookup("a"), 0u);
+    auto b = src.ranges.lookup("b");
+    EXPECT_EQ(b.begin, 0u);
+    EXPECT_EQ(b.end, 1u);
+}
+
+TEST_CASE(start_and_end) {
+    auto src = AnnotatedSource::from("§(s)ab§(e)");
+    EXPECT_EQ(src.content, "ab");
+    EXPECT_EQ(src.offsets.lookup("s"), 0u);
+    EXPECT_EQ(src.offsets.lookup("e"), 2u);
+}
+
+TEST_CASE(utf8_passthrough) {
+    // Box-drawing chars are 3 bytes each; the point lands at byte offset 9.
+    auto src = AnnotatedSource::from("┌─┐§(m)x");
+    EXPECT_EQ(src.content, "┌─┐x");
+    EXPECT_EQ(src.offsets.lookup("m"), 9u);
+}
+
+TEST_CASE(doxygen_passthrough) {
+    llvm::StringRef input = R"(/// @param[in] x
+/// @brief ${1:placeholder} $/cancelRequest
+)";
+    auto src = AnnotatedSource::from(input);
+    EXPECT_EQ(src.content, input);
+    EXPECT_TRUE(src.offsets.empty());
+    EXPECT_TRUE(src.ranges.empty());
+    EXPECT_TRUE(src.nameless_offsets.empty());
+}
+
+TEST_CASE(empty_input) {
+    auto src = AnnotatedSource::from("");
+    EXPECT_TRUE(src.content.empty());
+    EXPECT_TRUE(src.offsets.empty());
+    EXPECT_TRUE(src.ranges.empty());
+    EXPECT_TRUE(src.nameless_offsets.empty());
+}
+
+TEST_CASE(no_annotations) {
+    llvm::StringRef input = "int main() { return 0; }";
+    auto src = AnnotatedSource::from(input);
+    EXPECT_EQ(src.content, input);
+    EXPECT_TRUE(src.offsets.empty());
+    EXPECT_TRUE(src.ranges.empty());
+    EXPECT_TRUE(src.nameless_offsets.empty());
+}
+
+};  // TEST_SUITE(annotation)
+
+// Region offsets are byte offsets into the raw input; a region spans from just
+// past the begin marker line's newline to the start of the end marker line.
+TEST_SUITE(snap_region) {
+
+TEST_CASE(no_markers) {
+    auto regions = extract_snap_regions("int x;\nint y;\n");
+    EXPECT_TRUE(regions.empty());
+    // With no regions the filter admits everything.
+    EXPECT_TRUE(snap_region_filter(regions, LocalSourceRange{3, 5}));
+    EXPECT_TRUE(snap_region_filter(regions, LocalSourceRange{100, 200}));
+}
+
+TEST_CASE(single_pair) {
+    auto regions = extract_snap_regions("/// <snap:begin>\nbody\n/// <snap:end>\n");
+    ASSERT_EQ(regions.size(), 1u);
+    EXPECT_EQ(regions[0].begin, 17u);
+    EXPECT_EQ(regions[0].end, 22u);
+}
+
+TEST_CASE(two_pairs_union) {
+    auto regions = extract_snap_regions(
+        "/// <snap:begin>\naaa\n/// <snap:end>\nmid\n/// <snap:begin>\nbbb\n/// <snap:end>\n");
+    ASSERT_EQ(regions.size(), 2u);
+    EXPECT_EQ(regions[0].begin, 17u);
+    EXPECT_EQ(regions[0].end, 21u);
+    EXPECT_EQ(regions[1].begin, 57u);
+    EXPECT_EQ(regions[1].end, 61u);
+    // The filter is a union over regions.
+    EXPECT_TRUE(snap_region_filter(regions, LocalSourceRange{17, 20}));
+    EXPECT_TRUE(snap_region_filter(regions, LocalSourceRange{57, 60}));
+    EXPECT_FALSE(snap_region_filter(regions, LocalSourceRange{36, 39}));
+}
+
+TEST_CASE(named_pair) {
+    auto regions = extract_snap_regions("/// <snap:begin foo>\nx\n/// <snap:end foo>\n");
+    ASSERT_EQ(regions.size(), 1u);
+    EXPECT_EQ(regions[0].begin, 21u);
+    EXPECT_EQ(regions[0].end, 23u);
+}
+
+TEST_CASE(indented_markers) {
+    auto regions = extract_snap_regions("  /// <snap:begin>\nx\n    /// <snap:end>\n");
+    ASSERT_EQ(regions.size(), 1u);
+    EXPECT_EQ(regions[0].begin, 19u);
+    EXPECT_EQ(regions[0].end, 21u);
+}
+
+TEST_CASE(mid_line_ignored) {
+    // Marker-like text that is not at the line start after trimming is not a
+    // marker, so no region is claimed.
+    auto regions =
+        extract_snap_regions("int x; // /// <snap:begin>\n// see /// <snap:begin> docs\nint y;\n");
+    EXPECT_TRUE(regions.empty());
+}
+
+TEST_CASE(filter_containment) {
+    std::vector<LocalSourceRange> regions = {
+        {10, 20}
+    };
+    // Fully inside.
+    EXPECT_TRUE(snap_region_filter(regions, LocalSourceRange{12, 18}));
+    // Straddling either boundary.
+    EXPECT_FALSE(snap_region_filter(regions, LocalSourceRange{18, 25}));
+    EXPECT_FALSE(snap_region_filter(regions, LocalSourceRange{5, 15}));
+    // Entirely outside.
+    EXPECT_FALSE(snap_region_filter(regions, LocalSourceRange{30, 40}));
+    // Empty region set admits everything.
+    EXPECT_TRUE(snap_region_filter({}, LocalSourceRange{30, 40}));
+}
+
+};  // TEST_SUITE(snap_region)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/test/snap_region.h
+++ b/tests/unit/test/snap_region.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cassert>
+#include <vector>
+
+#include "syntax/token.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clice::testing {
+
+/// Snapshot fixtures may bracket parts of the file with whole-line markers:
+///
+///     /// <snap:begin>          /// <snap:begin init>
+///     ... code ...              ... code ...
+///     /// <snap:end>            /// <snap:end init>
+///
+/// A feature's snapshot transform keeps only result entries fully contained
+/// in one of the marked regions; a file without markers snapshots
+/// everything. Regions may not nest, and a named end must match its begin.
+inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef content) {
+    std::vector<LocalSourceRange> regions;
+
+    bool open = false;
+    llvm::StringRef open_name;
+    std::uint32_t region_begin = 0;
+
+    std::uint32_t line_start = 0;
+    llvm::StringRef rest = content;
+    while(!rest.empty()) {
+        auto parts = rest.split('\n');
+        llvm::StringRef raw_line = parts.first;
+        rest = parts.second;
+        // Past-the-newline offset; for the last unterminated line this is
+        // simply the end of the file.
+        std::uint32_t next_line_start =
+            line_start + static_cast<std::uint32_t>(raw_line.size()) + (rest.data() ? 1 : 0);
+
+        llvm::StringRef line = raw_line.trim();
+        // Any line starting with `/// <snap:` is claimed by the marker
+        // grammar, so a typo fails loudly instead of being skipped.
+        if(llvm::StringRef marker = line; marker.consume_front("/// <snap:")) {
+            bool is_begin = marker.consume_front("begin");
+            bool is_end = !is_begin && marker.consume_front("end");
+            assert((is_begin || is_end) && "Expect <snap:begin ...> or <snap:end ...>.");
+            [[maybe_unused]] bool closed = marker.consume_back(">");
+            assert(closed && "Snap marker must end with `>`.");
+            assert((marker.empty() || marker.starts_with(" ")) &&
+                   "Snap marker name must be separated by a space.");
+            llvm::StringRef name = marker.trim();
+
+            if(is_begin) {
+                assert(!open && "<snap:begin> may not nest.");
+                open = true;
+                open_name = name;
+                region_begin = next_line_start;
+            } else {
+                assert(open && "<snap:end> without a matching <snap:begin>.");
+                assert((name.empty() || name == open_name) &&
+                       "<snap:end NAME> must match its <snap:begin NAME>.");
+                regions.emplace_back(region_begin, line_start);
+                open = false;
+            }
+        }
+
+        line_start = next_line_start;
+    }
+
+    assert(!open && "Unclosed <snap:begin> at end of file.");
+    return regions;
+}
+
+/// True when `range` should appear in the snapshot: always if the fixture
+/// has no marked regions, otherwise only when fully contained in one.
+inline bool snap_region_filter(llvm::ArrayRef<LocalSourceRange> regions, LocalSourceRange range) {
+    if(regions.empty()) {
+        return true;
+    }
+    for(const auto& region: regions) {
+        if(region.begin <= range.begin && range.end <= region.end) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace clice::testing

--- a/tests/unit/test/snap_region.h
+++ b/tests/unit/test/snap_region.h
@@ -18,7 +18,8 @@ namespace clice::testing {
 ///
 /// A feature's snapshot transform keeps only result entries fully contained
 /// in one of the marked regions; a file without markers snapshots
-/// everything. Regions may not nest, and a named end must match its begin.
+/// everything. Regions may not nest, and an end marker name (including
+/// its absence) must match its begin exactly.
 /// Malformed markers abort in every build mode so that typos fail loudly
 /// instead of silently producing misleading snapshots.
 inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef content) {
@@ -67,7 +68,7 @@ inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef conten
                 if(!open) {
                     LOG_FATAL("<snap:end> without a matching <snap:begin>.");
                 }
-                if(!name.empty() && name != open_name) {
+                if(name != open_name) {
                     LOG_FATAL("<snap:end {}> does not match <snap:begin {}>.", name, open_name);
                 }
                 regions.emplace_back(region_begin, line_start);

--- a/tests/unit/test/snap_region.h
+++ b/tests/unit/test/snap_region.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cassert>
 #include <vector>
 
+#include "support/logging.h"
 #include "syntax/token.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -19,6 +19,8 @@ namespace clice::testing {
 /// A feature's snapshot transform keeps only result entries fully contained
 /// in one of the marked regions; a file without markers snapshots
 /// everything. Regions may not nest, and a named end must match its begin.
+/// Malformed markers abort in every build mode so that typos fail loudly
+/// instead of silently producing misleading snapshots.
 inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef content) {
     std::vector<LocalSourceRange> regions;
 
@@ -39,26 +41,35 @@ inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef conten
 
         llvm::StringRef line = raw_line.trim();
         // Any line starting with `/// <snap:` is claimed by the marker
-        // grammar, so a typo fails loudly instead of being skipped.
+        // grammar.
         if(llvm::StringRef marker = line; marker.consume_front("/// <snap:")) {
             bool is_begin = marker.consume_front("begin");
             bool is_end = !is_begin && marker.consume_front("end");
-            assert((is_begin || is_end) && "Expect <snap:begin ...> or <snap:end ...>.");
-            [[maybe_unused]] bool closed = marker.consume_back(">");
-            assert(closed && "Snap marker must end with `>`.");
-            assert((marker.empty() || marker.starts_with(" ")) &&
-                   "Snap marker name must be separated by a space.");
+            if(!is_begin && !is_end) {
+                LOG_FATAL("Expect <snap:begin ...> or <snap:end ...>, got: {}", line);
+            }
+            if(!marker.consume_back(">")) {
+                LOG_FATAL("Snap marker must end with `>`: {}", line);
+            }
+            if(!marker.empty() && !marker.starts_with(" ")) {
+                LOG_FATAL("Snap marker name must be separated by a space: {}", line);
+            }
             llvm::StringRef name = marker.trim();
 
             if(is_begin) {
-                assert(!open && "<snap:begin> may not nest.");
+                if(open) {
+                    LOG_FATAL("<snap:begin> may not nest.");
+                }
                 open = true;
                 open_name = name;
                 region_begin = next_line_start;
             } else {
-                assert(open && "<snap:end> without a matching <snap:begin>.");
-                assert((name.empty() || name == open_name) &&
-                       "<snap:end NAME> must match its <snap:begin NAME>.");
+                if(!open) {
+                    LOG_FATAL("<snap:end> without a matching <snap:begin>.");
+                }
+                if(!name.empty() && name != open_name) {
+                    LOG_FATAL("<snap:end {}> does not match <snap:begin {}>.", name, open_name);
+                }
                 regions.emplace_back(region_begin, line_start);
                 open = false;
             }
@@ -67,7 +78,9 @@ inline std::vector<LocalSourceRange> extract_snap_regions(llvm::StringRef conten
         line_start = next_line_start;
     }
 
-    assert(!open && "Unclosed <snap:begin> at end of file.");
+    if(open) {
+        LOG_FATAL("Unclosed <snap:begin> at end of file.");
+    }
     return regions;
 }
 


### PR DESCRIPTION
## Why

The test annotation grammar reserved `$` and `@`, both of which collide with real content that tests need to contain:

- `@param[in]` matches the `@key[...]` annotation shape and destroys the input; a bare Doxygen tag like `@brief` aborts assertion-enabled builds. Net effect: no test source could contain Doxygen comments — the hover documentation fixtures avoid them entirely today.
- `$` collides with LSP snippet placeholders (`${1:...}`), `$/cancelRequest`, and `${workspace}` config variables.
- The `[...]` range delimiter collides with C++ brackets: the balance heuristic cannot express a range containing unbalanced brackets (lambda captures, partial subscripts).

## New grammar

The grammar now reserves no ASCII character at all — sigil `§` (U+00A7), range delimiters `⟦`/`⟧` (U+27E6/E7):

```
§              nameless point       §(name)          named point
§⟦...⟧         nameless range       §(name)⟦...⟧     named range
```

- Ranges nest (stack-based); the bracket-balance heuristic is gone, so unbalanced brackets inside a range are now expressible.
- `§(name)` requires an identifier name, keeping a nameless point directly before real parentheses unambiguous (`§()`).
- Malformed annotations abort in every build mode (assert-only guards would let NDEBUG wrap past `npos` and loop forever).

Also introduces `test/snap_region.h`: whole-line `/// <snap:begin [name]>` / `/// <snap:end [name]>` markers plus a containment filter, for snapshot fixtures that only want results from a marked region.

## Migration

~750 annotations across 40 files converted mechanically. A semantic differ replayed the old parser against the old files and the new parser against the new files and verified byte-identical stripped sources and annotation tables. Three findings from that process, all fixed:

- Four sites in selection tests relied on an old-parser quirk where `$()` meant point-plus-literal-parens; they now use the explicit `§()()` form.
- Three commented-out selection cases carried annotations that would have eaten real source parens if ever enabled; re-annotated correctly.
- One signature-help cursor point had been misclassified as a literal `$` during auditing.

## Tests

- New framework coverage (previously zero): 26 cases for the annotation parser and snap-region helpers, with hand-computed byte offsets, UTF-8 passthrough, and a Doxygen/snippet passthrough case.
- Unit: 1052 passed / 12 pre-existing skips on both RelWithDebInfo and Debug; Integration: 300; Smoke: 3/3.