### PR TITLE
chore(build): dedupe flatbuffers, bump kotatsu, gate artifact deps

### DIFF
--- a/.github/workflows/cross-pair.yml
+++ b/.github/workflows/cross-pair.yml
@@ -79,6 +79,16 @@ jobs:
           pixi run -e "${{ inputs.pixi_env }}" -- cmake --build build/RelWithDebInfo \
             --target clice-pack clice-pack-symbol
 
+      # Reject a shipped binary that links a non-system dynamic library (the
+      # conda @rpath libc++ failure mode). llvm binutils read cross-built
+      # ELF/Mach-O on the host; Windows (PE) is not covered yet.
+      - name: Check artifact dependencies
+        if: ${{ !contains(inputs.target_triple, 'windows') }}
+        shell: bash
+        run: |
+          pixi run -e "${{ inputs.pixi_env }}" -- \
+            python scripts/check_artifact_deps.py build/RelWithDebInfo/pack/clice/bin/clice
+
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/cross-pair.yml
+++ b/.github/workflows/cross-pair.yml
@@ -79,9 +79,6 @@ jobs:
           pixi run -e "${{ inputs.pixi_env }}" -- cmake --build build/RelWithDebInfo \
             --target clice-pack clice-pack-symbol
 
-      # Reject a shipped binary that links a non-system dynamic library (the
-      # conda @rpath libc++ failure mode). llvm binutils read cross-built
-      # ELF/Mach-O on the host; Windows (PE) is not covered yet.
       - name: Check artifact dependencies
         if: ${{ !contains(inputs.target_triple, 'windows') }}
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
               - 'tests/**'
               - 'config/**'
               - 'cmake/**'
+              - 'scripts/**'
               - 'editors/nvim/**'
               - 'editors/vscode/**'
               - 'pixi.toml'

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -105,9 +105,6 @@ jobs:
         shell: bash
         run: pixi run -- cmake --build build/${{ matrix.build_type }} --target clice-pack clice-pack-symbol
 
-      # Guard against the shipped binary linking a non-system (e.g. conda
-      # @rpath libc++) dynamic library — the failure mode that once only
-      # surfaced as an editor-test timeout. Windows (PE) is not covered yet.
       - name: Check artifact dependencies
         if: ${{ matrix.asset_name && !contains(matrix.os, 'windows') }}
         shell: bash

--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -105,6 +105,14 @@ jobs:
         shell: bash
         run: pixi run -- cmake --build build/${{ matrix.build_type }} --target clice-pack clice-pack-symbol
 
+      # Guard against the shipped binary linking a non-system (e.g. conda
+      # @rpath libc++) dynamic library — the failure mode that once only
+      # surfaced as an editor-test timeout. Windows (PE) is not covered yet.
+      - name: Check artifact dependencies
+        if: ${{ matrix.asset_name && !contains(matrix.os, 'windows') }}
+        shell: bash
+        run: pixi run -- python scripts/check_artifact_deps.py build/${{ matrix.build_type }}/pack/clice/bin/clice
+
       - name: Upload package artifacts
         if: ${{ matrix.asset_name }}
         uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,15 +155,16 @@ endif()
 set(FBS_SCHEMA_FILE "${PROJECT_SOURCE_DIR}/src/index/schema.fbs")
 set(GENERATED_HEADER "${PROJECT_BINARY_DIR}/generated/schema_generated.h")
 
-# flatc comes from the pixi environment (conda-forge flatbuffers), pinned to
-# match the header version kotatsu fetches. We only run it to codegen the
-# schema header; the flatbuffers runtime is header-only.
+# kotatsu builds the flatbuffers runtime but not its schema compiler, so flatc
+# comes from the pixi environment (conda-forge flatbuffers). Its version must
+# match the headers kotatsu fetches — the generated header static_asserts on
+# that, so a mismatch surfaces as a compile error in schema_generated.h.
 find_program(FLATC_EXECUTABLE flatc REQUIRED)
 
 add_custom_command(
     OUTPUT "${GENERATED_HEADER}"
     COMMAND ${FLATC_EXECUTABLE} --cpp -o "${PROJECT_BINARY_DIR}/generated" "${FBS_SCHEMA_FILE}"
-    DEPENDS "${FBS_SCHEMA_FILE}"
+    DEPENDS "${FBS_SCHEMA_FILE}" "${FLATC_EXECUTABLE}"
     COMMENT "Generating C++ header from ${FBS_SCHEMA_FILE}"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,16 +155,14 @@ endif()
 set(FBS_SCHEMA_FILE "${PROJECT_SOURCE_DIR}/src/index/schema.fbs")
 set(GENERATED_HEADER "${PROJECT_BINARY_DIR}/generated/schema_generated.h")
 
-if(CMAKE_CROSSCOMPILING)
-    find_program(FLATC_EXECUTABLE flatc REQUIRED)
-    set(FLATC_CMD "${FLATC_EXECUTABLE}")
-else()
-    set(FLATC_CMD "$<TARGET_FILE:flatc>")
-endif()
+# flatc comes from the pixi environment (conda-forge flatbuffers), pinned to
+# match the header version kotatsu fetches. We only run it to codegen the
+# schema header; the flatbuffers runtime is header-only.
+find_program(FLATC_EXECUTABLE flatc REQUIRED)
 
 add_custom_command(
     OUTPUT "${GENERATED_HEADER}"
-    COMMAND ${FLATC_CMD} --cpp -o "${PROJECT_BINARY_DIR}/generated" "${FBS_SCHEMA_FILE}"
+    COMMAND ${FLATC_EXECUTABLE} --cpp -o "${PROJECT_BINARY_DIR}/generated" "${FBS_SCHEMA_FILE}"
     DEPENDS "${FBS_SCHEMA_FILE}"
     COMMENT "Generating C++ header from ${FBS_SCHEMA_FILE}"
 )
@@ -221,7 +219,7 @@ target_link_libraries(clice-core PUBLIC
     llvm-libs
     spdlog::spdlog
     roaring::roaring
-    flatbuffers
+    kota::codec::flatbuffers
     kota::ipc::lsp
     kota::codec::toml
     kota::option

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -38,9 +38,10 @@ set(KOTA_ENABLE_TEST OFF)
 set(KOTA_CODEC_ENABLE_SIMDJSON ON)
 set(KOTA_CODEC_ENABLE_YYJSON ON)
 set(KOTA_CODEC_ENABLE_TOML ON)
-# clice uses flatbuffers header-only for index serialization; kotatsu already
-# fetches the flatbuffers headers (v25.2.10) and exposes them as an interface
-# target, so we ride on that instead of fetching/building our own copy.
+# kotatsu already fetches flatbuffers (v25.2.10) for its own codec and links the
+# runtime lib into anything that uses kota::codec, so clice rides on that copy
+# instead of fetching a second one. kotatsu does not build flatc, though, so the
+# schema compiler comes from pixi instead (see CMakeLists.txt).
 set(KOTA_CODEC_ENABLE_FLATBUFFERS ON)
 set(KOTA_ENABLE_EXCEPTIONS OFF)
 set(KOTA_ENABLE_RTTI OFF)

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -27,17 +27,6 @@ FetchContent_Declare(
 set(ENABLE_ROARING_TESTS OFF CACHE INTERNAL "" FORCE)
 set(ENABLE_ROARING_MICROBENCHMARKS OFF CACHE INTERNAL "" FORCE)
 
-# flatbuffers
-FetchContent_Declare(
-    flatbuffers
-    GIT_REPOSITORY https://github.com/google/flatbuffers.git
-    GIT_TAG v25.9.23
-    GIT_SHALLOW TRUE
-)
-set(FLATBUFFERS_BUILD_GRPC OFF CACHE BOOL "" FORCE)
-set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "" FORCE)
-
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
@@ -49,10 +38,14 @@ set(KOTA_ENABLE_TEST OFF)
 set(KOTA_CODEC_ENABLE_SIMDJSON ON)
 set(KOTA_CODEC_ENABLE_YYJSON ON)
 set(KOTA_CODEC_ENABLE_TOML ON)
+# clice uses flatbuffers header-only for index serialization; kotatsu already
+# fetches the flatbuffers headers (v25.2.10) and exposes them as an interface
+# target, so we ride on that instead of fetching/building our own copy.
+set(KOTA_CODEC_ENABLE_FLATBUFFERS ON)
 set(KOTA_ENABLE_EXCEPTIONS OFF)
 set(KOTA_ENABLE_RTTI OFF)
 
-FetchContent_MakeAvailable(kotatsu spdlog croaring flatbuffers)
+FetchContent_MakeAvailable(kotatsu spdlog croaring)
 
 # kotatsu adds -D_LIBCPP_DISABLE_AVAILABILITY globally; on macOS with
 # libc++ >= 21 that makes the headers emit references to dylib-only symbols

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -30,7 +30,7 @@ set(ENABLE_ROARING_MICROBENCHMARKS OFF CACHE INTERNAL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG f2cdf65
+    GIT_TAG febb730
 )
 
 set(KOTA_ENABLE_ZEST ON)
@@ -46,29 +46,3 @@ set(KOTA_ENABLE_EXCEPTIONS OFF)
 set(KOTA_ENABLE_RTTI OFF)
 
 FetchContent_MakeAvailable(kotatsu spdlog croaring)
-
-# kotatsu adds -D_LIBCPP_DISABLE_AVAILABILITY globally; on macOS with
-# libc++ >= 21 that makes the headers emit references to dylib-only symbols
-# (__hash_memory, llvm-project#77653) that the system libc++ lacks, breaking
-# the x64 cross link and poisoning shipped binaries. Directory COMPILE_OPTIONS
-# are copied into each target at creation time, so walk targets (not the
-# directory property) and strip the flag from every kotatsu target. Temporary
-# until the flag is removed upstream in kotatsu.
-function(clice_strip_disable_availability dir)
-    get_directory_property(targets DIRECTORY "${dir}" BUILDSYSTEM_TARGETS)
-    foreach(target IN LISTS targets)
-        get_target_property(target_type ${target} TYPE)
-        if(NOT target_type STREQUAL "INTERFACE_LIBRARY")
-            get_target_property(options ${target} COMPILE_OPTIONS)
-            if(options)
-                list(REMOVE_ITEM options "-D_LIBCPP_DISABLE_AVAILABILITY")
-                set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${options}")
-            endif()
-        endif()
-    endforeach()
-    get_directory_property(subdirs DIRECTORY "${dir}" SUBDIRECTORIES)
-    foreach(subdir IN LISTS subdirs)
-        clice_strip_disable_availability("${subdir}")
-    endforeach()
-endfunction()
-clice_strip_disable_availability("${kotatsu_SOURCE_DIR}")

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -30,7 +30,7 @@ set(ENABLE_ROARING_MICROBENCHMARKS OFF CACHE INTERNAL "" FORCE)
 FetchContent_Declare(
     kotatsu
     GIT_REPOSITORY https://github.com/clice-io/kotatsu
-    GIT_TAG febb730
+    GIT_TAG c516e3ae0ca3c7d7fb35fdcfdc7c6a111adef764
 )
 
 set(KOTA_ENABLE_ZEST ON)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -71,17 +71,10 @@ if(WIN32)
         set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PATH}" CACHE FILEPATH "")
         set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PATH}" CACHE FILEPATH "")
     endif()
