### PR TITLE
feat(driver): one subcommand per translation unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,8 @@ target_link_libraries(clice-core PUBLIC
     simdjson::simdjson
 )
 
-add_executable(clice "${PROJECT_SOURCE_DIR}/src/clice.cc")
+file(GLOB CLICE_DRIVER_SOURCES CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/src/driver/*.cc")
+add_executable(clice "${PROJECT_SOURCE_DIR}/src/clice.cc" ${CLICE_DRIVER_SOURCES})
 target_link_libraries(clice PRIVATE clice::core kota::deco)
 add_dependencies(clice generate_version_header)
 install(TARGETS clice RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/clice.cc
+++ b/src/clice.cc
@@ -1,83 +1,10 @@
 #include <csignal>
-#include <cstdint>
 #include <print>
-#include <sstream>
-#include <string>
 
 #include "version.h"
-#include "server/transport/agentic.h"
-#include "server/transport/master_server.h"
-#include "server/worker/stateful_worker.h"
-#include "server/worker/stateless_worker.h"
-#include "support/logging.h"
+#include "driver/driver.h"
 
 #include "kota/deco/deco.h"
-
-namespace clice {
-
-namespace deco = kota::deco;
-using deco::decl::KVStyle;
-
-struct LintOptions {
-    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
-    help;
-};
-
-struct FormatOptions {
-    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
-    help;
-};
-
-struct WorkerOptions {
-    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
-    help;
-
-    DecoFlag(names = {"--stateful"},
-             help = "Run as stateful worker (default: stateless)",
-             required = false)
-    stateful;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--memory-limit", "--memory-limit="},
-           help = "Memory limit in bytes (stateful worker only)",
-           required = false)
-    <std::uint64_t> memory_limit;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--max-documents", "--max-documents="},
-           help = "Max compiled documents kept before LRU eviction (stateful worker only)",
-           required = false)
-    <std::uint64_t> max_documents;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate,
-           names = {"--worker-name", "--worker-name="},
-           required = false)
-    <std::string> worker_name;
-
-    DecoKV(style = KVStyle::JoinedOrSeparate, names = {"--log-dir", "--log-dir="}, required = false)
-    <std::string> log_dir;
-};
-
-bool apply_log_level(const std::string& level_str) {
-    auto level = spdlog::level::from_str(level_str);
-    if(level == spdlog::level::off && level_str != "off") {
-        std::println(stderr,
-                     "unknown log level '{}', valid: trace, debug, info, warn, error, off",
-                     level_str);
-        return false;
-    }
-    logging::options.level = level;
-    return true;
-}
-
-template <typename T>
-void print_usage(T& cmd) {
-    std::ostringstream ss;
-    cmd.usage(ss);
-    std::print("{}", ss.str());
-}
-
-}  // namespace clice
 
 int main(int argc, const char** argv) {
 #ifndef _WIN32
@@ -85,111 +12,37 @@ int main(int argc, const char** argv) {
 #endif
 
     namespace deco = kota::deco;
+    namespace driver = clice::driver;
 
     auto args = deco::util::argvify(argc, argv);
     const char* self_path = argv[0];
 
     int exit_code = 1;
 
-    auto serve_cmd = deco::cli::command<clice::ServerOptions>("clice serve [OPTIONS]");
-    serve_cmd
-        .matchAll([&](clice::ServerOptions opts) {
-            if(opts.help) {
-                clice::print_usage(serve_cmd);
-                exit_code = 0;
-                return;
-            }
-            if(!clice::apply_log_level(opts.log_level.value_or("info")))
-                return;
-            exit_code = clice::run_serve_mode(opts, self_path);
-        })
-        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
-
-    auto query_cmd = deco::cli::command<clice::QueryOptions>("clice query [OPTIONS]");
-    query_cmd
-        .matchAll([&](clice::QueryOptions opts) {
-            if(opts.help) {
-                clice::print_usage(query_cmd);
-                exit_code = 0;
-                return;
-            }
-            auto port = opts.port.value_or(0);
-            if(port <= 0 || port > 65535) {
-                LOG_ERROR("--port must be between 1 and 65535");
-                return;
-            }
-            if(!clice::apply_log_level(opts.log_level.value_or("info")))
-                return;
-            exit_code = clice::run_agentic_mode(opts);
-        })
-        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
-
-    auto worker_cmd = deco::cli::command<clice::WorkerOptions>("clice worker [OPTIONS]");
-    worker_cmd
-        .matchAll([&](clice::WorkerOptions opts) {
-            if(opts.help) {
-                clice::print_usage(worker_cmd);
-                exit_code = 0;
-                return;
-            }
-            auto name = opts.worker_name.value_or("worker");
-            auto log_dir = opts.log_dir.value_or("");
-            if(opts.stateful) {
-                auto limit = opts.memory_limit.value_or(4ULL * 1024 * 1024 * 1024);
-                auto max_docs = opts.max_documents.value_or(clice::default_max_documents);
-                exit_code = clice::run_stateful_worker_mode(limit, name, log_dir, max_docs);
-            } else {
-                exit_code = clice::run_stateless_worker_mode(name, log_dir);
-            }
-        })
-        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
-
-    auto lint_cmd = deco::cli::command<clice::LintOptions>("clice lint [OPTIONS]");
-    lint_cmd
-        .matchAll([&](clice::LintOptions opts) {
-            if(opts.help) {
-                clice::print_usage(lint_cmd);
-                exit_code = 0;
-                return;
-            }
-            LOG_ERROR("lint is not yet implemented");
-        })
-        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
-
-    auto format_cmd = deco::cli::command<clice::FormatOptions>("clice format [OPTIONS]");
-    format_cmd
-        .matchAll([&](clice::FormatOptions opts) {
-            if(opts.help) {
-                clice::print_usage(format_cmd);
-                exit_code = 0;
-                return;
-            }
-            LOG_ERROR("format is not yet implemented");
-        })
-        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
-
     deco::cli::SubCommander clice("clice <command> [<args>]",
                                   "A C++ development toolkit built on LLVM/Clang");
 
     auto print_root_usage = [&] {
         std::println("usage: clice <command> [<args>]\n");
-        clice::print_usage(clice);
+        driver::print_usage(clice);
     };
 
-    clice.add({.name = "serve", .description = "Start LSP server"}, serve_cmd)
-        .add({.name = "query", .description = "Query symbol information from a running server"},
-             query_cmd)
-        .add({.name = "worker"}, worker_cmd)
-        .add({.name = "lint", .description = "Lint C++ source files"}, lint_cmd)
-        .add({.name = "format", .description = "Format C++ source files"}, format_cmd)
-        .when_err([&](auto err) {
-            if(err.type == deco::cli::SubCommandError::Type::MissingSubCommand) {
-                print_root_usage();
-                exit_code = 0;
-            } else {
-                LOG_ERROR("{}", err.message);
-            }
-        });
+    driver::add_serve(clice, exit_code, self_path);
+    driver::add_query(clice, exit_code);
+    driver::add_worker(clice, exit_code);
+    driver::add_index(clice, exit_code);
+    driver::add_doc(clice, exit_code);
+    driver::add_lint(clice, exit_code);
+    driver::add_format(clice, exit_code);
+
+    clice.when_err([&](auto err) {
+        if(err.type == deco::cli::SubCommandError::Type::MissingSubCommand) {
+            print_root_usage();
+            exit_code = 0;
+        } else {
+            LOG_ERROR("{}", err.message);
+        }
+    });
 
     if(!args.empty() && (args[0] == "--version" || args[0] == "-v")) {
         std::println("clice version {}", clice::version);

--- a/src/driver/doc.cc
+++ b/src/driver/doc.cc
@@ -1,0 +1,36 @@
+#include "driver/driver.h"
+
+namespace clice::driver {
+
+namespace {
+
+struct DocOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
+
+auto make_command() {
+    return kota::deco::cli::command<DocOptions>("clice doc [OPTIONS]");
+}
+
+}  // namespace
+
+void add_doc(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](DocOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           std::println(
+               stderr,
+               "clice doc is not implemented yet: it will generate documentation data for the workspace.");
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "doc", .description = "Generate documentation data"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/driver.h
+++ b/src/driver/driver.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <print>
+#include <sstream>
+#include <string>
+
+#include "support/logging.h"
+
+#include "kota/deco/deco.h"
+
+namespace clice::driver {
+
+/// Each subcommand lives in its own translation unit under src/driver/ and
+/// registers itself with the root commander through one of these builders.
+/// `exit_code` is written by the matched handler when the command runs;
+/// clice.cc owns the commander and the final process exit.
+
+void add_serve(kota::deco::cli::SubCommander& root, int& exit_code, const char* self_path);
+void add_query(kota::deco::cli::SubCommander& root, int& exit_code);
+void add_worker(kota::deco::cli::SubCommander& root, int& exit_code);
+void add_index(kota::deco::cli::SubCommander& root, int& exit_code);
+void add_doc(kota::deco::cli::SubCommander& root, int& exit_code);
+void add_lint(kota::deco::cli::SubCommander& root, int& exit_code);
+void add_format(kota::deco::cli::SubCommander& root, int& exit_code);
+
+/// Set the global log level from a user-supplied string; complains and
+/// returns false on an unknown level.
+inline bool apply_log_level(const std::string& level_str) {
+    auto level = spdlog::level::from_str(level_str);
+    if(level == spdlog::level::off && level_str != "off") {
+        std::println(stderr,
+                     "unknown log level '{}', valid: trace, debug, info, warn, error, off",
+                     level_str);
+        return false;
+    }
+    logging::options.level = level;
+    return true;
+}
+
+template <typename Command>
+void print_usage(Command& cmd) {
+    std::ostringstream ss;
+    cmd.usage(ss);
+    std::print("{}", ss.str());
+}
+
+}  // namespace clice::driver

--- a/src/driver/driver.h
+++ b/src/driver/driver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <cctype>
 #include <print>
 #include <sstream>
 #include <string>
@@ -26,8 +28,14 @@ void add_format(kota::deco::cli::SubCommander& root, int& exit_code);
 /// Set the global log level from a user-supplied string; complains and
 /// returns false on an unknown level.
 inline bool apply_log_level(const std::string& level_str) {
-    auto level = spdlog::level::from_str(level_str);
-    if(level == spdlog::level::off && level_str != "off") {
+    // from_str accepts mixed case, so the "off" sentinel comparison must
+    // be case-insensitive too or `OFF` gets rejected as unknown.
+    std::string lowered = level_str;
+    std::ranges::transform(lowered, lowered.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    auto level = spdlog::level::from_str(lowered);
+    if(level == spdlog::level::off && lowered != "off") {
         std::println(stderr,
                      "unknown log level '{}', valid: trace, debug, info, warn, error, off",
                      level_str);

--- a/src/driver/format.cc
+++ b/src/driver/format.cc
@@ -1,0 +1,35 @@
+#include "driver/driver.h"
+
+namespace clice::driver {
+
+namespace {
+
+struct FormatOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
+
+auto make_command() {
+    return kota::deco::cli::command<FormatOptions>("clice format [OPTIONS]");
+}
+
+}  // namespace
+
+void add_format(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](FormatOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           std::println(stderr,
+                        "clice format is not implemented yet: it will format C++ source files.");
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "format", .description = "Format C++ source files"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/index.cc
+++ b/src/driver/index.cc
@@ -1,0 +1,36 @@
+#include "driver/driver.h"
+
+namespace clice::driver {
+
+namespace {
+
+struct IndexOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
+
+auto make_command() {
+    return kota::deco::cli::command<IndexOptions>("clice index [OPTIONS]");
+}
+
+}  // namespace
+
+void add_index(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](IndexOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           std::println(
+               stderr,
+               "clice index is not implemented yet: it will build the workspace symbol index ahead of time.");
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "index", .description = "Index a workspace ahead of time"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/lint.cc
+++ b/src/driver/lint.cc
@@ -1,0 +1,36 @@
+#include "driver/driver.h"
+
+namespace clice::driver {
+
+namespace {
+
+struct LintOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+};
+
+auto make_command() {
+    return kota::deco::cli::command<LintOptions>("clice lint [OPTIONS]");
+}
+
+}  // namespace
+
+void add_lint(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](LintOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           std::println(
+               stderr,
+               "clice lint is not implemented yet: it will run clang-tidy across the workspace with cross-TU caching.");
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "lint", .description = "Lint C++ source files"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/query.cc
+++ b/src/driver/query.cc
@@ -1,0 +1,38 @@
+#include "driver/driver.h"
+#include "server/transport/agentic.h"
+
+namespace clice::driver {
+
+namespace {
+
+auto make_command() {
+    return kota::deco::cli::command<QueryOptions>("clice query [OPTIONS]");
+}
+
+}  // namespace
+
+void add_query(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](QueryOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           auto port = opts.port.value_or(0);
+           if(port <= 0 || port > 65535) {
+               LOG_ERROR("--port must be between 1 and 65535");
+               return;
+           }
+           if(!apply_log_level(opts.log_level.value_or("info")))
+               return;
+           exit_code = run_agentic_mode(opts);
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "query", .description = "Query symbol information from a running server"},
+             std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/serve.cc
+++ b/src/driver/serve.cc
@@ -1,0 +1,32 @@
+#include "driver/driver.h"
+#include "server/transport/master_server.h"
+
+namespace clice::driver {
+
+namespace {
+
+auto make_command() {
+    return kota::deco::cli::command<ServerOptions>("clice serve [OPTIONS]");
+}
+
+}  // namespace
+
+void add_serve(kota::deco::cli::SubCommander& root, int& exit_code, const char* self_path) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code, self_path](ServerOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           if(!apply_log_level(opts.log_level.value_or("info")))
+               return;
+           exit_code = run_serve_mode(opts, self_path);
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "serve", .description = "Start LSP server"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/src/driver/worker.cc
+++ b/src/driver/worker.cc
@@ -1,0 +1,73 @@
+#include <cstdint>
+
+#include "driver/driver.h"
+#include "server/worker/stateful_worker.h"
+#include "server/worker/stateless_worker.h"
+
+namespace clice::driver {
+
+namespace {
+
+using kota::deco::decl::KVStyle;
+
+struct WorkerOptions {
+    DecoFlag(names = {"-h", "--help"}, help = "Show help", required = false)
+    help;
+
+    DecoFlag(names = {"--stateful"},
+             help = "Run as stateful worker (default: stateless)",
+             required = false)
+    stateful;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           names = {"--memory-limit", "--memory-limit="},
+           help = "Memory limit in bytes (stateful worker only)",
+           required = false)
+    <std::uint64_t> memory_limit;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           names = {"--max-documents", "--max-documents="},
+           help = "Max compiled documents kept before LRU eviction (stateful worker only)",
+           required = false)
+    <std::uint64_t> max_documents;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate,
+           names = {"--worker-name", "--worker-name="},
+           required = false)
+    <std::string> worker_name;
+
+    DecoKV(style = KVStyle::JoinedOrSeparate, names = {"--log-dir", "--log-dir="}, required = false)
+    <std::string> log_dir;
+};
+
+auto make_command() {
+    return kota::deco::cli::command<WorkerOptions>("clice worker [OPTIONS]");
+}
+
+}  // namespace
+
+void add_worker(kota::deco::cli::SubCommander& root, int& exit_code) {
+    auto cmd = make_command();
+    cmd.matchAll([&exit_code](WorkerOptions opts) {
+           if(opts.help) {
+               auto help = make_command();
+               print_usage(help);
+               exit_code = 0;
+               return;
+           }
+           auto name = opts.worker_name.value_or("worker");
+           auto log_dir = opts.log_dir.value_or("");
+           if(opts.stateful) {
+               auto limit = opts.memory_limit.value_or(4ULL * 1024 * 1024 * 1024);
+               auto max_docs = opts.max_documents.value_or(default_max_documents);
+               exit_code = run_stateful_worker_mode(limit, name, log_dir, max_docs);
+           } else {
+               exit_code = run_stateless_worker_mode(name, log_dir);
+           }
+       })
+        .on_error([](auto err) { LOG_ERROR("{}", err.message); });
+
+    root.add({.name = "worker"}, std::move(cmd));
+}
+
+}  // namespace clice::driver

--- a/tests/integration/lifecycle/test_subcommands.py
+++ b/tests/integration/lifecycle/test_subcommands.py
@@ -1,0 +1,39 @@
+import subprocess
+
+SUBCOMMANDS = ["serve", "query", "worker", "index", "doc", "lint", "format"]
+STUBS = ["index", "doc", "lint", "format"]
+
+
+def run_clice(executable, *args):
+    return subprocess.run(
+        [str(executable), *args], capture_output=True, text=True, timeout=30
+    )
+
+
+def test_root_usage_lists_subcommands(executable):
+    # Both the bare invocation and --help print the root usage and succeed.
+    for args in ([], ["--help"]):
+        result = run_clice(executable, *args)
+        assert result.returncode == 0
+        for name in SUBCOMMANDS:
+            assert name in result.stdout
+
+
+def test_stubs_report_unimplemented(executable):
+    # Stubs explain themselves on stderr and exit non-zero: the command is
+    # still unavailable and scripts must be able to detect that.
+    for name in STUBS:
+        result = run_clice(executable, name)
+        assert result.returncode == 1
+        assert "not implemented" in result.stderr
+
+
+def test_subcommand_help(executable):
+    for name in SUBCOMMANDS:
+        result = run_clice(executable, name, "--help")
+        assert result.returncode == 0
+        assert f"clice {name}" in result.stdout
+
+
+def test_unknown_subcommand_fails(executable):
+    assert run_clice(executable, "bogus").returncode != 0


### PR DESCRIPTION
## Why

Upcoming features (`clice lint` with cross-TU caching, ahead-of-time indexing, documentation data generation) are all CLI applications over the same core, but the CLI surface lived as one monolithic `clice.cc`. This PR gives every subcommand its own home before those features land.

## What

- `src/driver/` holds one translation unit per subcommand: `serve`, `query`, `worker`, plus new stubs `index`, `doc`, `lint`, `format`. Each file owns its options struct and registers a deco command with the root `SubCommander` through an `add_*` builder.
- `clice.cc` shrinks to collection and registration (206 → ~60 lines). Behavior parity everywhere: dispatch, `--version`, root/per-command `--help`, missing/unknown subcommand handling, worker defaults, query port validation.
- Stubs print a one-line self-description to stderr and exit non-zero, so scripts can detect the command is unavailable while humans learn what it will do.
- Commands are constructed inside the builders and moved into the `SubCommander` (owning overload); help re-constructs a fresh command for usage printing, so no closure captures a moved-from object.
- New `tests/integration/lifecycle/test_subcommands.py` pins the whole surface: all seven names registered in root usage, stub messages and exit codes, per-command help, unknown-subcommand failure.

## Tests

- Unit: 1059; Integration: 304 (incl. 4 new CLI surface tests); Smoke: 3/3.