### PR TITLE
fix(feature): stop parsing windows drive paths as URI schemes

### DIFF
--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -283,6 +283,9 @@ std::optional<std::size_t> CompilationDatabase::load(llvm::StringRef path) {
 
         // Resolve relative file paths against the directory so that entries
         // from different directories don't collide in the PathPool.
+        // TODO: remove_dots here — a "file" carrying "./" or "../" segments
+        // interns under a spelling that clang's realpath'd paths never use,
+        // so lookups against clang-reported paths miss the entry.
         std::string file_abs;
         if(!path::is_absolute(file_ref)) {
             file_abs = path::join(dir_ref, file_ref);

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -28,12 +28,14 @@ using kota::ipc::lsp::PositionEncoding;
 inline auto to_uri(llvm::StringRef file) -> std::string {
     const auto file_view = std::string_view(file.data(), file.size());
 
-    if(auto parsed = kota::ipc::lsp::URI::parse(file_view)) {
-        return parsed->str();
-    }
-
+    // Convert as a path first: a Windows drive prefix like "F:" would
+    // otherwise be accepted by URI::parse as a single-letter scheme.
     if(auto uri = kota::ipc::lsp::URI::from_file_path(file_view)) {
         return uri->str();
+    }
+
+    if(auto parsed = kota::ipc::lsp::URI::parse(file_view)) {
+        return parsed->str();
     }
 
     return file.str();

--- a/src/index/path_pool.h
+++ b/src/index/path_pool.h
@@ -16,6 +16,10 @@ namespace clice::index {
 /// path tables of serialized index artifacts: every persisted path id is an
 /// index into its artifact's own table, never a runtime pool id (those are
 /// per-session).
+///
+/// FIXME: like the runtime pool (support/path_pool.h), only
+/// separators are normalized — case-variant spellings of one file intern
+/// (and persist) as distinct paths.
 struct PathPool {
     llvm::BumpPtrAllocator allocator;
 

--- a/src/server/protocol/agentic.h
+++ b/src/server/protocol/agentic.h
@@ -9,6 +9,12 @@
 
 namespace clice::agentic {
 
+/// The `path`/`file` fields of the agentic protocol carry raw filesystem
+/// paths, not URIs.
+///
+/// FIXME: they are serialized into JSON verbatim, so a
+/// non-UTF-8 path (possible on POSIX, where filenames are raw bytes)
+/// produces invalid JSON. Non-UTF-8 paths are currently unsupported.
 struct CompileCommandParams {
     std::string path;
 };

--- a/src/support/filesystem.h
+++ b/src/support/filesystem.h
@@ -3,10 +3,8 @@
 #include <cassert>
 #include <chrono>
 #include <cstdint>
-#include <cstdlib>
 #include <expected>
 #include <memory>
-#include <print>
 #include <string>
 
 #include "support/format.h"
@@ -26,16 +24,6 @@ template <typename... Args>
 std::string join(Args&&... args) {
     llvm::SmallString<128> path;
     ((path::append(path, std::forward<Args>(args))), ...);
-    return path.str().str();
-}
-
-inline std::string real_path(llvm::StringRef file) {
-    llvm::SmallString<128> path;
-    auto error = llvm::sys::fs::real_path(file, path);
-    if(error) {
-        std::println("Failed to get real path of {}: {}", file, error.message());
-        std::abort();
-    }
     return path.str().str();
 }
 

--- a/src/support/path_pool.h
+++ b/src/support/path_pool.h
@@ -14,6 +14,21 @@
 namespace clice {
 
 /// Intern pool that maps file paths to compact uint32_t IDs.
+///
+/// Paths are opaque byte strings; the only normalization applied is
+/// backslash-to-slash replacement.
+///
+/// FIXME: character case is not normalized, so case-variant
+/// spellings of one file on a case-insensitive filesystem intern to
+/// different IDs. The practical instance is the drive letter: VS Code
+/// sends lowercase ("file:///f%3A/...") while the CDB and clang report
+/// "F:/...", so the same file can receive two IDs when both sources feed
+/// one pool.
+///
+/// FIXME: paths are assumed to be valid UTF-8. POSIX filenames
+/// are raw bytes; a non-UTF-8 path survives interning but breaks
+/// downstream where it is embedded into JSON (worker IPC, the agentic
+/// protocol) or percent-decoded by clients that interpret URIs as UTF-8.
 struct PathPool {
     llvm::BumpPtrAllocator allocator;
     llvm::SmallVector<llvm::StringRef> paths;

--- a/tests/unit/feature/feature_tests.cpp
+++ b/tests/unit/feature/feature_tests.cpp
@@ -1,0 +1,46 @@
+#include "test/test.h"
+#include "feature/feature.h"
+
+namespace clice::testing {
+
+namespace {
+
+TEST_SUITE(ToUri) {
+
+TEST_CASE(WindowsDrivePath) {
+    // A drive letter must not be mistaken for a URI scheme.
+    ASSERT_EQ(feature::to_uri("F:/C++/cmake/clice/main.cpp"),
+              "file:///F:/C++/cmake/clice/main.cpp");
+}
+
+TEST_CASE(WindowsBackslashPath) {
+    ASSERT_EQ(feature::to_uri(R"(F:\C++\cmake\clice\main.cpp)"),
+              "file:///F:/C++/cmake/clice/main.cpp");
+}
+
+TEST_CASE(PosixPath) {
+    ASSERT_EQ(feature::to_uri("/home/user/main.cpp"), "file:///home/user/main.cpp");
+}
+
+TEST_CASE(FormedUri) {
+    ASSERT_EQ(feature::to_uri("file:///home/user/main.cpp"), "file:///home/user/main.cpp");
+}
+
+TEST_CASE(RelativePath) {
+    // Neither an absolute path nor a URI: returned verbatim.
+    ASSERT_EQ(feature::to_uri("include/test.h"), "include/test.h");
+}
+
+TEST_CASE(PathWithSpaces) {
+    ASSERT_EQ(feature::to_uri("/home/user/my file.cpp"), "file:///home/user/my%20file.cpp");
+}
+
+TEST_CASE(UncPath) {
+    ASSERT_EQ(feature::to_uri("//server/share/main.cpp"), "file://server/share/main.cpp");
+}
+
+};  // TEST_SUITE(ToUri)
+
+}  // namespace
+
+}  // namespace clice::testing


### PR DESCRIPTION
## Problem

On Windows, go-to-definition on an include directive returns a malformed URI like `f:/C++/project/header.h` instead of `file:///F:/C++/project/header.h`. Document links and diagnostics URIs produced through the same helper are affected as well.

`feature::to_uri` tried `URI::parse` before `URI::from_file_path`. A drive-letter prefix such as `F:` is a syntactically valid single-letter URI scheme, so absolute Windows paths were accepted by the parser and returned with the drive letter mangled into a scheme. Backslash spellings came out even worse (`f:\C++\...`).

## Fix

Try `from_file_path` first and fall back to `parse`. `from_file_path` rejects anything that is not an absolute filesystem path (including real URIs), so already-formed URIs still take the parse branch; only drive-letter paths change behavior, from wrong to correct.

Also in this PR:

- remove the unused `path::real_path` helper (dead code that aborted on failure)
- document known path-handling limitations (case-variant spellings interning as distinct IDs, non-UTF-8 path bytes) as FIXME/TODO comments discovered during a broader path-handling review

## Testing

- New `ToUri` unit suite: drive path, backslash path, POSIX path, formed URI passthrough, relative-path fallback, percent-encoding, UNC path
- Full local run: 1033 unit tests, 300 integration tests, smoke 3/3 all pass