-    # TODO(prebuilt-respin): switch to "MultiThreaded" (/MT) so the shipped exe
-    # is self-contained. /MD makes it import MSVCP140.dll and VCRUNTIME140.dll
-    # (x64 also VCRUNTIME140_1.dll), which ship with the Visual C++
-    # redistributable rather than with Windows, so a machine without the
-    # redistributable cannot start clice. This flag cannot be flipped on its
-    # own: every object embeds /DEFAULTLIB and /FAILIFMISMATCH directives
-    # naming its CRT, so linking a /MD prebuilt LLVM into a /MT clice is a hard
-    # link error, not a warning. The prebuilt is built with this same toolchain
-    # file, so it has to be respun to /MT in the same change. Local Windows
-    # Debug builds would also need the static ASan runtime in place of the
-    # clang_rt.asan_dynamic pair linked in CMakeLists.txt.
+    # TODO(prebuilt-respin): switch to "MultiThreaded" (/MT). /MD makes the exe
+    # import MSVCP140.dll and VCRUNTIME140.dll, which come from the Visual C++
+    # redistributable rather than from Windows. The CRT is baked into every
+    # object, so the prebuilt LLVM must be respun to /MT in the same change.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING "")
     set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld-link")
     set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld-link")
@@ -99,11 +92,9 @@ endif()
 
 if(APPLE)
     # TODO(prebuilt-respin): set an explicit CMAKE_OSX_DEPLOYMENT_TARGET. With
-    # none, the deployment target follows whatever the build machine runs, so
-    # the shipped binary is stamped minos 15.0 and refuses to launch on macOS
-    # 14 or older. Lowering it needs the prebuilt LLVM built against the same
-    # target, and needs availability annotations to stay on (see the kotatsu
-    # _LIBCPP_DISABLE_AVAILABILITY removal), so it belongs with the respin.
+    # none it follows the build machine, so the artifact is stamped minos 15.0
+    # and will not launch on macOS 14 or older. Lowering it needs the prebuilt
+    # built against the same target.
 
     # conda-forge clang 22's bundled config files (<triple>-clang++.cfg)
     # inject -L/-rpath pointing into the conda env at link time, binding
@@ -117,12 +108,11 @@ if(APPLE)
     string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " --no-default-config")
     string(APPEND CMAKE_MODULE_LINKER_FLAGS_INIT " --no-default-config")
 
-    # TODO(prebuilt-respin): remove this once the prebuilt is respun — its
-    # dylibs will then link the system libc++ via --no-default-config above.
     # Debug links the prebuilt LLVM ASan dylibs, which reference conda's
     # @rpath libc++ with rpaths baked for the machine that built them.
     # Debug binaries are CI-internal, so resolve libc++ from the build
-    # env instead.
+    # env instead. TODO(prebuilt-respin): remove once the prebuilt is
+    # respun — its dylibs will then link the system libc++ above.
     if(DEFINED ENV{CONDA_PREFIX})
         string(APPEND CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT " -Wl,-rpath,$ENV{CONDA_PREFIX}/lib")
         string(APPEND CMAKE_SHARED_LINKER_FLAGS_DEBUG_INIT " -Wl,-rpath,$ENV{CONDA_PREFIX}/lib")

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -71,6 +71,17 @@ if(WIN32)
         set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PATH}" CACHE FILEPATH "")
         set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PATH}" CACHE FILEPATH "")
     endif()
+    # TODO(prebuilt-respin): switch to "MultiThreaded" (/MT) so the shipped exe
+    # is self-contained. /MD makes it import MSVCP140.dll and VCRUNTIME140.dll
+    # (x64 also VCRUNTIME140_1.dll), which ship with the Visual C++
+    # redistributable rather than with Windows, so a machine without the
+    # redistributable cannot start clice. This flag cannot be flipped on its
+    # own: every object embeds /DEFAULTLIB and /FAILIFMISMATCH directives
+    # naming its CRT, so linking a /MD prebuilt LLVM into a /MT clice is a hard
+    # link error, not a warning. The prebuilt is built with this same toolchain
+    # file, so it has to be respun to /MT in the same change. Local Windows
+    # Debug builds would also need the static ASan runtime in place of the
+    # clang_rt.asan_dynamic pair linked in CMakeLists.txt.
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL" CACHE STRING "")
     set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld-link")
     set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld-link")
@@ -87,6 +98,13 @@ else()
 endif()
 
 if(APPLE)
