### PR TITLE
ci(vscode): serialize marketplace publish with retries

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -34,6 +34,14 @@ prunes odd-minor pre-releases older than 30 days. Promotion fails loudly
 if no packaged green run exists. A failed nightly just means no nightly
 that day — fix main and rerun via dispatch.
 
+The vsix packaging matrix runs in parallel, but release upload and
+Marketplace publishing happen in one serial job (`publish-release`) with
+3 attempts per vsix — concurrent publishes trip Marketplace internal
+errors (TF400898). The job is rerun-safe: `gh run rerun <id> --failed`
+re-uploads with `--clobber` and skips already-published versions, so a
+transient Marketplace failure is recovered by rerunning just that job —
+never by a new tag.
+
 The binary embeds its build identity (`git describe`: nearest tag + commit
 hash), not the release tag — the tag is applied after the build. Match crash
 logs to releases by the commit hash; the release notes state the hash.

--- a/.github/workflows/publish-clice.yml
+++ b/.github/workflows/publish-clice.yml
@@ -97,12 +97,13 @@ jobs:
       - name: Upload assets to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           cd pkg
           mv clice.tar.gz "${{ matrix.asset_name }}" 2>/dev/null || mv clice.zip "${{ matrix.asset_name }}"
           mv clice-symbol.tar.xz "${{ matrix.symbol_asset_name }}" 2>/dev/null \
             || mv clice-symbol.zip "${{ matrix.symbol_asset_name }}"
-          gh release upload "${{ inputs.release_tag }}" --repo "$GITHUB_REPOSITORY" \
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
             --clobber "${{ matrix.asset_name }}" "${{ matrix.symbol_asset_name }}"
 
       # Bridge for publish-vscode.yml: make the package available as an

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -146,20 +146,68 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Upload .vsix to Release
-        uses: softprops/action-gh-release@v3
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
+  # Publishing runs apart from the packaging matrix: the Marketplace
+  # intermittently throws internal errors (TF400898) when six publishes for
+  # one extension land concurrently, and parallel release uploads race on
+  # the same release. Packaging stays parallel above; this single job
+  # uploads and publishes the collected vsix files one at a time.
+  publish-release:
+    needs: publish-vscode
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
         with:
-          files: "editors/vscode/*.vsix"
-          tag_name: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag || github.ref }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pixi
+        with:
+          environments: node
+
+      - name: Download vsix packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: vsix-${{ inputs.source }}-*
+          merge-multiple: true
+          path: vsix
+
+      - name: Upload .vsix to Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.release_tag || github.ref_name }}" \
+            --repo "$GITHUB_REPOSITORY" --clobber vsix/*.vsix
 
       - name: Publish to Marketplace
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
         env:
           VSCE_PAT: ${{ secrets.VSCODE_EXTENSION }}
         run: |
           FLAG="${{ (inputs.prerelease || contains(github.ref_name, '-')) && '--pre-release' || '' }}"
-          pixi run publish-vscode -p "$VSCE_PAT" $FLAG \
-            --packagePath "$GITHUB_WORKSPACE/$(ls editors/vscode/*.vsix)"
+          FAILED=""
+          for f in vsix/*.vsix; do
+            OK=""
+            for ATTEMPT in 1 2 3; do
+              # --skip-duplicate: a rerun meets versions an earlier attempt
+              # already published; that is success, not an error.
+              if pixi run publish-vscode -p "$VSCE_PAT" $FLAG --skip-duplicate \
+                  --packagePath "$GITHUB_WORKSPACE/$f"; then
+                OK=1
+                break
+              fi
+              if [ "$ATTEMPT" -lt 3 ]; then
+                echo "publish failed for $f (attempt $ATTEMPT); retrying in 30s"
+                sleep 30
+              fi
+            done
+            if [ -z "$OK" ]; then
+              FAILED="$FAILED $f"
+            fi
+          done
+          if [ -n "$FAILED" ]; then
+            echo "::error::marketplace publish failed after retries:$FAILED"
+            exit 1
+          fi

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -178,8 +178,9 @@ jobs:
       - name: Upload .vsix to Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
-          gh release upload "${{ inputs.release_tag || github.ref_name }}" \
+          gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" --clobber vsix/*.vsix
 
       - name: Publish to Marketplace

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -151,12 +151,14 @@ jobs:
   # one extension land concurrently, and parallel release uploads race on
   # the same release. Packaging stays parallel above; this single job
   # uploads and publishes the collected vsix files one at a time.
+  # No job-level permissions block: startup validation checks every nested
+  # job against the caller's grant even when the job will be skipped, and
+  # the PR-check caller grants read-only. The publishing callers pass
+  # contents: write at the call site.
   publish-release:
     needs: publish-vscode
     if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.release_tag != '' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
The nightly for v0.1.2026072205 needed four attempts because the Marketplace intermittently returns internal errors (TF400898) when six platform publishes for one extension land concurrently — each rerun cleared a few more targets (3 → 2 → 1 → 0 failures). Parallel release-asset uploads from six jobs also race on the same release.

- The six-target **packaging matrix stays parallel** and now only produces vsix workflow artifacts.
- A new serial `publish-release` job collects the six vsix files, uploads them to the GitHub release in **one `gh release upload --clobber` call**, then publishes them to the Marketplace **one at a time with 3 attempts per vsix** (30s backoff).
- Reruns are idempotent: `--clobber` re-uploads cleanly and `vsce --skip-duplicate` treats versions an earlier attempt already published as success.
- Deliberate semantic change: publishing is now all-or-nothing behind the full packaging matrix (`needs: publish-vscode`). Previously a failed target still let the other five publish, which is exactly the partial state that made reruns awkward; a failed leg now means rerun the failed jobs and publish once, atomically.
- The release runbook documents the recovery path: transient Marketplace failures are fixed by rerunning the `publish-release` job, never by a new tag.

Verified with actionlint; per-path behavior (nightly dispatch, stable tag push, PR check, instant builds) audited against all four callers.