+    # TODO(prebuilt-respin): set an explicit CMAKE_OSX_DEPLOYMENT_TARGET. With
+    # none, the deployment target follows whatever the build machine runs, so
+    # the shipped binary is stamped minos 15.0 and refuses to launch on macOS
+    # 14 or older. Lowering it needs the prebuilt LLVM built against the same
+    # target, and needs availability annotations to stay on (see the kotatsu
+    # _LIBCPP_DISABLE_AVAILABILITY removal), so it belongs with the respin.
+
     # conda-forge clang 22's bundled config files (<triple>-clang++.cfg)
     # inject -L/-rpath pointing into the conda env at link time, binding
     # binaries to conda's @rpath libc++ — they then fail to load outside
@@ -99,11 +117,12 @@ if(APPLE)
     string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " --no-default-config")
     string(APPEND CMAKE_MODULE_LINKER_FLAGS_INIT " --no-default-config")
 
+    # TODO(prebuilt-respin): remove this once the prebuilt is respun — its
+    # dylibs will then link the system libc++ via --no-default-config above.
     # Debug links the prebuilt LLVM ASan dylibs, which reference conda's
     # @rpath libc++ with rpaths baked for the machine that built them.
     # Debug binaries are CI-internal, so resolve libc++ from the build
-    # env instead. Remove once the prebuilt is respun (its dylibs will
-    # then link the system libc++ via --no-default-config above).
+    # env instead.
     if(DEFINED ENV{CONDA_PREFIX})
         string(APPEND CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT " -Wl,-rpath,$ENV{CONDA_PREFIX}/lib")
         string(APPEND CMAKE_SHARED_LINKER_FLAGS_DEBUG_INIT " -Wl,-rpath,$ENV{CONDA_PREFIX}/lib")

--- a/pixi.lock
+++ b/pixi.lock
@@ -57,7 +57,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-aarch64-15.1.0-hed9a4ee_5.conda
@@ -146,7 +146,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.4.0-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt-22.1.8-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt22-22.1.8-hfefdfc9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.9.23-h5248ec3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.2.10-ha90f286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -224,7 +224,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-4.4.0-h2426fb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.8-h694c41f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.8-h1637cdf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.2.10-h2cf7b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h3ddfcb2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-956.6-llvm22_1_hc399b6d_4.conda
@@ -294,7 +294,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.4.0-h8cb302d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.8-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.8-hd34ed20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.2.10-h3144c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-956.6-llvm22_1_h5b97f1b_4.conda
@@ -356,7 +356,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.4.0-hdcbee5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-22.1.8-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt22-22.1.8-h49e36cd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.9.23-h4025804_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.2.10-hc130f0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_hf735972_3.conda
@@ -415,7 +415,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
@@ -494,7 +494,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.3.1-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt-22.1.8-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt22-22.1.8-hfefdfc9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.9.23-h5248ec3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.2.10-ha90f286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
@@ -570,7 +570,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-4.3.1-h2426fb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.8-h694c41f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.8-h1637cdf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.2.10-h2cf7b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-956.6-llvm22_1_hc399b6d_4.conda
@@ -639,7 +639,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.3.1-h8cb302d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.8-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.8-hd34ed20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.2.10-h3144c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-956.6-llvm22_1_h5b97f1b_4.conda
@@ -700,7 +700,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.3.1-hdcbee5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-22.1.8-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt22-22.1.8-h49e36cd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.9.23-h4025804_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.2.10-hc130f0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_hf735972_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcompiler-rt-22.1.8-h49e36cd_1.conda
@@ -760,7 +760,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
@@ -854,7 +854,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.3.1-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt-22.1.8-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt22-22.1.8-hfefdfc9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.9.23-h5248ec3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.2.10-ha90f286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
@@ -944,7 +944,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-4.3.1-h2426fb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.8-h694c41f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.8-h1637cdf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.2.10-h2cf7b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-956.6-llvm22_1_hc399b6d_4.conda
@@ -1027,7 +1027,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.2.1-h54ad630_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.8-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.8-hd34ed20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.2.10-h3144c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.1-h38cb7af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-956.6-llvm22_1_h5b97f1b_4.conda
@@ -1102,7 +1102,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.2.1-hdcbee5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-22.1.8-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt22-22.1.8-h49e36cd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.9.23-h4025804_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.2.10-hc130f0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.1-h637d24d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_hf735972_3.conda
@@ -1724,7 +1724,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
@@ -1817,7 +1817,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-4.3.1-hc9d863e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt-22.1.8-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/compiler-rt22-22.1.8-hfefdfc9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.9.23-h5248ec3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.2.10-ha90f286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
@@ -1907,7 +1907,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-4.3.1-h2426fb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.8-h694c41f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.8-h1637cdf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.2.10-h2cf7b43_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-956.6-llvm22_1_hc399b6d_4.conda
@@ -1990,7 +1990,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.2.1-h54ad630_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.8-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.8-hd34ed20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.2.10-h3144c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-956.6-llvm22_1_h5b97f1b_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm22_1_h692d5aa_4.conda
@@ -2064,7 +2064,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-4.2.1-hdcbee5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt-22.1.8-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/compiler-rt22-22.1.8-h49e36cd_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.9.23-h4025804_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.2.10-hc130f0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-22.1.8-default_hf735972_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcompiler-rt-22.1.8-h49e36cd_1.conda
@@ -2942,21 +2942,21 @@ packages:
   license_family: MIT
   size: 1209421
   timestamp: 1757336717570
-- conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
-  sha256: e5f90c2fd61012d6ad332657a5bf5455620f0db8524f0b005d91e1c2737bad69
-  md5: 10a330bfd5345af730b0fc1349d15eaf
+- conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
+  sha256: 0e58114d0e16bc89b94ef9068558e304d2eccae5dbaa55b955274ea60da81dfd
+  md5: 279ba9719d1afc81538d8260f31e42a0
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc >=13
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
   purls: []
   run_exports:
     weak:
-    - flatbuffers >=25.9.23,<25.9.24.0a0
-  size: 1584732
-  timestamp: 1761142459651
+    - flatbuffers >=25.2.10,<25.2.11.0a0
+  size: 1539958
+  timestamp: 1747130572350
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
   sha256: 3740f57b37cf2d7b92ad25c88c414bd277938f03e7add166fa77789180310d82
   md5: 64929ec997f947630434b6b812fff11e
@@ -5162,20 +5162,20 @@ packages:
   license_family: MIT
   size: 1113801
   timestamp: 1773352768018
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.9.23-h5248ec3_0.conda
-  sha256: 9e0559987ca6a4a5b4a942514709311993ded4b1fb911a1fc69876ba3e221fe0
-  md5: b68619170886a3289fdc167e1120122c
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-25.2.10-ha90f286_0.conda
+  sha256: 0d802dd9a8b804521a25ee21423a674d73d5ac6cecc2faae4264b5286f9d2deb
+  md5: 2093f2029d159ec0dc522f42990c0bd2
   depends:
-  - libgcc >=14
-  - libstdcxx >=14
+  - libgcc >=13
+  - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
   purls: []
   run_exports:
     weak:
-    - flatbuffers >=25.9.23,<25.9.24.0a0
-  size: 1414741
-  timestamp: 1761328999536
+    - flatbuffers >=25.2.10,<25.2.11.0a0
+  size: 1380724
+  timestamp: 1747130553663
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
   sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
   md5: 546da38c2fa9efacf203e2ad3f987c59
@@ -7079,20 +7079,20 @@ packages:
   license_family: MIT
   size: 1133353
   timestamp: 1773353161332
-- conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
-  sha256: 7d430e5fbe47e690e00345e4c5a856d2469aa1ea6afc573e8dabd0eb8aabea5f
-  md5: 314a166f491f531788ad6220acad496c
+- conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.2.10-h2cf7b43_0.conda
+  sha256: eb6be3a3db53cb53f9300f08cfd6579549787e6ec45007d589f4629fec1b9a42
+  md5: 109d4025e003f228844a06f246503177
   depends:
   - __osx >=10.13
-  - libcxx >=19
+  - libcxx >=18
   license: Apache-2.0
   license_family: APACHE
   purls: []
   run_exports:
     weak:
-    - flatbuffers >=25.9.23,<25.9.24.0a0
-  size: 1358478
-  timestamp: 1761142801269
+    - flatbuffers >=25.2.10,<25.2.11.0a0
+  size: 1337567
+  timestamp: 1747130405020
 - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
   sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
   md5: 627eca44e62e2b665eeec57a984a7f00
@@ -8472,20 +8472,20 @@ packages:
   license_family: MIT
   size: 1050638
   timestamp: 1757337263602
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
-  sha256: b8f4ce2919f2542c6688af909c18f9672b2a19efdb57118c5f415dd5ff0fb3cd
-  md5: 1d6e0829bc8d6907fae9a81f169414ce
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.2.10-h3144c11_0.conda
+  sha256: d339e7b15c6a927b6ecdb27513d001ab037e3d4bb146fa498e330cbec0cdf9fe
+  md5: 87c66c4a31165b25b9f56da755197a64
   depends:
   - __osx >=11.0
-  - libcxx >=19
+  - libcxx >=18
   license: Apache-2.0
   license_family: APACHE
   purls: []
   run_exports:
     weak:
-    - flatbuffers >=25.9.23,<25.9.24.0a0
-  size: 1299156
-  timestamp: 1761143339517
+    - flatbuffers >=25.2.10,<25.2.11.0a0
+  size: 1286290
+  timestamp: 1747130536643
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
   md5: 5eb22c1d7b3fc4abb50d92d621583137
@@ -10158,21 +10158,21 @@ packages:
   license_family: MIT
   size: 1196708
   timestamp: 1757337405047
-- conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.9.23-h4025804_0.conda
-  sha256: dc5a1b8bf5c667f5d86bdafd56faabbd2cfd3d498d612f709e6bf493a52c4713
-  md5: e9eda0b0b9dd959828fa35e84cc09669
+- conda: https://conda.anaconda.org/conda-forge/win-64/flatbuffers-25.2.10-hc130f0a_0.conda
+  sha256: 8c26cca2271d99e8b723847c3a3a7e7de3f5f1908dbd1d2413e6b0b154b97d47
+  md5: 29353e2ac55f6192b1a5bb0244021128
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
   purls: []
   run_exports:
     weak:
-    - flatbuffers >=25.9.23,<25.9.24.0a0
-  size: 1777143
-  timestamp: 1761142523983
+    - flatbuffers >=25.2.10,<25.2.11.0a0
+  size: 1753609
+  timestamp: 1747130826577
 - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.1-h637d24d_0.conda
   sha256: bee083d5a0f05c380fcec1f30a71ef5518b23563aeb0a21f6b60b792645f9689
   md5: cb8048bed35ef01431184d6a88e46b3e

--- a/pixi.lock
+++ b/pixi.lock
@@ -56,16 +56,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.4.0-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-aarch64-15.1.0-hed9a4ee_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-aarch64-15.1.0-he1a95ce_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-aarch64-15.1.0-h73b5d84_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-aarch64-15.1.0-h8b95c0a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-aarch64-15.2.0-he60e42a_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-aarch64-15.2.0-hf143b70_27.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-aarch64-15.2.0-h4327bcd_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-aarch64-15.2.0-ha206bb4_27.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -90,7 +90,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
@@ -120,10 +120,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.1.0-h0c6536c_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.1.0-h0c6536c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h8a1c250_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-h3c77fe8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
@@ -397,8 +397,8 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ccache-4.13.2-hedf47ba_0.conda
@@ -414,16 +414,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.3.1-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h6c227bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h9692865_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
@@ -442,7 +442,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
@@ -471,8 +471,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_linux-64-22.1.8-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -742,8 +742,8 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ccache-4.13.2-hedf47ba_0.conda
@@ -759,16 +759,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.2.1-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.1-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h6c227bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h9692865_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
@@ -787,7 +787,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-hf4e2dac_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
@@ -817,8 +817,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_linux-64-22.1.8-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -1706,8 +1706,8 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45-default_h4852527_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ccache-4.13.2-hedf47ba_0.conda
@@ -1723,15 +1723,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.2.1-hc85cc9f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.2.10-hb7832b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h6c227bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h9692865_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
@@ -1750,7 +1750,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
@@ -1780,8 +1780,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_linux-64-22.1.8-hffcefe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h8577fbf_1.conda
@@ -2120,15 +2120,15 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
@@ -2137,7 +2137,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
@@ -2154,8 +2154,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -2459,16 +2459,6 @@ packages:
   run_exports: {}
   size: 35432
   timestamp: 1766513140840
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
-  sha256: 3c7c5580c1720206f28b7fa3d60d17986b3f32465e63009c14c9ae1ea64f926c
-  md5: 212fe5f1067445544c99dc1c847d032c
-  depends:
-  - binutils_impl_linux-64 >=2.45.1,<2.45.2.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  run_exports: {}
-  size: 35436
-  timestamp: 1774197482571
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
   sha256: 659c367ef49df7741749a2ad240b007d7df51b4f210505a78543deafb001e44c
   md5: e8452fe381cac5fff20563a07722dfa5
@@ -2476,21 +2466,10 @@ packages:
   - binutils_impl_linux-64 >=2.46.1,<2.46.2.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   run_exports: {}
   size: 35399
   timestamp: 1784214547142
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
-  sha256: 054a77ccab631071a803737ea8e5d04b5b18e57db5b0826a04495bd3fdf39a7c
-  md5: a7a67bf132a4a2dea92a7cb498cdc5b1
-  depends:
-  - ld_impl_linux-64 2.45 default_hbd61a6d_104
-  - sysroot_linux-64
-  - zstd >=1.5.7,<1.6.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 3747046
-  timestamp: 1764007847963
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_105.conda
   sha256: 17fbb32191430310d3eb8309f80a8df54f0d66eda9cf84b2ae5113e6d74e24d8
   md5: e410a8f80e22eb6d840e39ac6a34bd0e
@@ -2504,18 +2483,6 @@ packages:
   run_exports: {}
   size: 3719982
   timestamp: 1766513109980
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
-  sha256: 0a7d405064f53b9d91d92515f1460f7906ee5e8523f3cd8973430e81219f4917
-  md5: 8165352fdce2d2025bf884dc0ee85700
-  depends:
-  - ld_impl_linux-64 2.45.1 default_hbd61a6d_102
-  - sysroot_linux-64
-  - zstd >=1.5.7,<1.6.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 3661455
-  timestamp: 1774197460085
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
   sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
   md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
@@ -2525,6 +2492,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   run_exports: {}
   size: 3713752
   timestamp: 1784214522814
@@ -2919,17 +2887,16 @@ packages:
   run_exports: {}
   size: 115679
   timestamp: 1781741196856
-- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.1.0-hc55bae6_5.conda
-  sha256: e1ee96f81e48507ede67ff15651ae477bda4b512eab438027cf7c3002223973e
-  md5: 9cb6d34614938b4ebfca7f54cf1e766f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-15.2.0-h53410ce_20.conda
+  sha256: a74410edbdccfe386a13995242175fddffdc9374295a189cf810625707eec153
+  md5: 6f13db9f6663f12724a932f29bfc3317
   depends:
-  - gcc_impl_linux-64 >=15.1.0,<15.1.1.0a0
+  - gcc_impl_linux-64 >=15.2.0,<15.2.1.0a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 33167
-  timestamp: 1757042749056
+  size: 32354
+  timestamp: 1784923998243
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fd-find-10.3.0-hdab8a38_0.conda
   sha256: 55d3011ca72e1d97acc651b2af5d4d4d785988a8cfa9026205e9cf11f2d4ee67
   md5: 1b8aaa7bb23496abb0e23369db7fb5b7
@@ -2957,54 +2924,53 @@ packages:
     - flatbuffers >=25.2.10,<25.2.11.0a0
   size: 1539958
   timestamp: 1747130572350
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.1.0-hd165ed4_5.conda
-  sha256: 3740f57b37cf2d7b92ad25c88c414bd277938f03e7add166fa77789180310d82
-  md5: 64929ec997f947630434b6b812fff11e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.2.0-hc6a0c74_20.conda
+  sha256: 559aebbc0b6754681c7eec0b6ef8924a13eaa4c110510e99b8224ef3020fed69
+  md5: 07a50d62feaa7d8656ee442bdc2c0e8d
   depends:
   - conda-gcc-specs
-  - gcc_impl_linux-64 15.1.0.*
+  - gcc_impl_linux-64 15.2.0 h8ddf172_20
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
   run_exports: {}
-  size: 30919
-  timestamp: 1757042894962
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_5.conda
-  sha256: 725aac2128459f5a7d38df35024e300c02bec33dc4ebb9d2bdd79e15858c5046
-  md5: 4c1dbd9316a6916e63439f79d7a81c4b
+  size: 29163
+  timestamp: 1784924103503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-h8ddf172_20.conda
+  sha256: 8e5725dfd8dfb4df6b78252abca52e29c778862900714d38aed6328144da229b
+  md5: 2b360e802262428a5e21312b3c95fffb
   depends:
-  - binutils_impl_linux-64 >=2.40
-  - libgcc >=15.1.0
-  - libgcc-devel_linux-64 15.1.0 h4c094af_105
-  - libgomp >=15.1.0
-  - libsanitizer 15.1.0 h97b714f_5
-  - libstdcxx >=15.1.0
+  - binutils_impl_linux-64 >=2.46.1
+  - libgcc >=15.2.0
+  - libgcc-devel_linux-64 15.2.0 hcc6f6b0_120
+  - libgomp >=15.2.0
+  - libsanitizer 15.2.0 h984fb3e_20
+  - libstdcxx >=15.2.0
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_120
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 77602037
-  timestamp: 1757042646901
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-aarch64-15.1.0-hed9a4ee_5.conda
-  sha256: 7cde3006dc4264838c20d102f32c4f31aaf43b94bbae1615c678cdd8f502c15d
-  md5: cf9303bdbcdc33eee49f564ed0870638
+  size: 81311910
+  timestamp: 1784923892134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-aarch64-15.2.0-he60e42a_20.conda
+  sha256: 5b7f59689626215b577b05e6b62229568b57113f4697aa950ab177bd8511f126
+  md5: 3c72dd52f2c0b02482a95e877304debd
   depends:
-  - binutils_impl_linux-aarch64 >=2.40
-  - libgcc-devel_linux-aarch64 15.1.0 h0c6536c_5
+  - binutils_impl_linux-aarch64 >=2.46.1
+  - libgcc-devel_linux-aarch64 15.2.0 h8a1c250_20
+  - libstdcxx-devel_linux-aarch64 15.2.0 h3c77fe8_20
   - sysroot_linux-aarch64
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   run_exports: {}
-  size: 465475334
-  timestamp: 1757041225885
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-aarch64-15.1.0-he1a95ce_11.conda
-  sha256: c4b79510ca4b07328947ebabff471b0bb592a28ac733b75a31defab749b74ebd
-  md5: 8a4cf8350885f48deb708a4334fdf26d
+  size: 85916233
+  timestamp: 1784923109666
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-aarch64-15.2.0-hf143b70_27.conda
+  sha256: abab9571b8b7e6bdea801ab9f98625084ac9efe902e4f797e8dc0101827e7d1f
+  md5: 9037db896880a369fc9e47045109eabc
   depends:
+  - gcc_impl_linux-64 15.2.0.*
+  - gcc_impl_linux-aarch64 15.2.0.*
   - binutils_linux-aarch64
-  - gcc_impl_linux-64 15.1.0.*
-  - gcc_impl_linux-aarch64 15.1.0.*
   - sysroot_linux-64
   - sysroot_linux-aarch64
   license: BSD-3-Clause
@@ -3012,55 +2978,53 @@ packages:
   run_exports:
     strong:
     - libgcc >=15
-  size: 32514
-  timestamp: 1748907357174
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.1.0-h33e79ad_5.conda
-  sha256: b3205660bbe91156afaf66289a59c693fe4d476c8ba07f29693e75a1e72027d6
-  md5: 7e6d4d25c1e512e7b03fdf28833686f5
+  size: 29309
+  timestamp: 1781279945653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.2.0-h834e499_7.conda
+  sha256: daa8be8e1ee8b01a4f632e421ff0fb7dcbf6aabfb036fc67f61495775fb576b8
+  md5: d9e0c692abcf86b9b259825454b0ae40
   depends:
-  - gcc 15.1.0.*
-  - gxx_impl_linux-64 15.1.0.*
+  - gcc 15.2.0.*
+  - gxx_impl_linux-64 15.2.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
   run_exports: {}
-  size: 30387
-  timestamp: 1757042917228
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.1.0-h6a1bac1_5.conda
-  sha256: 9fb73c0135fd1d7f9279cce4bb7652bef13e715c2f8330ba2a4982a99c69eab4
-  md5: a8e2ebf76bfd4d0e67b1047c340cf915
+  size: 30506
+  timestamp: 1759968643632
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-he8f701c_20.conda
+  sha256: 4cfbde34c89ad1707ebd240b0ba705aae912de9ba24792d2a0e2872c1d9fce2a
+  md5: 8541ee94f1d03791333d6341b65436a2
   depends:
-  - gcc_impl_linux-64 15.1.0 h4393ad2_5
-  - libstdcxx-devel_linux-64 15.1.0 h4c094af_105
+  - gcc_impl_linux-64 15.2.0 h8ddf172_20
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_120
   - sysroot_linux-64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 15776077
-  timestamp: 1757042854396
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-aarch64-15.1.0-h73b5d84_5.conda
-  sha256: aa1eeb3e416706fb94bdf24a969a1328bd4f82fc968ddc61fd1135efd8128b67
-  md5: 74c77e35accd83be33a25053ae73cf32
+  size: 15603218
+  timestamp: 1784924072148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-aarch64-15.2.0-h4327bcd_20.conda
+  sha256: e737335a05a876c142fef33718b1b182af741a3f384bc3652d9e66ecf099ad2c
+  md5: 6205a38904e9f60347b50f6008aa119c
   depends:
-  - gcc_impl_linux-aarch64 15.1.0 hed9a4ee_5
-  - libstdcxx-devel_linux-aarch64 15.1.0 h0c6536c_5
+  - gcc_impl_linux-aarch64 15.2.0 he60e42a_20
+  - libstdcxx-devel_linux-aarch64 15.2.0 h3c77fe8_20
   - sysroot_linux-aarch64
   - tzdata
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   run_exports: {}
-  size: 116454703
-  timestamp: 1757042387601
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-aarch64-15.1.0-h8b95c0a_11.conda
-  sha256: 1dc055f591e449724213dfa9154c92e43b2b935563d82a61b0690bcc468487da
-  md5: a3f4feb7b2015e6088045064798b0d6e
+  size: 15952476
+  timestamp: 1784923278899
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-aarch64-15.2.0-ha206bb4_27.conda
+  sha256: 746fd1d7ec3d22db5fb8a5d04322b7b0ded0e7a4a3d4c2f1d1535bddaf70a7d6
+  md5: 0201e09a96ca558c50a7b2938aed38e0
   depends:
+  - gxx_impl_linux-64 15.2.0.*
+  - gxx_impl_linux-aarch64 15.2.0.*
+  - gcc_linux-aarch64 ==15.2.0 hf143b70_27
   - binutils_linux-aarch64
-  - gcc_linux-aarch64 15.1.0 he1a95ce_11
-  - gxx_impl_linux-64 15.1.0.*
-  - gxx_impl_linux-aarch64 15.1.0.*
   - sysroot_linux-aarch64
   license: BSD-3-Clause
   license_family: BSD
@@ -3068,8 +3032,8 @@ packages:
     strong:
     - libstdcxx >=15
     - libgcc >=15
-  size: 30833
-  timestamp: 1748907375942
+  size: 27885
+  timestamp: 1781279945653
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
@@ -3169,19 +3133,6 @@ packages:
     - krb5 >=1.22.2,<1.23.0a0
   size: 1388990
   timestamp: 1781859420533
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
-  sha256: 9e191baf2426a19507f1d0a17be0fdb7aa155cdf0f61d5a09c808e0a69464312
-  md5: a6abd2796fc332536735f68ba23f7901
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.45
-  license: GPL-3.0-only
-  license_family: GPL
-  purls: []
-  size: 725545
-  timestamp: 1764007826689
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_105.conda
   sha256: 1027bd8aa0d5144e954e426ab6218fd5c14e54a98f571985675468b339c808ca
   md5: 3ec0aa5037d39b06554109a01e6fb0c6
@@ -3218,6 +3169,7 @@ packages:
   - binutils_impl_linux-64 2.46.1
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   run_exports: {}
   size: 745303
   timestamp: 1784214507189
@@ -3754,21 +3706,20 @@ packages:
     - libpsl >=0.22.0,<0.23.0a0
   size: 70092
   timestamp: 1783936855082
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_5.conda
-  sha256: 60a9318c41d9d3d0dc235e015799b60a609d801320a5443ec2c4a13c40ceda19
-  md5: 7c9027f66aaca7dcfb9688da0e6f7845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h984fb3e_20.conda
+  sha256: d7b184884d924154c2ffb924e188be93d5922096e3754d11a26277d99a8f3943
+  md5: fd805662ef1211d7a54d98fd4efb130b
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=15.1.0
-  - libstdcxx >=15.1.0
+  - libgcc >=15.2.0
+  - libstdcxx >=15.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     weak:
-    - libsanitizer 15.1.0
-  size: 5203111
-  timestamp: 1757042586073
+    - libsanitizer 15.2.0
+  size: 7403387
+  timestamp: 1784923843022
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
   sha256: 6f0e8a812e8e33a4d8b7a0e595efe28373080d27b78ee4828aa4f6649a088454
   md5: 2e1b84d273b01835256e53fd938de355
@@ -6561,17 +6512,6 @@ packages:
   run_exports: {}
   size: 1149924
   timestamp: 1781670214284
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_105.conda
-  sha256: 714648a02a42bf9c9ee63be4d56ee88de0c66e3b1c8f041995512173b0482278
-  md5: a38922dbdf037d78b3d00d6d0a0399da
-  depends:
-  - __unix
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  run_exports: {}
-  size: 2728198
-  timestamp: 1757042471636
 - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
   sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
   md5: 683fcb168e1df9a21fa80d5aa2d9330b
@@ -6582,16 +6522,16 @@ packages:
   run_exports: {}
   size: 3095909
   timestamp: 1778268932148
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.1.0-h0c6536c_5.conda
-  sha256: 4244fab8d907955478defc30b5af67026158d04515781cee7563fca7d11c52a3
-  md5: d3f0956ab5dfc2458d145568cf4e0496
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_120.conda
+  sha256: a57003c6ea0d7464d06f1e37ac3832faa0578b48e51896c896d83eda01c83d04
+  md5: c2d79cd96c64647ada04757c41803c87
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
+  purls: []
   run_exports: {}
-  size: 2117272
-  timestamp: 1757041091263
+  size: 3085810
+  timestamp: 1784923656707
 - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_118.conda
   sha256: 661e29553769ceb5874eb1ed6c00263fcd36fac9f5fe0fee65d5e5cac3187ff3
   md5: 42284981c315916d916fb3156b8d5b9e
@@ -6612,27 +6552,34 @@ packages:
   run_exports: {}
   size: 2353893
   timestamp: 1778268665954
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.1.0-h4c094af_105.conda
-  sha256: 7eb7bee2316673db612899ddf5cadef90b5e78da2832af6cb80b55bd3fb0056f
-  md5: 3bc809fa9c4b2cd49ed38fe555af5f99
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h8a1c250_20.conda
+  sha256: 4a540d58263374761a707d16dc62eeadf6965bc5121d4916b63e348b5df349f2
+  md5: b6c943413fb0710ced83a41613a70e5c
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
+  run_exports: {}
+  size: 2344703
+  timestamp: 1784923037742
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_120.conda
+  sha256: 3cabbd98a31d584517c9d8588f5a5b32b49d9898bcce379f41f6138d5af6d6be
+  md5: 05a8304d2ab5aa21c7144a114596f669
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
   purls: []
   run_exports: {}
-  size: 14716938
-  timestamp: 1757042497739
-- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.1.0-h0c6536c_5.conda
-  sha256: cdc0d70fdc81f794cfbe58119d15a180353544a0c94e06b51cb9ff611f37c002
-  md5: 2a9d7d97e4cae2b8c4f559eedd4e2684
+  size: 20731561
+  timestamp: 1784923742656
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-h3c77fe8_20.conda
+  sha256: 276b7be5b50fac1612c54a87f544f13d6ff5c5218f1ebaf93c62b809527dcca8
+  md5: 8bc6d611be95dc3fc3fef19f0a1c3a87
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   run_exports: {}
-  size: 12756963
-  timestamp: 1757041110769
+  size: 16936444
+  timestamp: 1784923048897
 - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_118.conda
   sha256: 52afca5e24e0bbc840cf9c28b440dea2cebc4500e97084a38cdd27fdc8a3e57c
   md5: 99ea26f70c5e380294e760e8bdbaddff

--- a/pixi.toml
+++ b/pixi.toml
@@ -53,8 +53,8 @@ sccache = "*"
 
 [feature.build.target.linux-64.dependencies]
 sysroot_linux-64 = "==2.17"
-gcc = "==15.1.0"
-gxx = "==15.1.0"
+gcc = "==15.2.0"
+gxx = "==15.2.0"
 ccache = "*"
 
 [feature.build.target.osx-arm64.dependencies]
@@ -69,8 +69,8 @@ scripts = ["scripts/activate_asan.bat"]
 # Linux arm64 (from x64): needs the aarch64 sysroot and cross gcc for libstdc++.
 [feature.cross-linux-arm64.target.linux-64.dependencies]
 sysroot_linux-aarch64 = "==2.17"
-gcc_linux-aarch64 = "==15.1.0"
-gxx_linux-aarch64 = "==15.1.0"
+gcc_linux-aarch64 = "==15.2.0"
+gxx_linux-aarch64 = "==15.2.0"
 
 [feature.cross-linux-arm64.target.linux-64.activation]
 scripts = ["scripts/activate_cross_linux.sh"]
@@ -88,8 +88,8 @@ python = ">=3.13"
 # (<print>), so the test env must provide the same pinned gcc the build
 # env uses — runner system gcc is too old.
 [feature.test.target.linux-64.dependencies]
-gcc = "==15.1.0"
-gxx = "==15.1.0"
+gcc = "==15.2.0"
+gxx = "==15.2.0"
 # The symbolization round-trip test replays the release strip/GSYM flow
 # (linux-only, like the crash tests it builds on).
 llvm-tools = "==22.1.8"

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,7 +42,9 @@ lld = "==22.1.8"
 llvm-tools = "==22.1.8"
 clang-tools = "==22.1.8"
 compiler-rt = "==22.1.8"
-flatbuffers = "==25.9.23"
+# Must match the flatbuffers headers kotatsu fetches (v25.2.10): flatc-
+# generated headers carry a static_assert pinning them to that version.
+flatbuffers = "==25.2.10"
 # cmake/archive.cmake pipes tar through xz for the symbol archives.
 xz = ">=5.8.1,<6"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,8 +42,7 @@ lld = "==22.1.8"
 llvm-tools = "==22.1.8"
 clang-tools = "==22.1.8"
 compiler-rt = "==22.1.8"
-# Must match the flatbuffers headers kotatsu fetches (v25.2.10): flatc-
-# generated headers carry a static_assert pinning them to that version.
+# Must match the headers kotatsu fetches — generated code static_asserts on it.
 flatbuffers = "==25.2.10"
 # cmake/archive.cmake pipes tar through xz for the symbol archives.
 xz = ">=5.8.1,<6"

--- a/scripts/check_artifact_deps.py
+++ b/scripts/check_artifact_deps.py
@@ -13,14 +13,10 @@ instead of the OS.
 Both branches use LLVM binutils (``llvm-otool`` / ``llvm-readelf``), which ship
 in the build env and can read Mach-O even from a Linux host.
 
-TODO: read PE too, so the two Windows artifacts stop being the blind spot. They
-are not dependency-free — both import ``MSVCP140.dll`` and ``VCRUNTIME140.dll``
-(x64 also ``VCRUNTIME140_1.dll``), which come from the Visual C++
-redistributable rather than from Windows. That is a real instance of the thing
-this script looks for, so the whitelist (Win32 system DLLs plus the
-``api-ms-win-crt-*`` UCRT forwarders, which *are* part of Windows) should treat
-them as a violation only once the build switches to a static CRT — see the
-TODO(prebuilt-respin) note in cmake/toolchain.cmake.
+TODO: read PE too. The Windows artifacts import ``MSVCP140.dll`` and
+``VCRUNTIME140.dll``, which come from the Visual C++ redistributable rather than
+from Windows; treat those as violations once the build switches to a static CRT
+(see TODO(prebuilt-respin) in cmake/toolchain.cmake).
 """
 
 import argparse
@@ -66,11 +62,8 @@ def run_tool(args: list[str]) -> str:
 def assert_parsed(count: int, tool: str, what: str) -> list[str]:
     """Fail closed when a parse yielded nothing.
 
-    Every real executable has at least one dynamic dependency, so an empty
-    parse means the tool printed something this script no longer understands
-    (an LLVM upgrade reformatting its output, say) rather than a clean binary.
-    Without this the gate would silently degrade into a rubber stamp — the
-    exact failure mode it exists to prevent.
+    Every real executable has at least one dynamic dependency, so parsing none
+    means the tool's output format changed, not that the binary is clean.
     """
     if count:
         return []

--- a/scripts/check_artifact_deps.py
+++ b/scripts/check_artifact_deps.py
@@ -54,6 +54,23 @@ def run_tool(args: list[str]) -> str:
     return result.stdout
 
 
+def assert_parsed(count: int, tool: str, what: str) -> list[str]:
+    """Fail closed when a parse yielded nothing.
+
+    Every real executable has at least one dynamic dependency, so an empty
+    parse means the tool printed something this script no longer understands
+    (an LLVM upgrade reformatting its output, say) rather than a clean binary.
+    Without this the gate would silently degrade into a rubber stamp — the
+    exact failure mode it exists to prevent.
+    """
+    if count:
+        return []
+    return [
+        f"parsed no {what} from `{tool}` output; refusing to vouch for this "
+        f"binary (the tool's output format may have changed)"
+    ]
+
+
 def detect_format(binary: Path) -> str:
     magic = binary.read_bytes()[:4]
     if magic[:4] == b"\x7fELF":
@@ -87,25 +104,31 @@ def check_elf(binary: Path) -> list[str]:
     """
     out = run_tool(["llvm-readelf", "-d", str(binary)])
     violations = []
+    parsed = 0
     for line in out.splitlines():
         if "(NEEDED)" in line:
             m = re.search(r"Shared library: \[([^\]]+)\]", line)
-            if m and m.group(1) not in LINUX_NEEDED_WHITELIST:
+            if not m:
+                continue
+            parsed += 1
+            if m.group(1) not in LINUX_NEEDED_WHITELIST:
                 violations.append(f"unexpected NEEDED dependency: {m.group(1)}")
         elif "(RUNPATH)" in line or "(RPATH)" in line:
             m = re.search(r"\[([^\]]+)\]", line)
             if m and any(marker in m.group(1) for marker in CONDA_MARKERS):
                 print(f"note: RUNPATH references a conda/pixi env: {m.group(1)}")
 
+    violations.extend(assert_parsed(parsed, "llvm-readelf -d", "NEEDED entries"))
     return violations
 
 
 def check_macho(binary: Path) -> list[str]:
     """Return a list of violation messages for a Mach-O binary."""
     violations = []
+    parsed = 0
 
-    # Load dylib dependencies. The first line of -L output is the binary's own
-    # install name (no leading path constraint), so skip it.
+    # Load dylib dependencies. The first line of -L output is the file-path
+    # header ("<path>:"), not a dependency, so skip it.
     load_out = run_tool(["llvm-otool", "-L", str(binary)])
     lines = load_out.splitlines()
     for line in lines[1:]:
@@ -113,8 +136,11 @@ def check_macho(binary: Path) -> list[str]:
         if not line or not line.endswith(")"):
             continue
         dylib = line.split(" (", 1)[0].strip()
+        parsed += 1
         if not dylib.startswith(MACOS_SYSTEM_PREFIXES):
             violations.append(f"non-system dylib dependency: {dylib}")
+
+    violations.extend(assert_parsed(parsed, "llvm-otool -L", "dylib dependencies"))
 
     # LC_RPATH entries must not point into a conda/pixi env.
     rpath_out = run_tool(["llvm-otool", "-l", str(binary)])

--- a/scripts/check_artifact_deps.py
+++ b/scripts/check_artifact_deps.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Assert a packaged clice binary only depends on system dynamic libraries.
+
+macOS artifacts once silently linked conda's ``@rpath/libc++.1.dylib``; the
+binary loaded fine on the build machine (where the conda env was present) but
+would die anywhere else. Every test job passed because they all ran inside that
+same env — only the editor smoke test, by accident, exercised the binary in a
+fresh environment and failed with a 20-minute hang. This script turns that
+accidental sentinel into an explicit gate: it inspects the shipped binary's
+dynamic dependencies and rejects anything that resolves into a conda/pixi env
+instead of the OS.
+
+Both branches use LLVM binutils (``llvm-otool`` / ``llvm-readelf``), which ship
+in the build env and can read Mach-O even from a Linux host.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Linux NEEDED whitelist, derived from the real packaged x64-linux-gnu binary.
+# clice statically links libstdc++/libgcc, so a portable build only pulls in the
+# glibc runtime pieces. Notably libstdc++.so.6 / libc++.so are absent: if either
+# ever appears it would resolve from the conda RUNPATH (see check_elf), which is
+# exactly the shape of the macOS libc++ incident. Keeping them out of the
+# whitelist makes that regression a hard failure.
+LINUX_NEEDED_WHITELIST = {
+    "libpthread.so.0",
+    "librt.so.1",
+    "libdl.so.2",
+    "libm.so.6",
+    "libc.so.6",
+    "ld-linux-x86-64.so.2",
+    "ld-linux-aarch64.so.1",
+}
+
+# Path fragments that indicate a dependency or search path pointing into a
+# conda/pixi environment rather than the operating system.
+CONDA_MARKERS = ("conda", ".pixi", "/envs/")
+
+# macOS system library location prefixes. Anything outside these (notably
+# @rpath / @loader_path / absolute conda paths) is a violation.
+MACOS_SYSTEM_PREFIXES = ("/usr/lib/", "/System/Library/")
+
+
+def run_tool(args: list[str]) -> str:
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{args[0]} failed (exit {result.returncode}):\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def detect_format(binary: Path) -> str:
+    magic = binary.read_bytes()[:4]
+    if magic[:4] == b"\x7fELF":
+        return "elf"
+    # Mach-O: 32/64-bit little/big endian, or a fat/universal archive.
+    macho = {
+        b"\xcf\xfa\xed\xfe",  # 64-bit LE
+        b"\xce\xfa\xed\xfe",  # 32-bit LE
+        b"\xfe\xed\xfa\xcf",  # 64-bit BE
+        b"\xfe\xed\xfa\xce",  # 32-bit BE
+        b"\xca\xfe\xba\xbe",  # fat/universal
+    }
+    if magic in macho:
+        return "macho"
+    raise RuntimeError(f"{binary}: unrecognized object file magic {magic!r}")
+
+
+def check_elf(binary: Path) -> list[str]:
+    """Return a list of violation messages for an ELF binary.
+
+    The NEEDED whitelist is the real gate here: it rejects any C++ runtime
+    (libstdc++/libc++) or other non-glibc dependency, which is what would let a
+    conda-resolved library slip in.
+
+    The conda RUNPATH that Linux conda-clang bakes in via its default config is
+    reported for visibility but is not a hard failure: it is pre-existing,
+    benign (it resolves nothing on a user's machine, and every NEEDED entry is
+    system glibc), and removing it needs a separate toolchain change. macOS,
+    where the config is stripped with --no-default-config, enforces the
+    equivalent LC_RPATH rule strictly (see check_macho).
+    """
+    out = run_tool(["llvm-readelf", "-d", str(binary)])
+    violations = []
+    for line in out.splitlines():
+        if "(NEEDED)" in line:
+            m = re.search(r"Shared library: \[([^\]]+)\]", line)
+            if m and m.group(1) not in LINUX_NEEDED_WHITELIST:
+                violations.append(f"unexpected NEEDED dependency: {m.group(1)}")
+        elif "(RUNPATH)" in line or "(RPATH)" in line:
+            m = re.search(r"\[([^\]]+)\]", line)
+            if m and any(marker in m.group(1) for marker in CONDA_MARKERS):
+                print(f"note: RUNPATH references a conda/pixi env: {m.group(1)}")
+
+    return violations
+
+
+def check_macho(binary: Path) -> list[str]:
+    """Return a list of violation messages for a Mach-O binary."""
+    violations = []
+
+    # Load dylib dependencies. The first line of -L output is the binary's own
+    # install name (no leading path constraint), so skip it.
+    load_out = run_tool(["llvm-otool", "-L", str(binary)])
+    lines = load_out.splitlines()
+    for line in lines[1:]:
+        line = line.strip()
+        if not line or not line.endswith(")"):
+            continue
+        dylib = line.split(" (", 1)[0].strip()
+        if not dylib.startswith(MACOS_SYSTEM_PREFIXES):
+            violations.append(f"non-system dylib dependency: {dylib}")
+
+    # LC_RPATH entries must not point into a conda/pixi env.
+    rpath_out = run_tool(["llvm-otool", "-l", str(binary)])
+    for path in re.findall(r"cmd LC_RPATH.*?path (\S+)", rpath_out, re.DOTALL):
+        if any(marker in path for marker in CONDA_MARKERS):
+            violations.append(f"LC_RPATH points into a conda/pixi env: {path}")
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "binary", type=Path, help="Path to the packaged clice binary to inspect."
+    )
+    args = parser.parse_args()
+
+    binary: Path = args.binary
+    if not binary.is_file():
+        print(f"error: {binary} is not a file", file=sys.stderr)
+        return 1
+
+    fmt = detect_format(binary)
+    violations = check_elf(binary) if fmt == "elf" else check_macho(binary)
+
+    if violations:
+        print(f"FAIL: {binary} has forbidden dynamic dependencies:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {binary} ({fmt}) depends only on system libraries")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_artifact_deps.py
+++ b/scripts/check_artifact_deps.py
@@ -12,6 +12,15 @@ instead of the OS.
 
 Both branches use LLVM binutils (``llvm-otool`` / ``llvm-readelf``), which ship
 in the build env and can read Mach-O even from a Linux host.
+
+TODO: read PE too, so the two Windows artifacts stop being the blind spot. They
+are not dependency-free — both import ``MSVCP140.dll`` and ``VCRUNTIME140.dll``
+(x64 also ``VCRUNTIME140_1.dll``), which come from the Visual C++
+redistributable rather than from Windows. That is a real instance of the thing
+this script looks for, so the whitelist (Win32 system DLLs plus the
+``api-ms-win-crt-*`` UCRT forwarders, which *are* part of Windows) should treat
+them as a violation only once the build switches to a static CRT — see the
+TODO(prebuilt-respin) note in cmake/toolchain.cmake.
 """
 
 import argparse

--- a/tests/unit/test/test.h
+++ b/tests/unit/test/test.h
@@ -8,4 +8,4 @@
 #include "test/platform.h"
 #include "support/format.h"
 
-#include "kota/zest/macro.h"
+#include "kota/zest/zest.h"


### PR DESCRIPTION
## Summary

Build cleanup: drop a duplicated dependency, pick up an upstream fix, and add a
release check for the bug class that motivated that fix.

## Changes

- **flatbuffers now comes from kotatsu.** kotatsu already fetches it for its own
  codec, so clice was fetching and building a second copy of the same library.
  `flatc` comes from pixi, since kotatsu does not build the schema compiler.
- **gcc 15.2.0** in the build environment.
- **kotatsu pin bumped, availability workaround deleted.** kotatsu defined
  `-D_LIBCPP_DISABLE_AVAILABILITY` globally, which made libc++ headers reference
  dylib-only symbols that a target system's libc++ may not have. clice worked
  around it by stripping the flag off every kotatsu target. The flag is gone
  upstream (clice-io/kotatsu#180), so the workaround goes with it.
- **New check on packaged binaries.** `scripts/check_artifact_deps.py` reads a
  packaged binary's dynamic dependencies and fails if any of them resolve into a
  conda/pixi environment instead of the OS. It runs between packaging and
  upload, so a violation blocks the upload.

## Why the check exists

A macOS artifact once linked conda's `@rpath/libc++.1.dylib`. It ran fine on the
build machine, where that environment existed, and died everywhere else — and
every test job passed, because they all ran inside that same environment. This
turns that class of failure into a packaging-time error instead of a post-release
surprise.

## Verification

The kotatsu bump was checked against the fetched source rather than the declared
pin: a stale `_deps` checkout still carries the old flag and would make removing
the workaround look safe when it is not.

The check was run against a binary carrying `@rpath/libc++.1.dylib`, against a
conda-linked `libstdc++.so.6`, and against a clean packaged binary — plus empty
and malformed tool output, to confirm it fails rather than passing silently when
it cannot parse what it is given.

Linux: 1060 unit, 304 integration, 3 smoke.

## Recorded, not fixed here

Auditing the shipped artifacts turned up two portability limits. Both need the
prebuilt LLVM rebuilt to fix, so both are recorded as `TODO(prebuilt-respin)` in
`cmake/toolchain.cmake` and left for the next toolchain bump to carry, rather
than triggering a rebuild on their own.

**Windows binaries need the Visual C++ redistributable.** They import
`MSVCP140.dll` and `VCRUNTIME140.dll` (x64 also `VCRUNTIME140_1.dll`), which are
not part of Windows. This follows from building with `/MD`; `/MT` would make the
exe self-contained. The flag cannot be flipped alone — every object embeds
`/DEFAULTLIB` and `/FAILIFMISMATCH` directives naming its CRT, so linking a `/MD`
prebuilt LLVM into a `/MT` clice is a hard link error.

**macOS binaries require macOS 15 or newer.** No `CMAKE_OSX_DEPLOYMENT_TARGET`
is set, so the target follows the build machine and the artifact is stamped
`minos 15.0`. Lowering it needs the prebuilt built against the same target.

Neither is covered by the new check: it reads ELF and Mach-O dependencies, not
PE imports and not deployment targets. Extending it is noted in the script.

For contrast, the Linux `RUNPATH` pointing into the build machine's pixi
environment is *not* a problem: all six `NEEDED` entries are glibc sonames and
that environment ships none of them, so the loader finds nothing there and falls
through to the system — `ldd` on the build machine itself resolves every entry
from `/lib/x86_64-linux-gnu`. The script prints it as a note so it stays visible
without failing builds over a path that changes no resolution.
