### PR TITLE
refactor(syntax): in-place lexer, lexical scan, Module/Comment nodes

### DIFF
--- a/docs/en/features/folding-ranges.md
+++ b/docs/en/features/folding-ranges.md
@@ -186,6 +186,22 @@
   #pragma endregion
   ```
 
+- [x] Pragma classification — only the first argument token decides region/endregion
+
+  ```cpp
+  // The leading declaration ends the preamble so the pragmas below reach the
+  // main-file parse on both the standalone and the wire path.
+  int before = 0;
+
+  // Neither a region name nor another pragma's argument mentioning
+  // "endregion" may close the fold early.
+  #pragma region endregion_pair
+  int retries = 3;
+  #pragma mark see endregion notes
+  int limit = 10;
+  #pragma endregion
+  ```
+
 - [ ] Comment folding — multi-line `/* */` and consecutive `//` line comments
 
   ```cpp

--- a/docs/en/features/folding-ranges.md
+++ b/docs/en/features/folding-ranges.md
@@ -200,6 +200,13 @@
   #pragma mark see endregion notes
   int limit = 10;
   #pragma endregion
+
+  // The tail of a multiline comment before the introducer must not hide
+  // the region either.
+  /* spans
+  a line */ #pragma region after_comment
+  int after = 1;
+  #pragma endregion
   ```
 
 - [ ] Comment folding — multi-line `/* */` and consecutive `//` line comments

--- a/src/compile/directive.cpp
+++ b/src/compile/directive.cpp
@@ -198,8 +198,11 @@ public:
 
         // Classify by the first argument token: substring matching would
         // misfire on lines like `#pragma message("see endregion below")`.
+        // Lexing starts at the reported `#` (a suffix keeps the NUL
+        // terminator), not at the physical line start — the tail of a
+        // multiline comment may sit before the introducer.
         Pragma::Kind kind = Pragma::Other;
-        auto lexer = Lexer::from_line(content, offset, {.lang_opts = &unit.lang_options()});
+        Lexer lexer(content.substr(offset), {.lang_opts = &unit.lang_options()});
         lexer.advance();  // the introducer `#`
         lexer.advance();  // the `pragma` keyword
         if(lexer.advance_if("region")) {

--- a/src/compile/directive.cpp
+++ b/src/compile/directive.cpp
@@ -1,6 +1,7 @@
 #include "compile/directive.h"
 
 #include "compile/implement.h"
+#include "syntax/lexer.h"
 
 #include "clang/Basic/Module.h"
 #include "clang/Lex/MacroArgs.h"
@@ -190,12 +191,22 @@ public:
 
         clang::FileID fid = unit.file_id(loc);
 
-        llvm::StringRef text_to_end = unit.file_content(fid).substr(unit.file_offset(loc));
-        llvm::StringRef that_line = text_to_end.take_until([](char ch) { return ch == '\n'; });
+        llvm::StringRef content = unit.file_content(fid);
+        std::uint32_t offset = unit.file_offset(loc);
+        llvm::StringRef that_line =
+            content.substr(offset).take_until([](char ch) { return ch == '\n'; });
 
-        Pragma::Kind kind = that_line.contains("endregion") ? Pragma::EndRegion
-                            : that_line.contains("region")  ? Pragma::Region
-                                                            : Pragma::Other;
+        // Classify by the first argument token: substring matching would
+        // misfire on lines like `#pragma message("see endregion below")`.
+        Pragma::Kind kind = Pragma::Other;
+        auto lexer = Lexer::from_line(content, offset, {.lang_opts = &unit.lang_options()});
+        lexer.advance();  // the introducer `#`
+        lexer.advance();  // the `pragma` keyword
+        if(lexer.advance_if("region")) {
+            kind = Pragma::Region;
+        } else if(lexer.advance_if("endregion")) {
+            kind = Pragma::EndRegion;
+        }
 
         auto& directive = unit->directives[fid];
         directive.pragmas.emplace_back(Pragma{

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -26,13 +26,19 @@ static std::optional<LocalSourceRange>
             return std::nullopt;
         }
 
-        // Only the first matching identifier is the directive keyword; a
-        // later one is a macro standing in for the filename (legal pre-C++20
-        // even for one literally named `import`).
-        if(!after_keyword && token.is_identifier()) {
+        if(token.is_identifier()) {
             auto text = token.text(content);
-            if(text == "include" || text == "include_next" || text == "import" || text == "embed" ||
-               text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {
+            // The __has_include family are reserved operators that may recur
+            // within one #if line; every occurrence restarts the match.
+            if(text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {
+                after_keyword = true;
+                continue;
+            }
+            // A directive keyword only counts before the first match; a
+            // later one is a macro standing in for the filename (legal
+            // pre-C++20 even for one literally named `import`).
+            if(!after_keyword && (text == "include" || text == "include_next" || text == "import" ||
+                                  text == "embed")) {
                 after_keyword = true;
                 continue;
             }

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -28,7 +28,7 @@ static std::optional<LocalSourceRange>
 
         if(token.is_identifier()) {
             auto text = token.text(content);
-            if(text == "include" || text == "include_next" || text == "embed" ||
+            if(text == "include" || text == "include_next" || text == "import" || text == "embed" ||
                text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {
                 after_keyword = true;
                 continue;

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -26,7 +26,10 @@ static std::optional<LocalSourceRange>
             return std::nullopt;
         }
 
-        if(token.is_identifier()) {
+        // Only the first matching identifier is the directive keyword; a
+        // later one is a macro standing in for the filename (legal pre-C++20
+        // even for one literally named `import`).
+        if(!after_keyword && token.is_identifier()) {
             auto text = token.text(content);
             if(text == "include" || text == "include_next" || text == "import" || text == "embed" ||
                text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {

--- a/src/feature/document_links.cpp
+++ b/src/feature/document_links.cpp
@@ -7,6 +7,44 @@
 
 namespace clice::feature {
 
+/// Find the range of the filename argument in a preprocessor directive line.
+/// `content` is the full source text, `offset` points at or before the
+/// directive keyword. Returns the range of the first filename-like token
+/// (header name, string literal, or macro identifier) found on the same
+/// line, or nullopt if none.
+static std::optional<LocalSourceRange>
+    find_directive_argument(llvm::StringRef content,
+                            std::uint32_t offset,
+                            const clang::LangOptions* lang_opts) {
+    auto lexer = Lexer::from_line(content, offset, {.lang_opts = lang_opts});
+    bool after_keyword = false;
+
+    while(true) {
+        auto token = lexer.advance();
+        if(token.is_eof() || token.is_eod()) {
+            return std::nullopt;
+        }
+
+        if(token.is_identifier()) {
+            auto text = token.text(content);
+            if(text == "include" || text == "include_next" || text == "embed" ||
+               text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {
+                after_keyword = true;
+                continue;
+            }
+        }
+
+        if(token.range.begin < offset || !after_keyword) {
+            continue;
+        }
+
+        if(token.is_header_name() || token.kind == clang::tok::string_literal ||
+           token.is_identifier()) {
+            return token.range;
+        }
+    }
+}
+
 auto document_links(CompilationUnitRef unit) -> std::vector<DocumentLink> {
     std::vector<DocumentLink> links;
 

--- a/src/feature/semantic_tokens.cpp
+++ b/src/feature/semantic_tokens.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <optional>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -8,12 +9,11 @@
 #include "semantic/decls.h"
 #include "semantic/semantics.h"
 #include "semantic/symbol.h"
-#include "syntax/lexer.h"
+#include "syntax/token.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
-#include "clang/Basic/Module.h"
 
 namespace clice::feature {
 
@@ -268,12 +268,11 @@ Classified classify_decl(const clang::NamedDecl* decl, RelationKind relation) {
 class SemanticTokensCollector {
 public:
     explicit SemanticTokensCollector(CompilationUnitRef unit) :
-        unit(unit), semantics(unit.semantics()), content(unit.interested_content()) {}
+        unit(unit), semantics(unit.semantics()), content(unit.interested_content()),
+        comments(semantics.comments()) {}
 
     auto collect() -> std::vector<SemanticToken> {
-        precompute_module_declaration();
         precompute_semantics();
-        scan_comments();
 
         auto spelled = semantics.spelled_tokens();
         for(std::uint32_t i = 0; i < spelled.size(); i++) {
@@ -296,12 +295,6 @@ private:
             directive_context = DirectiveContext::None;
         }
         previous_end = range.end;
-
-        /// The module declaration (`export module foo.bar;`), precomputed.
-        if(auto it = module_tokens.find(index); it != module_tokens.end()) {
-            emit(range, it->second, 0);
-            return;
-        }
 
         Classified lexical = classify_lexical(token, offset);
         Classified semantic;
@@ -438,6 +431,20 @@ private:
         return static_cast<std::uint32_t>(it - spelled.begin());
     }
 
+    /// The spelled token starting exactly at file offset `offset`, or none.
+    auto spelled_index_at(std::uint32_t offset) -> std::optional<std::uint32_t> {
+        auto count = static_cast<std::uint32_t>(semantics.spelled_tokens().size());
+        auto range = std::views::iota(0u, count);
+        auto it = std::ranges::partition_point(range, [&](std::uint32_t index) {
+            return semantics.token_offset(index) < offset;
+        });
+        auto index = static_cast<std::uint32_t>(it - range.begin());
+        if(index >= count || semantics.token_offset(index) != offset) {
+            return std::nullopt;
+        }
+        return index;
+    }
+
     void precompute_semantics() {
         auto spelled = semantics.spelled_tokens();
 
@@ -531,6 +538,36 @@ private:
                     break;
                 }
 
+                case SemanticNode::Kind::Module: {
+                    auto* module = node.get<LexicalInfo::ModuleDeclaration>();
+                    auto anchor_offset = [&](std::uint32_t offset, Classified candidate) {
+                        if(auto index = spelled_index_at(offset)) {
+                            combine(token_semantics[*index], candidate);
+                        }
+                    };
+
+                    /// The contextual `module` lexes as a plain identifier;
+                    /// `export` and the private fragment's `private` are real
+                    /// keywords the lexical pass paints on its own, and the
+                    /// separators stay unpainted, matching the import side.
+                    anchor_offset(module->keyword.begin, {SymbolKind::Keyword, 0});
+                    for(auto& part: module->name_parts) {
+                        anchor_offset(part.begin, {SymbolKind::Module, 0});
+                    }
+                    if(module->kind == LexicalInfo::ModuleDeclaration::Kind::Declaration) {
+                        for(auto& part: module->partition_parts) {
+                            anchor_offset(part.begin, {SymbolKind::Module, 0});
+                        }
+                    }
+                    break;
+                }
+
+                case SemanticNode::Kind::Comment: {
+                    /// Comments own no spelled tokens; the emit loop
+                    /// interleaves them by offset instead.
+                    break;
+                }
+
                 case SemanticNode::Kind::Attr: {
                     /// `final` and `override` are contextual keywords.
                     if(llvm::isa<clang::FinalAttr, clang::OverrideAttr>(node.get<clang::Attr>())) {
@@ -555,109 +592,23 @@ private:
         }
     }
 
-    /// The module declaration has no AST node or directive record; locate its
-    /// tokens up front so the main pass can classify them in order.
-    void precompute_module_declaration() {
-        auto* mod = unit.context().getCurrentNamedModule();
-        if(!mod) {
-            return;
-        }
-
-        /// The global module fragment (`module;`) precedes DefinitionLoc and
-        /// its contextual `module` lexes as a plain identifier.
-        {
-            auto spelled = semantics.spelled_tokens();
-            if(!spelled.empty() && spelled.front().kind() == clang::tok::identifier &&
-               spelled.size() > 1 && spelled[1].kind() == clang::tok::semi) {
-                auto offset = semantics.token_offset(0);
-                if(content.substr(offset, spelled.front().length()) == "module") {
-                    module_tokens[0] = SymbolKind::Keyword;
-                }
-            }
-        }
-
-        /// `module :private;` — the private fragment's contextual `module`
-        /// also lexes as a plain identifier. The identifier-colon-`private`
-        /// token sequence is not valid C++ anywhere else, so locate it
-        /// lexically like the global module fragment above. Tokens
-        /// preprocessed away (a disabled branch, a macro body) spell no
-        /// fragment and keep their lexical handling.
-        {
-            auto spelled = semantics.spelled_tokens();
-            for(std::uint32_t i = 0; i + 2 < spelled.size(); i += 1) {
-                if(spelled[i].kind() != clang::tok::identifier ||
-                   spelled[i + 1].kind() != clang::tok::colon ||
-                   spelled[i + 2].kind() != clang::tok::kw_private ||
-                   semantics.token_preprocessed_away(i)) {
-                    continue;
-                }
-                auto offset = semantics.token_offset(i);
-                if(content.substr(offset, spelled[i].length()) == "module") {
-                    module_tokens[i] = SymbolKind::Keyword;
-                }
-            }
-        }
-
-        auto def_loc = mod->DefinitionLoc;
-        if(!def_loc.isValid() || !def_loc.isFileID() ||
-           unit.file_id(def_loc) != unit.interested_file()) {
-            return;
-        }
-
-        auto spelled = semantics.spelled_tokens();
-        auto count = static_cast<std::uint32_t>(spelled.size());
-        std::uint32_t i = 0;
-        while(i < count && spelled[i].location() < def_loc) {
-            i++;
-        }
-
-        /// `module`, then the dotted name parts until the semicolon.
-        if(i < count && spelled[i].kind() == clang::tok::identifier) {
-            module_tokens[i] = SymbolKind::Keyword;
-            i++;
-        }
-        for(; i < count && spelled[i].kind() != clang::tok::semi; i++) {
-            if(spelled[i].kind() == clang::tok::identifier) {
-                module_tokens[i] = SymbolKind::Module;
-            }
-        }
-    }
-
-    /// The spelled token stream does not retain comments; one slim raw scan
-    /// collects them (and nothing else).
-    void scan_comments() {
-        auto& lang_opts = unit.lang_options();
-        Lexer lexer(content, false, &lang_opts);
-
-        while(true) {
-            Token token = lexer.advance();
-            if(token.is_eof()) {
-                break;
-            }
-
-            if(token.kind == clang::tok::comment) {
-                comments.push_back(token.range);
-            }
-        }
-    }
-
     void flush_comments(std::uint32_t until) {
-        while(next_comment < comments.size() && comments[next_comment].begin < until) {
-            emit(comments[next_comment], SymbolKind::Comment, 0);
+        while(next_comment < comments.size() && comments[next_comment].range.begin < until) {
+            emit(comments[next_comment].range, SymbolKind::Comment, 0);
             next_comment++;
         }
     }
 
     bool has_logical_newline(std::uint32_t begin, std::uint32_t end) {
-        /// Comment ranges come from the Lexer scan; gaps are visited in
-        /// order, so one monotonic cursor suffices.
+        /// Comment ranges come from the semantics' lexical scan; gaps are
+        /// visited in order, so one monotonic cursor suffices.
         auto inside_comment = [&](std::uint32_t offset) {
             while(newline_scan_comment < comments.size() &&
-                  comments[newline_scan_comment].end <= offset) {
+                  comments[newline_scan_comment].range.end <= offset) {
                 newline_scan_comment += 1;
             }
             return newline_scan_comment < comments.size() &&
-                   comments[newline_scan_comment].begin <= offset;
+                   comments[newline_scan_comment].range.begin <= offset;
         };
 
         for(auto i = begin; i < end; i += 1) {
@@ -707,9 +658,8 @@ private:
     llvm::StringRef content;
     DirectiveContext directive_context = DirectiveContext::None;
     std::uint32_t previous_end = 0;
-    llvm::DenseMap<std::uint32_t, SymbolKind> module_tokens;
     llvm::DenseMap<std::uint32_t, Classified> token_semantics;
-    std::vector<LocalSourceRange> comments;
+    llvm::ArrayRef<LexicalInfo::Comment> comments;
     std::size_t next_comment = 0;
     /// Cursor of has_logical_newline over `comments`.
     std::size_t newline_scan_comment = 0;

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -9,7 +9,6 @@
 #include "semantic/display.h"
 #include "semantic/semantics.h"
 #include "semantic/types.h"
-#include "syntax/lexer.h"
 
 #include "llvm/Support/SHA256.h"
 #include "llvm/Support/xxhash.h"
@@ -258,77 +257,30 @@ public:
 
         // The module declaration of this unit: Definition in the interface
         // unit, Reference in an implementation unit. The declaration has no
-        // AST node or PP location, so locate the name with the lexer.
+        // AST node or PP location; the semantics' lexical scan located and
+        // cross-checked its written tokens. The occurrence spans the written
+        // name, partition included.
         if(!unit.is_named_module()) {
             return;
         }
         auto module_name = unit.module_name();
-        if(!module_name.empty()) {
-            // interested_content() is the full, NUL-terminated buffer; the
-            // lexer token ranges are offsets into it, i.e. file offsets.
-            llvm::StringRef content = unit.interested_content();
-            Lexer lexer(content);
-
-            auto is_identifier = [](const Token& token) {
-                return token.is_identifier();
-            };
-
-            bool found = false;
-            std::uint32_t name_begin = 0;
-            std::uint32_t name_end = 0;
-
-            // Whether the previous token was `export` at the start of a line,
-            // so a following `module` still introduces the declaration.
-            bool after_export = false;
-
-            while(true) {
-                auto token = lexer.advance();
-                if(token.is_eof())
-                    break;
-
-                // The `module` declaration keyword either starts the line or
-                // follows an `export` that starts the line (`export module M;`).
-                bool at_decl_start = token.is_at_start_of_line || after_export;
-                after_export = token.is_at_start_of_line && token.is_identifier() &&
-                               token.text(content) == "export";
-
-                // Only interested in a `module` keyword whose next token is an
-                // identifier (the name). This skips `module;` (global module
-                // fragment, next is `;`) and `module :private;` (next is `:`).
-                if(!at_decl_start || !token.is_identifier() || token.text(content) != "module")
-                    continue;
-
-                auto next = lexer.next();
-                if(!next.is_identifier())
-                    continue;
-
-                auto first = lexer.advance_if(is_identifier);
-                if(!first)
-                    continue;
-                name_begin = first->range.begin;
-                name_end = first->range.end;
-                while(true) {
-                    auto sep = lexer.advance_if([](const Token& token) {
-                        return token.kind == clang::tok::period || token.kind == clang::tok::colon;
-                    });
-                    if(!sep)
-                        break;
-                    auto part = lexer.advance_if(is_identifier);
-                    if(!part)
-                        break;
-                    name_end = part->range.end;
-                }
-                found = true;
-                break;
+        if(module_name.empty()) {
+            return;
+        }
+        for(auto& module: unit.semantics().module_declarations()) {
+            if(module.kind != LexicalInfo::ModuleDeclaration::Kind::Declaration) {
+                continue;
             }
-
-            if(found) {
-                emit(module_name,
-                     unit.interested_file(),
-                     LocalSourceRange{name_begin, name_end},
-                     unit.is_module_interface_unit() ? RelationKind::Definition
-                                                     : RelationKind::Reference);
-            }
+            auto name_begin = module.name_parts.front().begin;
+            auto name_end = (module.partition_parts.empty() ? module.name_parts.back()
+                                                            : module.partition_parts.back())
+                                .end;
+            emit(module_name,
+                 unit.interested_file(),
+                 LocalSourceRange{name_begin, name_end},
+                 unit.is_module_interface_unit() ? RelationKind::Definition
+                                                 : RelationKind::Reference);
+            break;
         }
     }
 

--- a/src/index/tu_index.cpp
+++ b/src/index/tu_index.cpp
@@ -204,7 +204,7 @@ public:
     /// Module names are indexed like macro names: an occurrence plus a
     /// Definition/Reference relation keyed by a hash of the full module
     /// name, so navigation flows through the ordinary index pipeline.
-    void index_modules() {
+    void index_modules(const Semantics& semantics) {
         auto emit = [&](llvm::StringRef name,
                         clang::FileID fid,
                         LocalSourceRange range,
@@ -267,7 +267,7 @@ public:
         if(module_name.empty()) {
             return;
         }
-        for(auto& module: unit.semantics().module_declarations()) {
+        for(auto& module: semantics.module_declarations()) {
             if(module.kind != LexicalInfo::ModuleDeclaration::Kind::Declaration) {
                 continue;
             }
@@ -463,14 +463,7 @@ public:
         }
     }
 
-    void project_semantics() {
-        /// The interested-only shape is the one features share, cached on the
-        /// unit; the whole-TU shape is transient — projected and dropped.
-        std::optional<Semantics> full;
-        if(!interested_only) {
-            full.emplace(Semantics::build(unit, false));
-        }
-        const Semantics& semantics = interested_only ? unit.semantics() : *full;
+    void project_semantics(const Semantics& semantics) {
         auto entries = semantics.node_entries();
 
         for(std::uint32_t i = 0; i < entries.size(); i++) {
@@ -511,9 +504,18 @@ public:
     }
 
     void build() {
-        project_semantics();
+        /// The interested-only shape is the one features share, cached on the
+        /// unit; the whole-TU shape is transient — projected and dropped.
+        /// Both phases below share the one build.
+        std::optional<Semantics> full;
+        if(!interested_only) {
+            full.emplace(Semantics::build(unit, false));
+        }
+        const Semantics& semantics = interested_only ? unit.semantics() : *full;
 
-        index_modules();
+        project_semantics(semantics);
+
+        index_modules(semantics);
 
         // Build the include graph from what the index actually recorded:
         // every fid keying `file_indices` gets its include chain resolved

--- a/src/semantic/semantics.cpp
+++ b/src/semantic/semantics.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/ExprConcepts.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Stmt.h"
+#include "clang/Basic/Module.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Lex/Lexer.h"
@@ -62,6 +63,10 @@ clang::SourceRange SemanticNode::source_range() const {
                 return clang::SourceRange(value->location, value->name_locations.back());
             }
             return clang::SourceRange(value->location);
+        } else if constexpr(std::same_as<T, const LexicalInfo::ModuleDeclaration*> ||
+                            std::same_as<T, const LexicalInfo::Comment*>) {
+            /// Lexical payloads carry file offsets, not SourceLocations.
+            return clang::SourceRange();
         } else if constexpr(std::same_as<T, const clang::Attr*>) {
             return value->getRange();
         } else if constexpr(std::is_pointer_v<T>) {
@@ -77,8 +82,10 @@ clang::DynTypedNode SemanticNode::dyn_typed() const {
     return visit([](const auto& value) -> clang::DynTypedNode {
         using T = std::remove_cvref_t<decltype(value)>;
         if constexpr(std::same_as<T, const MacroRef*> || std::same_as<T, const Include*> ||
-                     std::same_as<T, const Import*>) {
-            llvm_unreachable("dyn_typed on a preprocessor node");
+                     std::same_as<T, const Import*> ||
+                     std::same_as<T, const LexicalInfo::ModuleDeclaration*> ||
+                     std::same_as<T, const LexicalInfo::Comment*>) {
+            llvm_unreachable("dyn_typed on a non-AST node");
         } else if constexpr(std::is_pointer_v<T>) {
             return clang::DynTypedNode::create(*value);
         } else {
@@ -866,15 +873,66 @@ private:
         return location;
     }
 
-    // Append the interested file's preprocessor directives as nodes owning
-    // their name tokens. These live outside the AST segment: parent chains do
-    // not include them (yet), and selection ignores them, but hover and
-    // document links see macros, includes and imports as first-class nodes.
-    void append_directives() {
-        auto it = unit.directives().find(main_fid);
-        if(it == unit.directives().end()) {
+    // Whether a live spelled token starts exactly at `offset` (present and
+    // not preprocessed away).
+    bool token_alive_at(unsigned offset) const {
+        auto i = first_token_at(offset);
+        return i < semantics.tokens.size() && semantics.token_offset(i) == offset &&
+               !semantics.pp_ignored[i];
+    }
+
+    // Cross-check the lexically scanned module declarations against the
+    // compiled module before they become nodes: valid code cannot spell
+    // these token patterns with another meaning, but invalid or disabled
+    // code can, and a node must never outrank the compiler.
+    void filter_module_declarations() {
+        auto& modules = semantics.lexical.modules;
+        auto* mod = unit.context().getCurrentNamedModule();
+        if(!mod) {
+            modules.clear();
             return;
         }
+
+        // The declaration form additionally anchors on the compiler's
+        // DefinitionLoc — the written `module` keyword of the real
+        // declaration. This survives macro-spelled names (the keyword is
+        // always written) and kills duplicates in disabled branches.
+        std::optional<unsigned> definition_offset;
+        if(auto def_loc = mod->DefinitionLoc; def_loc.isValid()) {
+            definition_offset = offset_in_main_file(SM.getSpellingLoc(def_loc));
+        }
+
+        std::erase_if(modules, [&](const LexicalInfo::ModuleDeclaration& module) {
+            switch(module.kind) {
+                // The introducer is necessarily the file's first token, so no
+                // conditional can disable it — and under a preamble PCH its
+                // spelled token counts as preprocessed away, so a liveness
+                // check would wrongly drop it.
+                case LexicalInfo::ModuleDeclaration::Kind::GlobalFragment: return false;
+
+                // The DefinitionLoc anchor subsumes liveness: a duplicate in
+                // a disabled branch sits at a different offset.
+                case LexicalInfo::ModuleDeclaration::Kind::Declaration:
+                    return definition_offset != module.keyword.begin;
+
+                // The private fragment has no compiler-side location to
+                // anchor on; a disabled branch can spell the same tokens, so
+                // require the keyword's spelled token to be live.
+                case LexicalInfo::ModuleDeclaration::Kind::PrivateFragment:
+                    return !token_alive_at(module.keyword.begin);
+            }
+            llvm_unreachable("unknown module declaration kind");
+        });
+    }
+
+    // Append the interested file's preprocessor directives and lexically
+    // scanned entities as nodes owning their name tokens. These live outside
+    // the AST segment: parent chains do not include them (yet), and selection
+    // ignores them, but hover and document links see macros, includes and
+    // imports as first-class nodes.
+    void append_directives() {
+        semantics.lexical = lexical_scan(unit.interested_content(), &unit.lang_options());
+        filter_module_declarations();
 
         struct Row {
             unsigned offset;
@@ -883,45 +941,76 @@ private:
         };
 
         std::vector<Row> rows;
-        auto& directive = it->second;
 
-        for(auto& macro: directive.macros) {
-            if(auto offset = offset_in_main_file(macro.loc)) {
-                rows.push_back({*offset, SemanticNode(&macro), {}});
-            }
-        }
+        if(auto it = unit.directives().find(main_fid); it != unit.directives().end()) {
+            auto& directive = it->second;
 
-        for(auto& include: directive.includes) {
-            if(auto offset = offset_in_main_file(include.location)) {
-                rows.push_back({*offset, SemanticNode(&include), {}});
-            }
-        }
-
-        for(auto& import: directive.imports) {
-            /// An import spelled through a macro carries macro locations;
-            /// name tokens written as macro arguments still resolve to
-            /// spelled main-file tokens.
-            Row row{0, SemanticNode(&import), {}};
-            std::optional<unsigned> anchor;
-            if(auto offset = offset_in_main_file(import.location)) {
-                anchor = *offset;
-                row.extra_offsets.push_back(*offset);
-            }
-            for(auto loc: import.name_locations) {
-                if(loc.isMacroID()) {
-                    loc = SM.getSpellingLoc(loc);
+            for(auto& macro: directive.macros) {
+                if(auto offset = offset_in_main_file(macro.loc)) {
+                    rows.push_back({*offset, SemanticNode(&macro), {}});
                 }
-                if(auto name_offset = offset_in_main_file(loc)) {
-                    if(!anchor) {
-                        anchor = *name_offset;
+            }
+
+            for(auto& include: directive.includes) {
+                if(auto offset = offset_in_main_file(include.location)) {
+                    rows.push_back({*offset, SemanticNode(&include), {}});
+                }
+            }
+
+            for(auto& import: directive.imports) {
+                /// An import spelled through a macro carries macro locations;
+                /// name tokens written as macro arguments still resolve to
+                /// spelled main-file tokens.
+                Row row{0, SemanticNode(&import), {}};
+                std::optional<unsigned> anchor;
+                if(auto offset = offset_in_main_file(import.location)) {
+                    anchor = *offset;
+                    row.extra_offsets.push_back(*offset);
+                }
+                for(auto loc: import.name_locations) {
+                    if(loc.isMacroID()) {
+                        loc = SM.getSpellingLoc(loc);
                     }
-                    row.extra_offsets.push_back(*name_offset);
+                    if(auto name_offset = offset_in_main_file(loc)) {
+                        if(!anchor) {
+                            anchor = *name_offset;
+                        }
+                        row.extra_offsets.push_back(*name_offset);
+                    }
+                }
+                if(anchor) {
+                    row.offset = *anchor;
+                    rows.push_back(std::move(row));
                 }
             }
-            if(anchor) {
-                row.offset = *anchor;
-                rows.push_back(std::move(row));
+        }
+
+        // A comment node owns no spelled tokens (the stream drops them); it
+        // participates by its payload range only.
+        for(auto& comment: semantics.lexical.comments) {
+            rows.push_back({comment.range.begin, SemanticNode(&comment), {}});
+        }
+
+        // A module declaration owns its written tokens: the keywords, the
+        // name parts and the partition colon; the separators stay unowned,
+        // matching imports.
+        for(auto& module: semantics.lexical.modules) {
+            Row row{module.keyword.begin, SemanticNode(&module), {}};
+            if(module.export_keyword.valid()) {
+                row.offset = module.export_keyword.begin;
+                row.extra_offsets.push_back(module.export_keyword.begin);
             }
+            row.extra_offsets.push_back(module.keyword.begin);
+            for(auto& part: module.name_parts) {
+                row.extra_offsets.push_back(part.begin);
+            }
+            if(module.colon.valid()) {
+                row.extra_offsets.push_back(module.colon.begin);
+            }
+            for(auto& part: module.partition_parts) {
+                row.extra_offsets.push_back(part.begin);
+            }
+            rows.push_back(std::move(row));
         }
 
         std::ranges::sort(rows, {}, &Row::offset);

--- a/src/semantic/semantics.h
+++ b/src/semantic/semantics.h
@@ -6,6 +6,7 @@
 
 #include "compile/directive.h"
 #include "semantic/symbol.h"
+#include "syntax/lexical_scan.h"
 #include "syntax/token.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -37,10 +38,12 @@ class TemplateResolver;
 }
 
 /// The single currency for "what a token belongs to": the AST node kinds our
-/// traversal records, plus preprocessor entities, flattened into one tagged
-/// union (no nested discriminant like wrapping clang::DynTypedNode would
-/// introduce). Preprocessor payloads are pointers into the unit's Directive
-/// storage, which shares the unit's lifetime.
+/// traversal records, plus preprocessor and lexical entities, flattened into
+/// one tagged union (no nested discriminant like wrapping clang::DynTypedNode
+/// would introduce). Preprocessor payloads are pointers into the unit's
+/// Directive storage, which shares the unit's lifetime; lexical payloads
+/// (module declarations, comments) point into the Semantics' own LexicalInfo
+/// storage.
 class SemanticNode {
 public:
     enum class Kind : std::uint8_t {
@@ -64,6 +67,11 @@ public:
         Include,
         /// C++20 module import.
         Import,
+        /// A C++20 module declaration (any of its three lexical forms);
+        /// neither the AST nor the preprocessor callbacks record it.
+        Module,
+        /// A comment; the spelled token stream drops them.
+        Comment,
     };
 
     SemanticNode() = default;
@@ -91,6 +99,10 @@ public:
     explicit SemanticNode(const Include* include) : storage(include) {}
 
     explicit SemanticNode(const Import* import) : storage(import) {}
+
+    explicit SemanticNode(const LexicalInfo::ModuleDeclaration* module) : storage(module) {}
+
+    explicit SemanticNode(const LexicalInfo::Comment* comment) : storage(comment) {}
 
     Kind kind() const;
 
@@ -147,6 +159,14 @@ public:
             if(auto import = std::get_if<const Import*>(&storage)) {
                 return *import;
             }
+        } else if constexpr(std::same_as<T, LexicalInfo::ModuleDeclaration>) {
+            if(auto module = std::get_if<const LexicalInfo::ModuleDeclaration*>(&storage)) {
+                return *module;
+            }
+        } else if constexpr(std::same_as<T, LexicalInfo::Comment>) {
+            if(auto comment = std::get_if<const LexicalInfo::Comment*>(&storage)) {
+                return *comment;
+            }
         } else {
             static_assert(false, "unsupported type for SemanticNode::get");
         }
@@ -181,7 +201,9 @@ private:
                  clang::TemplateArgumentLoc,
                  const MacroRef*,
                  const Include*,
-                 const Import*>
+                 const Import*,
+                 const LexicalInfo::ModuleDeclaration*,
+                 const LexicalInfo::Comment*>
         storage;
 };
 
@@ -232,6 +254,15 @@ llvm::SmallVector<NameOccurrence, 2>
 class Semantics {
 public:
     constexpr static std::uint32_t invalid = static_cast<std::uint32_t>(-1);
+
+    Semantics() = default;
+
+    /// Move-only: nodes store payload pointers into the owned LexicalInfo,
+    /// so a copy would silently keep pointing into the original.
+    Semantics(const Semantics&) = delete;
+    Semantics& operator=(const Semantics&) = delete;
+    Semantics(Semantics&&) = default;
+    Semantics& operator=(Semantics&&) = default;
 
     struct NodeFlags {
         /// The node is implicit (e.g. an implicit cast wrapper kept for
@@ -313,6 +344,19 @@ public:
             .slice(owner_begin[index], owner_begin[index + 1] - owner_begin[index]);
     }
 
+    /// The interested file's comments in source order (the spelled token
+    /// stream drops them). The same objects back the Comment nodes.
+    llvm::ArrayRef<LexicalInfo::Comment> comments() const {
+        return lexical.comments;
+    }
+
+    /// The interested file's module declarations, already cross-checked
+    /// against the compiled module (bogus lexical matches are dropped at
+    /// build time). The same objects back the Module nodes.
+    llvm::ArrayRef<LexicalInfo::ModuleDeclaration> module_declarations() const {
+        return lexical.modules;
+    }
+
 private:
     friend class SemanticsBuilder;
 
@@ -330,6 +374,10 @@ private:
     /// owner_nodes[owner_begin[i] .. owner_begin[i + 1]).
     std::vector<std::uint32_t> owner_begin;
     std::vector<std::uint32_t> owner_nodes;
+
+    /// The lexically scanned entities; Module and Comment nodes point into
+    /// this storage.
+    LexicalInfo lexical;
 };
 
 /// resolve_occurrences with tree context: a dependent name that is the

--- a/src/syntax/completion.cpp
+++ b/src/syntax/completion.cpp
@@ -1,6 +1,7 @@
 #include "syntax/completion.h"
 
 #include "syntax/include_resolver.h"
+#include "syntax/lexer.h"
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSet.h"
@@ -11,49 +12,57 @@ namespace clice {
 
 PreambleCompletionContext detect_completion_context(llvm::StringRef text, std::uint32_t offset) {
     // TODO: cache newline offsets from incremental text updates to avoid
-    // the linear rfind/find scans on every completion trigger.
-    auto line_start = text.rfind('\n', offset > 0 ? offset - 1 : 0);
-    line_start = (line_start == llvm::StringRef::npos) ? 0 : line_start + 1;
+    // the linear line-boundary scans on every completion trigger.
+    //
+    // The full (NUL-terminated) text is lexed and the cursor applies as a
+    // logical bound: a keyword must end at or before it to count as typed.
+    auto lexer = Lexer::from_line(text, offset);
+    auto before_cursor = [&](const Token& token) {
+        return token.range.end <= offset;
+    };
 
-    auto line = text.slice(line_start, offset);
-    auto trimmed = line.ltrim();
+    auto first = lexer.advance();
 
-    if(trimmed.starts_with("#")) {
-        auto directive = trimmed.drop_front(1).ltrim();
-        if(directive.consume_front("include")) {
-            directive = directive.ltrim();
-            if(directive.consume_front("\"")) {
-                return {CompletionContext::IncludeQuoted, directive.str()};
-            }
-            if(directive.consume_front("<")) {
-                return {CompletionContext::IncludeAngled, directive.str()};
-            }
+    if(first.is_directive_hash() && before_cursor(first)) {
+        auto keyword = lexer.advance();
+        if(!keyword.is_identifier() || !before_cursor(keyword) || keyword.text(text) != "include") {
+            return {};
+        }
+        // The argument is likely half-typed, so its prefix is taken
+        // textually between the keyword token and the cursor.
+        auto argument = text.slice(keyword.range.end, offset).ltrim();
+        if(argument.consume_front("\"")) {
+            return {CompletionContext::IncludeQuoted, argument.str()};
+        }
+        if(argument.consume_front("<")) {
+            return {CompletionContext::IncludeAngled, argument.str()};
         }
         return {};
     }
 
-    // FIXME: the import detection is purely textual and can false-positive
-    // on a type named `import` (context-sensitive keyword). Use the
-    // module-name scanner from the syntax module for precise disambiguation.
-    auto import_check = trimmed;
-    if(import_check.consume_front("export") && !import_check.empty() &&
-       !std::isalnum(import_check[0])) {
-        import_check = import_check.ltrim();
+    // `[export] import` opening a logical line always means an import
+    // statement; lexing (instead of textual matching) rules out longer
+    // identifiers like `importlib` and sees through comments.
+    auto import_keyword = first;
+    if(first.is_identifier() && before_cursor(first) && first.text(text) == "export") {
+        import_keyword = lexer.advance();
     }
-    if(import_check.consume_front("import") &&
-       (import_check.empty() || !std::isalnum(import_check[0]))) {
-        import_check = import_check.ltrim();
-
-        auto line_end = text.find('\n', offset);
-        if(line_end == llvm::StringRef::npos)
-            line_end = text.size();
-        auto rest_of_line = text.slice(line_start, line_end);
-        if(!rest_of_line.contains(';')) {
-            return {CompletionContext::Import, import_check.str()};
-        }
+    if(!import_keyword.is_identifier() || !before_cursor(import_keyword) ||
+       import_keyword.text(text) != "import") {
+        return {};
     }
 
-    return {};
+    // Only complete while the statement is still open on this line.
+    auto line_end = text.find('\n', offset);
+    if(line_end == llvm::StringRef::npos) {
+        line_end = text.size();
+    }
+    if(text.slice(first.range.begin, line_end).contains(';')) {
+        return {};
+    }
+
+    auto prefix = text.slice(import_keyword.range.end, offset).ltrim();
+    return {CompletionContext::Import, prefix.str()};
 }
 
 std::vector<std::string>

--- a/src/syntax/lexer.cpp
+++ b/src/syntax/lexer.cpp
@@ -7,17 +7,23 @@ namespace clice {
 static clang::SourceLocation fake_loc = clang::SourceLocation::getFromRawEncoding(1);
 static clang::LangOptions default_opts;
 
-Lexer::Lexer(llvm::StringRef content,
-             bool ignore_comments,
-             const clang::LangOptions* lang_opts,
-             bool ignore_end_of_directive) :
-    content(content), ignore_end_of_directive(ignore_end_of_directive),
-    lexer(new clang::Lexer(fake_loc,
-                           lang_opts ? *lang_opts : default_opts,
-                           content.begin(),
-                           content.begin(),
-                           content.end())) {
-    lexer->SetCommentRetentionState(!ignore_comments);
+Lexer::Lexer(llvm::StringRef content, std::uint32_t start_offset, Options options) :
+    content(content), lexer(new clang::Lexer(fake_loc,
+                                             options.lang_opts ? *options.lang_opts : default_opts,
+                                             content.begin(),
+                                             content.begin() + start_offset,
+                                             content.end())) {
+    lexer->SetCommentRetentionState(options.keep_comments);
+}
+
+Lexer::Lexer(llvm::StringRef content, Options options) : Lexer(content, 0, options) {}
+
+Lexer Lexer::from_line(llvm::StringRef content, std::uint32_t offset, Options options) {
+    std::uint32_t line_start = 0;
+    if(auto nl = content.rfind('\n', offset); nl != llvm::StringRef::npos) {
+        line_start = static_cast<std::uint32_t>(nl + 1);
+    }
+    return Lexer(content, line_start, options);
 }
 
 Lexer::~Lexer() = default;
@@ -26,6 +32,8 @@ void Lexer::lex(Token& token) {
     clang::Token raw_token;
 
     if(parse_header_name) {
+        // One-shot: exactly the next token is a filename argument.
+        parse_header_name = false;
         lexer->LexIncludeFilename(raw_token);
     } else {
         lexer->LexFromRawLexer(raw_token);
@@ -35,12 +43,26 @@ void Lexer::lex(Token& token) {
     token.is_at_start_of_line = raw_token.isAtStartOfLine();
     token.is_pp_keyword = parse_pp_keyword;
 
+    // The fake location maps the buffer start, so raw locations decode
+    // straight to offsets into `content` even when lexing starts mid-buffer.
     auto offset = raw_token.getLocation().getRawEncoding() - fake_loc.getRawEncoding();
     token.range = LocalSourceRange{offset, offset + raw_token.getLength()};
 
-    if(token.is_at_start_of_line) {
-        parse_header_name = false;
+    // Comments are transparent to the directive machinery, matching how the
+    // lexer behaves when they are dropped: a retained line-leading comment
+    // must neither consume the start-of-line state the next token keys on
+    // nor end the module declaration context.
+    if(token.kind == clang::tok::comment) {
+        pending_start_of_line |= token.is_at_start_of_line;
+        return;
+    }
 
+    if(pending_start_of_line) {
+        token.is_at_start_of_line = true;
+        pending_start_of_line = false;
+    }
+
+    if(token.is_at_start_of_line) {
         if(token.kind == clang::tok::hash ||
            (module_declaration_context && token.text(content) == "export")) {
             parse_pp_keyword = true;
@@ -55,6 +77,21 @@ void Lexer::lex(Token& token) {
         parse_pp_keyword = false;
         auto kw = token.text(content);
         parse_header_name = kw == "include" || kw == "include_next" || kw == "embed";
+    }
+
+    // The __has_include family takes a parenthesized filename argument the
+    // raw lexer cannot detect on its own (LexIncludeFilename handles both
+    // "..." and <...>): switch to header-name mode right after the opening
+    // paren.
+    if(after_has_include && token.kind == clang::tok::l_paren) {
+        parse_header_name = true;
+    }
+
+    after_has_include = false;
+    if(token.is_identifier()) {
+        auto text = token.text(content);
+        after_has_include =
+            text == "__has_include" || text == "__has_include_next" || text == "__has_embed";
     }
 }
 
@@ -104,62 +141,6 @@ Token Lexer::advance_until(TokenKind kind) {
             return token;
         }
     }
-}
-
-static bool is_directive_keyword(llvm::StringRef word) {
-    return word == "include" || word == "include_next" || word == "import" || word == "embed" ||
-           word == "__has_include" || word == "__has_include_next" || word == "__has_embed";
-}
-
-std::optional<LocalSourceRange> find_directive_argument(llvm::StringRef content,
-                                                        std::uint32_t offset,
-                                                        const clang::LangOptions* lang_opts) {
-    std::uint32_t line_start = 0;
-    if(auto nl = content.rfind('\n', offset); nl != llvm::StringRef::npos)
-        line_start = static_cast<std::uint32_t>(nl + 1);
-
-    auto line = content.substr(line_start);
-    Lexer lexer(line, true, lang_opts);
-    bool after_has_keyword = false;
-    bool ready = false;
-
-    while(true) {
-        auto tok = lexer.advance();
-        if(tok.is_eof() || tok.is_eod())
-            break;
-
-        auto abs_begin = line_start + tok.range.begin;
-        auto abs_end = line_start + tok.range.end;
-
-        if(tok.is_identifier()) {
-            auto text = tok.text(line);
-            if(text == "__has_include" || text == "__has_include_next" || text == "__has_embed") {
-                after_has_keyword = true;
-                continue;
-            }
-            if(text == "include" || text == "include_next" || text == "embed") {
-                ready = true;
-                continue;
-            }
-        }
-
-        if(tok.kind == clang::tok::l_paren && after_has_keyword) {
-            after_has_keyword = false;
-            ready = true;
-            lexer.set_header_name_mode();
-            continue;
-        }
-
-        if(abs_begin < offset || !ready)
-            continue;
-
-        if(tok.is_header_name() || tok.kind == clang::tok::string_literal)
-            return LocalSourceRange(abs_begin, abs_end);
-
-        if(tok.is_identifier())
-            return LocalSourceRange(abs_begin, abs_end);
-    }
-    return std::nullopt;
 }
 
 }  // namespace clice

--- a/src/syntax/lexer.cpp
+++ b/src/syntax/lexer.cpp
@@ -13,6 +13,10 @@ Lexer::Lexer(llvm::StringRef content, std::uint32_t start_offset, Options option
                                              content.begin(),
                                              content.begin() + start_offset,
                                              content.end())) {
+    // clang's raw lexer reads the terminator as its end sentinel; a prefix
+    // slice would make it run past the buffer end.
+    assert(content.data() != nullptr && content.data()[content.size()] == '\0' &&
+           "Lexer requires a NUL-terminated buffer");
     lexer->SetCommentRetentionState(options.keep_comments);
 }
 
@@ -76,7 +80,10 @@ void Lexer::lex(Token& token) {
     } else if(parse_pp_keyword) {
         parse_pp_keyword = false;
         auto kw = token.text(content);
-        parse_header_name = kw == "include" || kw == "include_next" || kw == "embed";
+        // `import` here is the directive form (`#import`), which takes a
+        // filename; a module import never sets parse_pp_keyword.
+        parse_header_name =
+            kw == "include" || kw == "include_next" || kw == "embed" || kw == "import";
     }
 
     // The __has_include family takes a parenthesized filename argument the

--- a/src/syntax/lexer.h
+++ b/src/syntax/lexer.h
@@ -17,12 +17,6 @@ class Lexer;
 
 namespace clice {
 
-/// A pull-style wrapper over clang's raw lexer with just enough
-/// preprocessor awareness for scanning: directive lines are terminated by
-/// eod tokens, directive keywords are flagged via Token::is_pp_keyword, and
-/// header-name arguments (after #include/#embed keywords and inside the
-/// parentheses of the __has_include family) are lexed as single
-/// header_name tokens.
 struct LexerOptions {
     /// Emit comment tokens instead of dropping them.
     bool keep_comments = false;
@@ -30,6 +24,12 @@ struct LexerOptions {
     const clang::LangOptions* lang_opts = nullptr;
 };
 
+/// A pull-style wrapper over clang's raw lexer with just enough
+/// preprocessor awareness for scanning: directive lines are terminated by
+/// eod tokens, directive keywords are flagged via Token::is_pp_keyword, and
+/// header-name arguments (after #include/#embed keywords and inside the
+/// parentheses of the __has_include family) are lexed as single
+/// header_name tokens.
 class Lexer {
 public:
     using Options = LexerOptions;

--- a/src/syntax/lexer.h
+++ b/src/syntax/lexer.h
@@ -17,12 +17,33 @@ class Lexer;
 
 namespace clice {
 
+/// A pull-style wrapper over clang's raw lexer with just enough
+/// preprocessor awareness for scanning: directive lines are terminated by
+/// eod tokens, directive keywords are flagged via Token::is_pp_keyword, and
+/// header-name arguments (after #include/#embed keywords and inside the
+/// parentheses of the __has_include family) are lexed as single
+/// header_name tokens.
+struct LexerOptions {
+    /// Emit comment tokens instead of dropping them.
+    bool keep_comments = false;
+
+    const clang::LangOptions* lang_opts = nullptr;
+};
+
 class Lexer {
 public:
-    Lexer(llvm::StringRef content,
-          bool ignore_comments = true,
-          const clang::LangOptions* lang_opts = nullptr,
-          bool ignore_end_of_directive = true);
+    using Options = LexerOptions;
+
+    /// `content` must end at a NUL terminator (clang's raw lexer reads it
+    /// as its end sentinel): full buffers and suffix slices are fine, but
+    /// never pass a prefix slice — bound the lexing logically instead.
+    explicit Lexer(llvm::StringRef content, Options options = {});
+
+    /// Lex in place: start at the beginning of the line containing `offset`
+    /// rather than at the buffer start. Token ranges are still offsets into
+    /// the full `content`, so they compose directly with file coordinates
+    /// and token.text(content).
+    static Lexer from_line(llvm::StringRef content, std::uint32_t offset, Options options = {});
 
     Lexer(const Lexer&) = delete;
     Lexer(Lexer&&) = delete;
@@ -51,20 +72,14 @@ public:
 
     Token advance_until(TokenKind kind);
 
-    /// Force the lexer into header-name mode so the next token is lexed
-    /// via LexIncludeFilename (correctly handling both "..." and <...>).
-    /// Use this before lexing filename arguments in contexts like
-    /// __has_include() or __has_embed() where the lexer cannot detect
-    /// the mode automatically.
-    void set_header_name_mode() {
-        parse_header_name = true;
-    }
-
 private:
-    bool ignore_end_of_directive = true;
+    Lexer(llvm::StringRef content, std::uint32_t start_offset, Options options);
+
     bool parse_pp_keyword = false;
     bool parse_header_name = false;
+    bool after_has_include = false;
     bool module_declaration_context = true;
+    bool pending_start_of_line = false;
 
     Token last_token;
     Token current_token;
@@ -72,14 +87,5 @@ private:
     llvm::StringRef content;
     std::unique_ptr<clang::Lexer> lexer;
 };
-
-/// Find the range of the filename argument in a preprocessor directive line.
-/// `content` is the full source text, `offset` points at or before the directive keyword.
-/// Returns the range of the first filename-like token (header name, string literal,
-/// or macro identifier) found on the same line, or nullopt if none.
-std::optional<LocalSourceRange>
-    find_directive_argument(llvm::StringRef content,
-                            std::uint32_t offset,
-                            const clang::LangOptions* lang_opts = nullptr);
 
 }  // namespace clice

--- a/src/syntax/lexical_scan.cpp
+++ b/src/syntax/lexical_scan.cpp
@@ -1,0 +1,144 @@
+#include "syntax/lexical_scan.h"
+
+#include "syntax/lexer.h"
+
+namespace clice {
+
+LexicalInfo lexical_scan(llvm::StringRef content, const clang::LangOptions* lang_opts) {
+    using Comment = LexicalInfo::Comment;
+    using ModuleDeclaration = LexicalInfo::ModuleDeclaration;
+
+    LexicalInfo info;
+    Lexer lexer(content, {.keep_comments = true, .lang_opts = lang_opts});
+
+    auto record_comment = [&](const Token& token) {
+        auto kind =
+            token.text(content).starts_with("//") ? Comment::Kind::Line : Comment::Kind::Block;
+        info.comments.push_back({kind, token.range});
+    };
+
+    // A comment-transparent pull interface: module declaration grammar must
+    // match across interleaved comments, which are recorded on the way.
+    auto advance = [&] {
+        while(true) {
+            auto token = lexer.advance();
+            if(token.kind != clang::tok::comment) {
+                return token;
+            }
+            record_comment(token);
+        }
+    };
+
+    auto peek = [&] {
+        while(true) {
+            auto token = lexer.next();
+            if(token.kind != clang::tok::comment) {
+                return token;
+            }
+            lexer.advance();
+            record_comment(token);
+        }
+    };
+
+    auto advance_if = [&](llvm::function_ref<bool(const Token&)> pred) -> std::optional<Token> {
+        if(auto token = peek(); pred(token)) {
+            return advance();
+        }
+        return std::nullopt;
+    };
+
+    auto advance_if_kind = [&](TokenKind kind) {
+        return advance_if([&](const Token& token) { return token.kind == kind; });
+    };
+
+    auto is_spelled = [&](const Token& token, llvm::StringRef spelling) {
+        return token.is_identifier() && token.text(content) == spelling;
+    };
+
+    auto lex_dotted = [&](llvm::SmallVectorImpl<LocalSourceRange>& parts) {
+        while(true) {
+            auto part = advance_if([](const Token& token) { return token.is_identifier(); });
+            if(!part) {
+                return;
+            }
+            parts.push_back(part->range);
+            if(!advance_if_kind(clang::tok::period)) {
+                return;
+            }
+        }
+    };
+
+    bool file_start = true;
+
+    while(true) {
+        auto token = advance();
+        if(token.is_eof()) {
+            break;
+        }
+
+        bool at_file_start = file_start;
+        file_start = false;
+
+        // Valid code cannot begin a logical line with `module` (or `export
+        // module`) in any other meaning, so line-start matching is exact;
+        // stray matches in invalid code are filtered by the consumers'
+        // compiler-state cross-checks.
+        if(!token.is_at_start_of_line || !token.is_identifier()) {
+            continue;
+        }
+
+        ModuleDeclaration decl;
+        if(is_spelled(token, "export")) {
+            if(!is_spelled(peek(), "module")) {
+                continue;
+            }
+            decl.export_keyword = token.range;
+            token = advance();
+        } else if(!is_spelled(token, "module")) {
+            continue;
+        }
+        decl.keyword = token.range;
+
+        // `module;` introduces the global module fragment only as the
+        // file's first token; a bare `module;` anywhere else is nothing.
+        if(peek().kind == clang::tok::semi) {
+            if(at_file_start && !decl.export_keyword.valid()) {
+                decl.kind = ModuleDeclaration::Kind::GlobalFragment;
+                info.modules.push_back(std::move(decl));
+            }
+            continue;
+        }
+
+        // `module :private;` — the private fragment takes no export.
+        if(auto colon = advance_if_kind(clang::tok::colon)) {
+            decl.colon = colon->range;
+            auto is_private = [&](const Token& token) {
+                return is_spelled(token, "private");
+            };
+            if(auto private_keyword = advance_if(is_private);
+               private_keyword && !decl.export_keyword.valid()) {
+                decl.kind = ModuleDeclaration::Kind::PrivateFragment;
+                decl.partition_parts.push_back(private_keyword->range);
+                info.modules.push_back(std::move(decl));
+            }
+            continue;
+        }
+
+        lex_dotted(decl.name_parts);
+        if(decl.name_parts.empty()) {
+            continue;
+        }
+
+        if(auto colon = advance_if_kind(clang::tok::colon)) {
+            decl.colon = colon->range;
+            lex_dotted(decl.partition_parts);
+        }
+
+        decl.kind = ModuleDeclaration::Kind::Declaration;
+        info.modules.push_back(std::move(decl));
+    }
+
+    return info;
+}
+
+}  // namespace clice

--- a/src/syntax/lexical_scan.h
+++ b/src/syntax/lexical_scan.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "syntax/token.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "clang/Basic/LangOptions.h"
+
+namespace clice {
+
+/// Everything one lexical pass over a file records that neither the AST
+/// nor the preprocessor callbacks report: comments (the token buffer drops
+/// them) and the three module declaration forms (clang reports imports
+/// through PPCallbacks, but nothing covers the declarations themselves).
+struct LexicalInfo {
+    struct Comment {
+        enum class Kind : std::uint8_t {
+            /// A `//` comment.
+            Line,
+            /// A `/* */` comment.
+            Block,
+        };
+
+        Kind kind;
+        LocalSourceRange range;
+    };
+
+    struct ModuleDeclaration {
+        enum class Kind : std::uint8_t {
+            /// `module;` introducing the global module fragment.
+            GlobalFragment,
+            /// `[export] module name[:partition];`
+            Declaration,
+            /// `module :private;` introducing the private module fragment.
+            PrivateFragment,
+        };
+
+        Kind kind;
+
+        /// The `export` keyword; valid only when a Declaration has one.
+        LocalSourceRange export_keyword;
+
+        /// The `module` keyword.
+        LocalSourceRange keyword;
+
+        /// The identifiers of the dotted module name, in source order.
+        /// Empty for the fragment introducers.
+        llvm::SmallVector<LocalSourceRange, 4> name_parts;
+
+        /// The partition colon; invalid when there is no partition. Also
+        /// set for the private fragment (`:private`).
+        LocalSourceRange colon;
+
+        /// The identifiers of the dotted partition name; the `private`
+        /// keyword for the private fragment.
+        llvm::SmallVector<LocalSourceRange, 2> partition_parts;
+    };
+
+    // Both vectors heap-allocate so that payload pointers into them (the
+    // Semantics node table stores such pointers) survive moving the info.
+    std::vector<Comment> comments;
+
+    std::vector<ModuleDeclaration> modules;
+};
+
+/// Scan `content` once and collect its LexicalInfo. The matching is purely
+/// lexical: module declarations are recognized by line-start grammar, so
+/// consumers integrating them must cross-check compiler state (e.g. the
+/// unit's named module) before trusting them.
+LexicalInfo lexical_scan(llvm::StringRef content, const clang::LangOptions* lang_opts = nullptr);
+
+}  // namespace clice

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -502,7 +502,9 @@ bool is_preamble_complete(llvm::StringRef content, std::uint32_t bound) {
             if(line.size() < 3) {
                 return false;
             }
-            auto argument = line[2].text(content);
+            // A filename token's spelling may begin with line splices; skip
+            // them before inspecting the delimiter.
+            auto argument = line[2].text(content).ltrim("\\\r\n \t");
             if(argument.starts_with("\"")) {
                 return argument.size() >= 2 && argument.ends_with("\"");
             }

--- a/src/syntax/scan.cpp
+++ b/src/syntax/scan.cpp
@@ -440,7 +440,7 @@ std::uint32_t compute_preamble_bound(llvm::StringRef content) {
 std::vector<std::uint32_t> compute_preamble_bounds(llvm::StringRef content) {
     std::vector<std::uint32_t> result;
 
-    Lexer lexer(content, true, nullptr, false);
+    Lexer lexer(content);
 
     while(true) {
         auto token = lexer.advance();
@@ -480,56 +480,65 @@ std::vector<std::uint32_t> compute_preamble_bounds(llvm::StringRef content) {
     return result;
 }
 
-/// Check if a preprocessor #include/#import directive line is complete.
-static bool is_include_directive_complete(llvm::StringRef directive) {
-    if(directive.contains('"')) {
-        auto after_keyword = directive.drop_front(directive.starts_with("import") ? 6 : 7);
-        return after_keyword.count('"') >= 2;
-    }
-    if(directive.contains('<')) {
-        return directive.contains('>');
-    }
-    // No " or < — might be a macro (#include FOO) or just incomplete (#include ).
-    auto after_keyword = directive.drop_front(directive.starts_with("import") ? 6 : 7).ltrim();
-    return !after_keyword.empty();
-}
-
-/// Check if a C++20 module statement line (import/export module) is complete.
-/// A complete statement must end with ';'.
-static bool is_module_statement_complete(llvm::StringRef trimmed) {
-    return trimmed.rtrim().ends_with(";");
-}
-
 bool is_preamble_complete(llvm::StringRef content, std::uint32_t bound) {
-    auto preamble = content.substr(0, bound);
+    // The full (NUL-terminated) content is lexed; `bound` applies as a
+    // logical end — tokens starting at or past it belong to the body.
+    Lexer lexer(content);
 
-    while(!preamble.empty()) {
-        auto [line, rest] = preamble.split('\n');
-        preamble = rest;
+    // Tokens of the current logical line; eod tokens only act as line ends.
+    llvm::SmallVector<Token, 8> line;
 
-        auto trimmed = line.ltrim();
-
-        // Preprocessor directive: #include or #import
-        if(trimmed.starts_with("#")) {
-            auto directive = trimmed.drop_front(1).ltrim();
-            if(directive.starts_with("include") || directive.starts_with("import")) {
-                if(!is_include_directive_complete(directive)) {
-                    return false;
-                }
+    auto line_complete = [&] {
+        // A #include/#import directive is complete once it has a terminated
+        // filename argument (or a macro identifier standing in for one).
+        if(line.front().is_directive_hash()) {
+            if(line.size() < 2 || !line[1].is_identifier()) {
+                return true;
             }
-            continue;
-        }
-
-        // C++20 module statements: import, export module, export import
-        // Check word boundary to avoid matching identifiers like "important".
-        auto is_keyword = [](llvm::StringRef s, llvm::StringRef keyword) {
-            return s.starts_with(keyword) &&
-                   (s.size() == keyword.size() || !llvm::isAlnum(s[keyword.size()]));
-        };
-        if(is_keyword(trimmed, "import") || is_keyword(trimmed, "export")) {
-            if(!is_module_statement_complete(trimmed)) {
+            auto keyword = line[1].text(content);
+            if(keyword != "include" && keyword != "include_next" && keyword != "import") {
+                return true;
+            }
+            if(line.size() < 3) {
                 return false;
             }
+            auto argument = line[2].text(content);
+            if(argument.starts_with("\"")) {
+                return argument.size() >= 2 && argument.ends_with("\"");
+            }
+            if(argument.starts_with("<")) {
+                return argument.ends_with(">");
+            }
+            return true;
+        }
+
+        // A module statement (import, export module, export import) is
+        // complete once its last token is the semicolon. Working on tokens
+        // instead of text keeps a trailing comment from hiding it.
+        if(!line.front().is_identifier()) {
+            return true;
+        }
+        auto keyword = line.front().text(content);
+        if(keyword != "import" && keyword != "export") {
+            return true;
+        }
+        return line.back().kind == clang::tok::semi;
+    };
+
+    while(true) {
+        auto token = lexer.advance();
+        bool at_end = token.is_eof() || token.range.begin >= bound;
+        if((at_end || token.is_at_start_of_line) && !line.empty()) {
+            if(!line_complete()) {
+                return false;
+            }
+            line.clear();
+        }
+        if(at_end) {
+            break;
+        }
+        if(!token.is_eod()) {
+            line.push_back(token);
         }
     }
 

--- a/tests/snap/folding_range/abbreviated_function_template.cpp
+++ b/tests/snap/folding_range/abbreviated_function_template.cpp
@@ -3,7 +3,7 @@
 /// ## Abbreviated function templates — bodies of functions with `auto` or constrained `auto` parameters fold like any other function
 ///
 /// - status: supported
-/// - order: 13
+/// - order: 14
 
 template <typename T>
 concept Small = sizeof(T) <= 8;

--- a/tests/snap/folding_range/comment_folding.cpp
+++ b/tests/snap/folding_range/comment_folding.cpp
@@ -3,7 +3,7 @@
 /// ## Comment folding — multi-line `/* */` and consecutive `//` line comments
 ///
 /// - status: unsupported
-/// - order: 7
+/// - order: 8
 
 // This is a long
 // multi-line comment

--- a/tests/snap/folding_range/coroutine_body.cpp
+++ b/tests/snap/folding_range/coroutine_body.cpp
@@ -3,7 +3,7 @@
 /// ## Coroutine bodies — the written block folds exactly once and the coroutine transformation wrapper adds no duplicate fold; a coroutine lambda keeps its body fold
 ///
 /// - status: supported
-/// - order: 15
+/// - order: 16
 
 namespace std {
 

--- a/tests/snap/folding_range/include_region.cpp
+++ b/tests/snap/folding_range/include_region.cpp
@@ -3,7 +3,7 @@
 /// ## Include region folding — consecutive `#include` directives
 ///
 /// - status: unsupported
-/// - order: 8
+/// - order: 9
 
 #include <vector>       // ┐
 #include <string>       // │ foldable region

--- a/tests/snap/folding_range/initializer_list_construction.cpp
+++ b/tests/snap/folding_range/initializer_list_construction.cpp
@@ -3,7 +3,7 @@
 /// ## Initializer-list constructions — the constructor's braces and the nested initializer list share delimiters and fold once; a parenthesized list argument keeps both folds
 ///
 /// - status: supported
-/// - order: 16
+/// - order: 17
 
 namespace std {
 

--- a/tests/snap/folding_range/macro_folding.cpp
+++ b/tests/snap/folding_range/macro_folding.cpp
@@ -3,7 +3,7 @@
 /// ## Macro-generated folding — braces and access specifiers spelled through macros fold at the invocation site
 ///
 /// - status: supported
-/// - order: 14
+/// - order: 15
 
 #define NS_BEGIN namespace ns {
 #define NS_END }

--- a/tests/snap/folding_range/pragma_classification.cpp
+++ b/tests/snap/folding_range/pragma_classification.cpp
@@ -1,0 +1,18 @@
+/// # Fold Kinds
+///
+/// ## Pragma classification — only the first argument token decides region/endregion
+///
+/// - status: supported
+/// - order: 7
+
+// The leading declaration ends the preamble so the pragmas below reach the
+// main-file parse on both the standalone and the wire path.
+int before = 0;
+
+// Neither a region name nor another pragma's argument mentioning
+// "endregion" may close the fold early.
+#pragma region endregion_pair
+int retries = 3;
+#pragma mark see endregion notes
+int limit = 10;
+#pragma endregion

--- a/tests/snap/folding_range/pragma_classification.cpp
+++ b/tests/snap/folding_range/pragma_classification.cpp
@@ -16,3 +16,10 @@ int retries = 3;
 #pragma mark see endregion notes
 int limit = 10;
 #pragma endregion
+
+// The tail of a multiline comment before the introducer must not hide
+// the region either.
+/* spans
+a line */ #pragma region after_comment
+int after = 1;
+#pragma endregion

--- a/tests/snap/folding_range/pragma_classification.snap.yml
+++ b/tests/snap/folding_range/pragma_classification.snap.yml
@@ -3,3 +3,4 @@ created_at: 2026-08-01
 input_file: pragma_classification.cpp
 ---
 - { range: "13:0-17:1", kind: region }
+- { range: "22:10-24:1", kind: region }

--- a/tests/snap/folding_range/pragma_classification.snap.yml
+++ b/tests/snap/folding_range/pragma_classification.snap.yml
@@ -1,0 +1,5 @@
+---
+created_at: 2026-08-01
+input_file: pragma_classification.cpp
+---
+- { range: "13:0-17:1", kind: region }

--- a/tests/snap/folding_range/raw_string_literal.cpp
+++ b/tests/snap/folding_range/raw_string_literal.cpp
@@ -3,7 +3,7 @@
 /// ## Raw string literal folding
 ///
 /// - status: unsupported
-/// - order: 9
+/// - order: 10
 
 auto sql = R"(
     SELECT *

--- a/tests/snap/folding_range/template_instantiations.cpp
+++ b/tests/snap/folding_range/template_instantiations.cpp
@@ -3,7 +3,7 @@
 /// ## Template specializations and instantiations — written specializations and their members fold; instantiated declarations reuse the pattern's source locations and must not fold it again
 ///
 /// - status: supported
-/// - order: 12
+/// - order: 13
 
 template <typename T>
 struct Box {

--- a/tests/snap/folding_range/template_parameter_list.cpp
+++ b/tests/snap/folding_range/template_parameter_list.cpp
@@ -3,7 +3,7 @@
 /// ## Template parameter list folding
 ///
 /// - status: unsupported
-/// - order: 11
+/// - order: 12
 
 template<typename T>
 struct Less;

--- a/tests/snap/folding_range/using_declaration_block.cpp
+++ b/tests/snap/folding_range/using_declaration_block.cpp
@@ -3,7 +3,7 @@
 /// ## `using` declaration blocks — consecutive using declarations/directives
 ///
 /// - status: unsupported
-/// - order: 10
+/// - order: 11
 
 using std::vector;  // ┐
 using std::string;  // │ foldable

--- a/tests/unit/feature/document_link_tests.cpp
+++ b/tests/unit/feature/document_link_tests.cpp
@@ -93,6 +93,26 @@ TEST_CASE(MacroInclude) {
     EXPECT_LINK(0, "0", TestVFS::path("test.h"));
 }
 
+TEST_CASE(HasIncludeTwice) {
+    // Two operators on one line: each restarts the argument match.
+    run(R"cpp(
+#[a.h]
+
+#[b.h]
+
+#[main.cpp]
+#include "a.h"
+#include "b.h"
+#if __has_include(§(0)⟦"a.h"⟧) && __has_include(§(1)⟦"b.h"⟧)
+#endif
+)cpp");
+
+    // Two include links, then the two operator arguments.
+    ASSERT_EQ(links.size(), 4U);
+    EXPECT_LINK(2, "0", TestVFS::path("a.h"));
+    EXPECT_LINK(3, "1", TestVFS::path("b.h"));
+}
+
 TEST_CASE(ImportNamedMacro) {
     // Pre-C++20, even `import` is a legal macro name; as the filename
     // argument it must link, not read as a directive keyword.

--- a/tests/unit/feature/document_link_tests.cpp
+++ b/tests/unit/feature/document_link_tests.cpp
@@ -93,6 +93,21 @@ TEST_CASE(MacroInclude) {
     EXPECT_LINK(0, "0", TestVFS::path("test.h"));
 }
 
+TEST_CASE(ImportNamedMacro) {
+    // Pre-C++20, even `import` is a legal macro name; as the filename
+    // argument it must link, not read as a directive keyword.
+    run(R"cpp(
+#[test.h]
+
+#[main.cpp]
+#define import "test.h"
+#include §(0)⟦import§⟧
+)cpp");
+
+    ASSERT_EQ(links.size(), 1U);
+    EXPECT_LINK(0, "0", TestVFS::path("test.h"));
+}
+
 TEST_CASE(Embed) {
     run(R"cpp(
 #[bytes.bin]

--- a/tests/unit/feature/semantic_tokens_tests.cpp
+++ b/tests/unit/feature/semantic_tokens_tests.cpp
@@ -167,6 +167,32 @@ TEST_CASE(PreambleDefineUnderPch) {
     EXPECT_TOKEN("c0", SymbolKind::Comment);
 }
 
+TEST_CASE(ModuleDeclarationUnderPch) {
+    // The whole module preamble (global fragment included) sits under the
+    // PCH split; every written module token must still classify — with a
+    // leading comment block ahead of the global fragment, like a license
+    // header.
+    run_utf8(R"cpp(// leading comment block
+// above the global module fragment
+
+§(g0)⟦module⟧;
+
+export §(k0)⟦module⟧ §(n0)⟦demo⟧.§(n1)⟦core⟧;
+
+export int exported_value = 1;
+
+§(p0)⟦module⟧ :private;
+
+int private_value = 2;
+)cpp");
+
+    EXPECT_TOKEN("g0", SymbolKind::Keyword);
+    EXPECT_TOKEN("k0", SymbolKind::Keyword);
+    EXPECT_TOKEN("n0", SymbolKind::Module);
+    EXPECT_TOKEN("n1", SymbolKind::Module);
+    EXPECT_TOKEN("p0", SymbolKind::Keyword);
+}
+
 TEST_CASE(UTF16LengthDiffersFromUTF8) {
     add_main("main.cpp", R"cpp(
 int main() {
@@ -249,6 +275,54 @@ int y = x;
 
     EXPECT_TOKEN("kw", SymbolKind::Keyword);
     EXPECT_TOKEN("mod", SymbolKind::Module);
+}
+
+TEST_CASE(ImportChannelAudit) {
+    add_files("main.cppm", R"(
+#[a.cppm]
+export module a;
+export int va = 1;
+
+#[b.cppm]
+export module b;
+export int vb = 1;
+
+#[part.cppm]
+export module foo:part;
+export int vp = 1;
+
+#[main.cppm]
+export module foo;
+import a;
+export import b;
+import :part;
+)");
+    ASSERT_TRUE(compile_with_modules());
+
+    // The preprocessor callback channel must record every import form the
+    // AST records: a named import, an export-import and a partition import
+    // (whose full name resolves through the owning module).
+    auto& imports = unit->directives()[unit->interested_file()].imports;
+    ASSERT_EQ(imports.size(), 3U);
+    ASSERT_EQ(imports[0].name, "a");
+    ASSERT_EQ(imports[1].name, "b");
+    ASSERT_EQ(imports[2].name, "foo:part");
+
+    std::size_t ast_imports = 0;
+    auto count = [&](const clang::Decl* decl, auto& self) -> void {
+        if(llvm::isa<clang::ImportDecl>(decl)) {
+            ast_imports += 1;
+        }
+        if(auto* context = llvm::dyn_cast<clang::DeclContext>(decl)) {
+            for(auto* child: context->decls()) {
+                self(child, self);
+            }
+        }
+    };
+    for(auto* decl: unit->context().getTranslationUnitDecl()->decls()) {
+        count(decl, count);
+    }
+    ASSERT_EQ(ast_imports, 3U);
 }
 
 TEST_CASE(ModulePartitionImport) {

--- a/tests/unit/index/tu_index_tests.cpp
+++ b/tests/unit/index/tu_index_tests.cpp
@@ -665,6 +665,60 @@ TEST_CASE(ModuleName) {
     ASSERT_TRUE(found_definition);
 }
 
+TEST_CASE(ModulePartitionName) {
+    build_index(R"(export module §(m)⟦§(m)foo:part⟧;)");
+
+    // The occurrence spans the whole written name, partition included.
+    auto occs = select("m");
+    ASSERT_FALSE(occs.empty());
+    ASSERT_EQ(occs.front().range, range("m"));
+
+    auto& index = tu_index.main_file_index;
+    auto it = index.relations.find(occs.front().target);
+    ASSERT_TRUE(it != index.relations.end());
+
+    bool found_definition = false;
+    for(auto& r: it->second) {
+        if(r.kind.value() == static_cast<std::uint32_t>(RelationKind::Definition)) {
+            found_definition = true;
+        }
+    }
+    ASSERT_TRUE(found_definition);
+}
+
+TEST_CASE(ImplementationUnitReference) {
+    add_files("main.cpp", R"(
+#[foo.cppm]
+export module foo;
+export int x = 1;
+
+#[main.cpp]
+module §(m)⟦§(m)foo⟧;
+)");
+    ASSERT_TRUE(compile_with_modules());
+    tu_index = index::TUIndex::build(*unit);
+
+    // An implementation unit's declaration is a Reference, not a Definition.
+    auto occs = select("m");
+    ASSERT_FALSE(occs.empty());
+    ASSERT_EQ(occs.front().range, range("m"));
+
+    auto& index = tu_index.main_file_index;
+    auto it = index.relations.find(occs.front().target);
+    ASSERT_TRUE(it != index.relations.end());
+
+    bool found_reference = false;
+    for(auto& r: it->second) {
+        if(r.kind.value() == static_cast<std::uint32_t>(RelationKind::Definition)) {
+            ASSERT_TRUE(false);
+        }
+        if(r.kind.value() == static_cast<std::uint32_t>(RelationKind::Reference)) {
+            found_reference = true;
+        }
+    }
+    ASSERT_TRUE(found_reference);
+}
+
 TEST_CASE(OverrideRelation) {
     build_index(R"(
             struct Base {

--- a/tests/unit/semantic/semantics_tests.cpp
+++ b/tests/unit/semantic/semantics_tests.cpp
@@ -39,7 +39,7 @@ module :private;
     ASSERT_EQ(modules[1].name_parts.size(), 2U);
 
     // The declaration's written name tokens are owned by its Module node,
-    // so selection sees the declaration like any other node.
+    // so the ownership machinery can attribute them.
     auto index = token_index_at(semantics, range("name").begin);
     ASSERT_TRUE(index.has_value());
     auto owners = semantics.owners(*index);
@@ -70,6 +70,24 @@ TEST_CASE(CommentNodes) {
         }
     }
     ASSERT_EQ(comment_nodes, 2U);
+}
+
+TEST_CASE(DisabledDuplicateDeclaration) {
+    // A duplicate declaration in a disabled branch fails the DefinitionLoc
+    // anchor; only the live one becomes a node.
+    add_main("main.cpp", R"cpp(
+export §(live)⟦module⟧ app;
+#if 0
+export module app;
+#endif
+)cpp");
+    ASSERT_TRUE(compile());
+    auto& semantics = unit->semantics();
+
+    auto modules = semantics.module_declarations();
+    ASSERT_EQ(modules.size(), 1U);
+    ASSERT_EQ(modules[0].kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(modules[0].keyword, range("live"));
 }
 
 TEST_CASE(NoModuleNoNodes) {

--- a/tests/unit/semantic/semantics_tests.cpp
+++ b/tests/unit/semantic/semantics_tests.cpp
@@ -1,0 +1,92 @@
+#include <optional>
+
+#include "test/test.h"
+#include "test/tester.h"
+#include "semantic/semantics.h"
+
+namespace clice::testing {
+
+namespace {
+
+using ModuleDeclaration = LexicalInfo::ModuleDeclaration;
+
+TEST_SUITE(SemanticsTable, Tester) {
+
+std::optional<std::uint32_t> token_index_at(const Semantics& semantics, std::uint32_t offset) {
+    for(std::uint32_t i = 0; i < semantics.spelled_tokens().size(); i += 1) {
+        if(semantics.token_offset(i) == offset) {
+            return i;
+        }
+    }
+    return std::nullopt;
+}
+
+TEST_CASE(ModuleNodes) {
+    add_main("main.cpp", R"cpp(
+module;
+export module §(name)⟦demo⟧.core;
+export int value = 1;
+module :private;
+)cpp");
+    ASSERT_TRUE(compile());
+    auto& semantics = unit->semantics();
+
+    auto modules = semantics.module_declarations();
+    ASSERT_EQ(modules.size(), 3U);
+    ASSERT_EQ(modules[0].kind, ModuleDeclaration::Kind::GlobalFragment);
+    ASSERT_EQ(modules[1].kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(modules[2].kind, ModuleDeclaration::Kind::PrivateFragment);
+    ASSERT_EQ(modules[1].name_parts.size(), 2U);
+
+    // The declaration's written name tokens are owned by its Module node,
+    // so selection sees the declaration like any other node.
+    auto index = token_index_at(semantics, range("name").begin);
+    ASSERT_TRUE(index.has_value());
+    auto owners = semantics.owners(*index);
+    ASSERT_EQ(owners.size(), 1U);
+    auto& node = semantics.node(owners[0]);
+    ASSERT_EQ(node.node.kind(), SemanticNode::Kind::Module);
+    ASSERT_EQ(node.node.get<ModuleDeclaration>(), &modules[1]);
+}
+
+TEST_CASE(CommentNodes) {
+    add_main("main.cpp", "// note\nint x = 1; /* tail */\n");
+    ASSERT_TRUE(compile());
+    auto& semantics = unit->semantics();
+
+    auto comments = semantics.comments();
+    ASSERT_EQ(comments.size(), 2U);
+    ASSERT_EQ(comments[0].kind, LexicalInfo::Comment::Kind::Line);
+    ASSERT_EQ(comments[1].kind, LexicalInfo::Comment::Kind::Block);
+
+    // Each comment is also a node; it owns no spelled tokens (the stream
+    // drops comments) and carries only its payload.
+    std::size_t comment_nodes = 0;
+    for(auto& entry: semantics.node_entries()) {
+        if(entry.node.kind() == SemanticNode::Kind::Comment) {
+            ASSERT_EQ(entry.node.get<LexicalInfo::Comment>(), &comments[comment_nodes]);
+            ASSERT_EQ(entry.owned, 0U);
+            comment_nodes += 1;
+        }
+    }
+    ASSERT_EQ(comment_nodes, 2U);
+}
+
+TEST_CASE(NoModuleNoNodes) {
+    // `module` as an ordinary identifier in a non-module unit: the lexical
+    // candidates (if any) must not survive the compiler cross-check.
+    add_main("main.cpp", "int module = 1;\nvoid f() { module = 2; }\n");
+    ASSERT_TRUE(compile());
+    auto& semantics = unit->semantics();
+
+    ASSERT_EQ(semantics.module_declarations().size(), 0U);
+    for(auto& entry: semantics.node_entries()) {
+        ASSERT_TRUE(entry.node.kind() != SemanticNode::Kind::Module);
+    }
+}
+
+};  // TEST_SUITE(SemanticsTable)
+
+}  // namespace
+
+}  // namespace clice::testing

--- a/tests/unit/syntax/completion_tests.cpp
+++ b/tests/unit/syntax/completion_tests.cpp
@@ -32,6 +32,18 @@ TEST_CASE(IncludeEmpty) {
     EXPECT_EQ(ctx.prefix, "");
 }
 
+TEST_CASE(CursorInsideKeyword) {
+    // A keyword is only "typed" once the cursor passed its end.
+    EXPECT_EQ(detect_completion_context("#include", 5).kind, CompletionContext::None);
+    EXPECT_EQ(detect_completion_context("import", 3).kind, CompletionContext::None);
+}
+
+TEST_CASE(CrlfLineEndings) {
+    auto ctx = detect_completion_context("#include <a>\r\n#include <ve", 26);
+    EXPECT_EQ(ctx.kind, CompletionContext::IncludeAngled);
+    EXPECT_EQ(ctx.prefix, "ve");
+}
+
 TEST_CASE(ImportSimple) {
     auto ctx = detect_completion_context("import std", 10);
     EXPECT_EQ(ctx.kind, CompletionContext::Import);

--- a/tests/unit/syntax/completion_tests.cpp
+++ b/tests/unit/syntax/completion_tests.cpp
@@ -38,6 +38,14 @@ TEST_CASE(CursorInsideKeyword) {
     EXPECT_EQ(detect_completion_context("import", 3).kind, CompletionContext::None);
 }
 
+TEST_CASE(CursorAtNewline) {
+    // A cursor sitting on a line's terminating newline still completes the
+    // statement that line opened.
+    auto ctx = detect_completion_context("import std\nint x;", 10);
+    EXPECT_EQ(ctx.kind, CompletionContext::Import);
+    EXPECT_EQ(ctx.prefix, "std");
+}
+
 TEST_CASE(CrlfLineEndings) {
     auto ctx = detect_completion_context("#include <a>\r\n#include <ve", 26);
     EXPECT_EQ(ctx.kind, CompletionContext::IncludeAngled);

--- a/tests/unit/syntax/lexer_tests.cpp
+++ b/tests/unit/syntax/lexer_tests.cpp
@@ -155,6 +155,7 @@ TEST_CASE(MacroArgument) {
     Lexer lexer(content);
     auto tokens = lex_all(lexer);
 
+    ASSERT_TRUE(tokens.size() >= 3U);
     ASSERT_EQ(first_header_name(content), "");
     ASSERT_TRUE(tokens[2].is_identifier());
     ASSERT_EQ(tokens[2].text(content), "HEADER");
@@ -275,6 +276,7 @@ TEST_CASE(UnterminatedComment) {
     llvm::StringRef content = "int x; /* abc";
     Lexer lexer(content, {.keep_comments = true});
     auto tokens = lex_all(lexer);
+    ASSERT_EQ(tokens.size(), 3U);
     ASSERT_EQ(tokens.back().kind, clang::tok::semi);
 }
 

--- a/tests/unit/syntax/lexer_tests.cpp
+++ b/tests/unit/syntax/lexer_tests.cpp
@@ -6,164 +6,249 @@
 
 namespace clice::testing {
 namespace {
-TEST_SUITE(SourceText) {
 
-TEST_CASE(IgnoreComments) {
-    std::size_t count = 0;
-
-    std::vector<clang::tok::TokenKind> kinds = {
-        clang::tok::raw_identifier,
-        clang::tok::raw_identifier,
-        clang::tok::equal,
-        clang::tok::numeric_constant,
-        clang::tok::semi,
-    };
-
-    {
-        Lexer lexer("int x = 1; // comment", true);
-
-        while(true) {
-            Token token = lexer.advance();
-            if(token.is_eof()) {
-                break;
-            }
-
-            ASSERT_EQ(token.kind, kinds[count]);
-            count += 1;
-        }
-
-        ASSERT_EQ(count, 5);
-    }
-
-    count = 0;
-
-    kinds = {
-        clang::tok::raw_identifier,
-        clang::tok::raw_identifier,
-        clang::tok::equal,
-        clang::tok::numeric_constant,
-        clang::tok::semi,
-        clang::tok::comment,
-    };
-
-    {
-        Lexer lexer("int x = 1; // comment", false);
-
-        while(true) {
-            Token token = lexer.advance();
-            if(token.is_eof()) {
-                break;
-            }
-
-            ASSERT_EQ(token.kind, kinds[count]);
-            count += 1;
-        }
-
-        ASSERT_EQ(count, 6);
-    }
-}
-
-TEST_CASE(LexInclude) {
-    Lexer lexer(R"(
-#include <iostream>
-#include "gtest/test.h"
-module;
-int x = 1;
-)",
-                true,
-                nullptr,
-                false);
-
+/// Drain the lexer and return every token before eof.
+std::vector<Token> lex_all(Lexer& lexer) {
+    std::vector<Token> tokens;
     while(true) {
         Token token = lexer.advance();
         if(token.is_eof()) {
             break;
         }
+        tokens.push_back(token);
     }
+    return tokens;
+}
+
+TEST_SUITE(SourceText) {
+
+TEST_CASE(IgnoreComments) {
+    llvm::StringRef content = "int x = 1; // comment";
+
+    std::vector<TokenKind> kinds = {
+        clang::tok::raw_identifier,
+        clang::tok::raw_identifier,
+        clang::tok::equal,
+        clang::tok::numeric_constant,
+        clang::tok::semi,
+    };
+
+    {
+        Lexer lexer(content);
+        auto tokens = lex_all(lexer);
+        ASSERT_EQ(tokens.size(), kinds.size());
+        for(std::size_t i = 0; i < kinds.size(); i += 1) {
+            ASSERT_EQ(tokens[i].kind, kinds[i]);
+        }
+    }
+
+    kinds.push_back(clang::tok::comment);
+
+    {
+        Lexer lexer(content, {.keep_comments = true});
+        auto tokens = lex_all(lexer);
+        ASSERT_EQ(tokens.size(), kinds.size());
+        for(std::size_t i = 0; i < kinds.size(); i += 1) {
+            ASSERT_EQ(tokens[i].kind, kinds[i]);
+        }
+        ASSERT_EQ(tokens.back().text(content), "// comment");
+    }
+}
+
+TEST_CASE(TokenRanges) {
+    llvm::StringRef content = "int foo = 42;";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+
+    ASSERT_EQ(tokens.size(), 5U);
+    ASSERT_EQ(tokens[0].text(content), "int");
+    ASSERT_EQ(tokens[1].text(content), "foo");
+    ASSERT_EQ(tokens[1].range.begin, 4U);
+    ASSERT_EQ(tokens[1].range.end, 7U);
+    ASSERT_EQ(tokens[3].text(content), "42");
+    ASSERT_EQ(tokens[4].text(content), ";");
+}
+
+TEST_CASE(LexInclude) {
+    llvm::StringRef content = R"(
+#include <iostream>
+#include "gtest/test.h"
+module;
+int x = 1;
+)";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+
+    std::vector<TokenKind> kinds = {
+        clang::tok::hash,            // #
+        clang::tok::raw_identifier,  // include
+        clang::tok::header_name,     // <iostream>
+        clang::tok::eod,
+        clang::tok::hash,            // #
+        clang::tok::raw_identifier,  // include
+        clang::tok::header_name,     // "gtest/test.h"
+        clang::tok::eod,
+        clang::tok::raw_identifier,  // module
+        clang::tok::semi,            // ;
+        clang::tok::eod,
+        clang::tok::raw_identifier,  // int
+        clang::tok::raw_identifier,  // x
+        clang::tok::equal,           // =
+        clang::tok::numeric_constant,
+        clang::tok::semi,
+    };
+
+    ASSERT_EQ(tokens.size(), kinds.size());
+    for(std::size_t i = 0; i < kinds.size(); i += 1) {
+        ASSERT_EQ(tokens[i].kind, kinds[i]);
+    }
+
+    ASSERT_EQ(tokens[2].text(content), "<iostream>");
+    ASSERT_TRUE(tokens[1].is_pp_keyword);
+    ASSERT_EQ(tokens[6].text(content), R"("gtest/test.h")");
+    ASSERT_TRUE(tokens[8].is_pp_keyword);
 }
 
 };  // TEST_SUITE(SourceText)
 
-TEST_SUITE(DirectiveArgument) {
+TEST_SUITE(HeaderNameLexing) {
 
-void EXPECT_RANGE(llvm::StringRef content, std::uint32_t offset, llvm::StringRef expected) {
-    auto result = find_directive_argument(content, offset);
-    ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(content.substr(result->begin, result->length()), expected);
+/// The text of the first header-name token in `content`, or empty.
+llvm::StringRef first_header_name(llvm::StringRef content) {
+    Lexer lexer(content);
+    while(true) {
+        Token token = lexer.advance();
+        if(token.is_eof()) {
+            return "";
+        }
+        if(token.is_header_name()) {
+            return token.text(content);
+        }
+    }
 }
 
-void EXPECT_NONE(llvm::StringRef content, std::uint32_t offset) {
-    auto result = find_directive_argument(content, offset);
-    ASSERT_FALSE(result.has_value());
+TEST_CASE(HasIncludeArgument) {
+    ASSERT_EQ(first_header_name("#if __has_include(<vector>)"), "<vector>");
+    ASSERT_EQ(first_header_name(R"(#if __has_include("foo.h"))"), R"("foo.h")");
+    ASSERT_EQ(first_header_name("#if __has_include_next(<stdlib.h>)"), "<stdlib.h>");
 }
 
-TEST_CASE(IncludeQuoted) {
-    llvm::StringRef src = R"(#include "foo.h")";
-    EXPECT_RANGE(src, 0, R"("foo.h")");
+TEST_CASE(HasEmbedArgument) {
+    ASSERT_EQ(first_header_name(R"(#if __has_embed("data.bin"))"), R"("data.bin")");
 }
 
-TEST_CASE(IncludeAngled) {
-    llvm::StringRef src = "#include <iostream>";
-    EXPECT_RANGE(src, 0, "<iostream>");
+TEST_CASE(IncludeNextArgument) {
+    ASSERT_EQ(first_header_name("#include_next <stdlib.h>"), "<stdlib.h>");
 }
 
-TEST_CASE(IncludeMacro) {
-    llvm::StringRef src = "#include HEADER";
-    EXPECT_RANGE(src, 0, "HEADER");
+TEST_CASE(EmbedArgument) {
+    ASSERT_EQ(first_header_name(R"(#embed "data.bin")"), R"("data.bin")");
 }
 
-TEST_CASE(HasIncludeQuoted) {
-    llvm::StringRef src = R"(#if __has_include("foo.h"))";
-    // offset at __has_include
-    auto pos = src.find("__has_include");
-    EXPECT_RANGE(src, static_cast<std::uint32_t>(pos), R"("foo.h")");
+TEST_CASE(MacroArgument) {
+    // A macro filename argument stays an ordinary identifier.
+    llvm::StringRef content = "#include HEADER";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+
+    ASSERT_EQ(first_header_name(content), "");
+    ASSERT_TRUE(tokens[2].is_identifier());
+    ASSERT_EQ(tokens[2].text(content), "HEADER");
 }
 
-TEST_CASE(HasIncludeAngled) {
-    llvm::StringRef src = "#if __has_include(<vector>)";
-    auto pos = src.find("__has_include");
-    EXPECT_RANGE(src, static_cast<std::uint32_t>(pos), "<vector>");
+TEST_CASE(SplicedInclude) {
+    // The token spelling legitimately contains the line splice; only the
+    // trailing part is the written filename.
+    ASSERT_TRUE(first_header_name("#include \\\n<foo.h>\nint x;").ends_with("<foo.h>"));
 }
 
-TEST_CASE(EmbedQuoted) {
-    llvm::StringRef src = R"(#embed "data.bin")";
-    EXPECT_RANGE(src, 0, R"("data.bin")");
+TEST_CASE(EmptyInclude) {
+    llvm::StringRef content = "#include \nint x;";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+
+    // No filename: the directive just ends; nothing is lexed as a header name.
+    ASSERT_EQ(first_header_name(content), "");
+    ASSERT_EQ(tokens[2].kind, clang::tok::eod);
 }
 
-TEST_CASE(HasEmbedQuoted) {
-    llvm::StringRef src = R"(#if __has_embed("data.bin"))";
-    auto pos = src.find("__has_embed");
-    EXPECT_RANGE(src, static_cast<std::uint32_t>(pos), R"("data.bin")");
+};  // TEST_SUITE(HeaderNameLexing)
+
+TEST_SUITE(FromLine) {
+
+TEST_CASE(MidFileLine) {
+    llvm::StringRef content = "int a;\n#include <foo>\nint b;\n";
+    auto offset = static_cast<std::uint32_t>(content.find("include"));
+
+    auto lexer = Lexer::from_line(content, offset);
+    auto hash = lexer.advance();
+    ASSERT_EQ(hash.kind, clang::tok::hash);
+    ASSERT_TRUE(hash.is_at_start_of_line);
+    ASSERT_EQ(hash.range.begin, static_cast<std::uint32_t>(content.find('#')));
+
+    auto keyword = lexer.advance();
+    ASSERT_TRUE(keyword.is_pp_keyword);
+    ASSERT_EQ(keyword.text(content), "include");
+
+    auto name = lexer.advance();
+    ASSERT_TRUE(name.is_header_name());
+    ASSERT_EQ(name.text(content), "<foo>");
 }
 
-TEST_CASE(MultilineOffset) {
-    llvm::StringRef src = "#include \"a.h\"\n#include \"b.h\"";
-    // offset pointing into the second line
-    auto pos = src.find("#include \"b.h\"");
-    EXPECT_RANGE(src, static_cast<std::uint32_t>(pos), R"("b.h")");
+TEST_CASE(FirstLine) {
+    llvm::StringRef content = "int a = 1;\nint b;\n";
+    auto lexer = Lexer::from_line(content, 4);
+    ASSERT_EQ(lexer.advance().text(content), "int");
 }
 
-TEST_CASE(EmptyDirective) {
-    llvm::StringRef src = "#include \n";
-    EXPECT_NONE(src, 0);
+TEST_CASE(OffsetAtNewline) {
+    // An offset on the terminating newline still lexes the line it ends.
+    llvm::StringRef content = "int a;\nint b;\n";
+    auto offset = static_cast<std::uint32_t>(content.find('\n', content.find('b')));
+
+    auto lexer = Lexer::from_line(content, offset);
+    auto token = lexer.advance();
+    ASSERT_EQ(token.text(content), "int");
+    ASSERT_EQ(token.range.begin, static_cast<std::uint32_t>(content.find("int b")));
 }
 
-TEST_CASE(HasIncludeFromLineStart) {
-    llvm::StringRef src = "#if __has_include(<vector>)";
-    EXPECT_RANGE(src, 0, "<vector>");
+TEST_CASE(ContinuesToEnd) {
+    // from_line picks the starting point; lexing continues past the line.
+    llvm::StringRef content = "int a;\nint b;\nint c;\n";
+    auto lexer = Lexer::from_line(content, static_cast<std::uint32_t>(content.find('b')));
+    auto tokens = lex_all(lexer);
+    ASSERT_EQ(tokens.size(), 6U);
+    ASSERT_EQ(tokens.back().text(content), ";");
 }
 
-TEST_CASE(HasEmbedFromLineStart) {
-    llvm::StringRef src = R"(#if __has_embed("data.bin"))";
-    EXPECT_RANGE(src, 0, R"("data.bin")");
+};  // TEST_SUITE(FromLine)
+
+TEST_SUITE(IncompleteInput) {
+
+TEST_CASE(UnterminatedHeaderName) {
+    llvm::StringRef content = "#include <iost";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+    ASSERT_TRUE(tokens.size() >= 2U);
 }
 
-TEST_CASE(IncludeNext) {
-    llvm::StringRef src = "#include_next <stdlib.h>";
-    EXPECT_RANGE(src, 0, "<stdlib.h>");
+TEST_CASE(UnterminatedString) {
+    llvm::StringRef content = R"(const char* s = "abc)";
+    Lexer lexer(content);
+    auto tokens = lex_all(lexer);
+    ASSERT_TRUE(tokens.size() >= 4U);
 }
 
-};  // TEST_SUITE(DirectiveArgument)
+TEST_CASE(UnterminatedComment) {
+    // clang's raw lexer swallows a block comment left unterminated at eof;
+    // no comment token is produced for it.
+    llvm::StringRef content = "int x; /* abc";
+    Lexer lexer(content, {.keep_comments = true});
+    auto tokens = lex_all(lexer);
+    ASSERT_EQ(tokens.back().kind, clang::tok::semi);
+}
+
+};  // TEST_SUITE(IncompleteInput)
 
 }  // namespace
 }  // namespace clice::testing

--- a/tests/unit/syntax/lexer_tests.cpp
+++ b/tests/unit/syntax/lexer_tests.cpp
@@ -145,6 +145,10 @@ TEST_CASE(EmbedArgument) {
     ASSERT_EQ(first_header_name(R"(#embed "data.bin")"), R"("data.bin")");
 }
 
+TEST_CASE(HashImportArgument) {
+    ASSERT_EQ(first_header_name("#import <Foundation/Foundation.h>"), "<Foundation/Foundation.h>");
+}
+
 TEST_CASE(MacroArgument) {
     // A macro filename argument stays an ordinary identifier.
     llvm::StringRef content = "#include HEADER";
@@ -154,6 +158,27 @@ TEST_CASE(MacroArgument) {
     ASSERT_EQ(first_header_name(content), "");
     ASSERT_TRUE(tokens[2].is_identifier());
     ASSERT_EQ(tokens[2].text(content), "HEADER");
+}
+
+TEST_CASE(CommentThenDirective) {
+    // A retained leading comment must not consume the start-of-line state
+    // the directive machinery keys on.
+    llvm::StringRef content = "/* c */ #include <x>\nint y;\n";
+    Lexer lexer(content, {.keep_comments = true});
+
+    auto comment = lexer.advance();
+    ASSERT_EQ(comment.kind, clang::tok::comment);
+
+    auto hash = lexer.advance();
+    ASSERT_EQ(hash.kind, clang::tok::hash);
+    ASSERT_TRUE(hash.is_at_start_of_line);
+
+    auto keyword = lexer.advance();
+    ASSERT_TRUE(keyword.is_pp_keyword);
+
+    auto name = lexer.advance();
+    ASSERT_TRUE(name.is_header_name());
+    ASSERT_EQ(name.text(content), "<x>");
 }
 
 TEST_CASE(SplicedInclude) {
@@ -210,6 +235,11 @@ TEST_CASE(OffsetAtNewline) {
     auto token = lexer.advance();
     ASSERT_EQ(token.text(content), "int");
     ASSERT_EQ(token.range.begin, static_cast<std::uint32_t>(content.find("int b")));
+}
+
+TEST_CASE(EmptyContent) {
+    auto lexer = Lexer::from_line("", 0);
+    ASSERT_TRUE(lexer.advance().is_eof());
 }
 
 TEST_CASE(ContinuesToEnd) {

--- a/tests/unit/syntax/lexical_scan_tests.cpp
+++ b/tests/unit/syntax/lexical_scan_tests.cpp
@@ -1,0 +1,176 @@
+#include <cstddef>
+
+#include "test/test.h"
+#include "syntax/lexical_scan.h"
+
+namespace clice::testing {
+namespace {
+
+using Comment = LexicalInfo::Comment;
+using ModuleDeclaration = LexicalInfo::ModuleDeclaration;
+
+llvm::StringRef text(llvm::StringRef content, LocalSourceRange range) {
+    return content.substr(range.begin, range.length());
+}
+
+TEST_SUITE(LexicalScanComments) {
+
+TEST_CASE(CommentKinds) {
+    llvm::StringRef content = R"(// line comment
+int x = 1; /* block
+comment */ int y = 2;
+)";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.comments.size(), 2U);
+    ASSERT_EQ(info.comments[0].kind, Comment::Kind::Line);
+    ASSERT_EQ(text(content, info.comments[0].range), "// line comment");
+    ASSERT_EQ(info.comments[1].kind, Comment::Kind::Block);
+    ASSERT_TRUE(text(content, info.comments[1].range).starts_with("/* block"));
+    ASSERT_TRUE(text(content, info.comments[1].range).ends_with("comment */"));
+}
+
+TEST_CASE(CommentInString) {
+    llvm::StringRef content = R"(const char* s = "// not a comment";)";
+    auto info = lexical_scan(content);
+    ASSERT_EQ(info.comments.size(), 0U);
+}
+
+TEST_CASE(DirectiveComments) {
+    llvm::StringRef content = "#include <vector> // trailing\n/* leading */ #define X 1\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.comments.size(), 2U);
+    ASSERT_EQ(info.comments[0].kind, Comment::Kind::Line);
+    ASSERT_EQ(info.comments[1].kind, Comment::Kind::Block);
+}
+
+};  // TEST_SUITE(LexicalScanComments)
+
+TEST_SUITE(LexicalScanModules) {
+
+TEST_CASE(GlobalFragment) {
+    llvm::StringRef content = "module;\n#include <vector>\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 1U);
+    auto& decl = info.modules[0];
+    ASSERT_EQ(decl.kind, ModuleDeclaration::Kind::GlobalFragment);
+    ASSERT_EQ(text(content, decl.keyword), "module");
+    ASSERT_FALSE(decl.export_keyword.valid());
+    ASSERT_EQ(decl.name_parts.size(), 0U);
+}
+
+TEST_CASE(ExportDeclaration) {
+    llvm::StringRef content = "export module foo.bar;\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 1U);
+    auto& decl = info.modules[0];
+    ASSERT_EQ(decl.kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(text(content, decl.export_keyword), "export");
+    ASSERT_EQ(text(content, decl.keyword), "module");
+    ASSERT_EQ(decl.name_parts.size(), 2U);
+    ASSERT_EQ(text(content, decl.name_parts[0]), "foo");
+    ASSERT_EQ(text(content, decl.name_parts[1]), "bar");
+    ASSERT_FALSE(decl.colon.valid());
+}
+
+TEST_CASE(ImplementationUnit) {
+    llvm::StringRef content = "module a.b.c;\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 1U);
+    auto& decl = info.modules[0];
+    ASSERT_EQ(decl.kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_FALSE(decl.export_keyword.valid());
+    ASSERT_EQ(decl.name_parts.size(), 3U);
+}
+
+TEST_CASE(PartitionDeclaration) {
+    llvm::StringRef content = "export module app:impl.detail;\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 1U);
+    auto& decl = info.modules[0];
+    ASSERT_EQ(decl.kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(decl.name_parts.size(), 1U);
+    ASSERT_EQ(text(content, decl.name_parts[0]), "app");
+    ASSERT_EQ(text(content, decl.colon), ":");
+    ASSERT_EQ(decl.partition_parts.size(), 2U);
+    ASSERT_EQ(text(content, decl.partition_parts[0]), "impl");
+    ASSERT_EQ(text(content, decl.partition_parts[1]), "detail");
+}
+
+TEST_CASE(PrivateFragment) {
+    llvm::StringRef content = "int x = 1;\nmodule : private ;\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 1U);
+    auto& decl = info.modules[0];
+    ASSERT_EQ(decl.kind, ModuleDeclaration::Kind::PrivateFragment);
+    ASSERT_EQ(text(content, decl.keyword), "module");
+    ASSERT_EQ(text(content, decl.colon), ":");
+    ASSERT_EQ(decl.partition_parts.size(), 1U);
+    ASSERT_EQ(text(content, decl.partition_parts[0]), "private");
+}
+
+TEST_CASE(FullInterfaceUnit) {
+    llvm::StringRef content = R"(// interface unit
+module;
+#include <vector>
+export module app;
+import :part;
+export int f();
+module :private;
+int hidden = 0;
+)";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 3U);
+    ASSERT_EQ(info.modules[0].kind, ModuleDeclaration::Kind::GlobalFragment);
+    ASSERT_EQ(info.modules[1].kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(text(content, info.modules[1].name_parts[0]), "app");
+    ASSERT_EQ(info.modules[2].kind, ModuleDeclaration::Kind::PrivateFragment);
+    ASSERT_EQ(info.comments.size(), 1U);
+}
+
+TEST_CASE(CommentInterleaved) {
+    llvm::StringRef content = "/* gmf */ module;\nexport /* here */ module foo;\n";
+    auto info = lexical_scan(content);
+
+    ASSERT_EQ(info.modules.size(), 2U);
+    ASSERT_EQ(info.modules[0].kind, ModuleDeclaration::Kind::GlobalFragment);
+    ASSERT_EQ(info.modules[1].kind, ModuleDeclaration::Kind::Declaration);
+    ASSERT_EQ(text(content, info.modules[1].name_parts[0]), "foo");
+    ASSERT_EQ(info.comments.size(), 2U);
+}
+
+TEST_CASE(IncompleteDeclaration) {
+    // While typing: no trailing semicolon yet.
+    ASSERT_EQ(lexical_scan("export module fo").modules.size(), 1U);
+    // No name yet: nothing to record.
+    ASSERT_EQ(lexical_scan("export module ").modules.size(), 0U);
+}
+
+TEST_CASE(NegativeControls) {
+    // `module` as an ordinary identifier.
+    ASSERT_EQ(lexical_scan("int module = 1;\nmodule = 2;\n").modules.size(), 0U);
+    // Mid-line and mid-file bare `module;`.
+    ASSERT_EQ(lexical_scan("int x;\nmodule;\n").modules.size(), 0U);
+    ASSERT_EQ(lexical_scan("int x; module;\n").modules.size(), 0U);
+    // Inside comments and strings.
+    ASSERT_EQ(lexical_scan("// module foo;\n").modules.size(), 0U);
+    ASSERT_EQ(lexical_scan("const char* s = \"module foo;\";\n").modules.size(), 0U);
+    // Imports belong to the preprocessor callbacks, not to this scan.
+    ASSERT_EQ(lexical_scan("import foo;\nexport import bar;\n").modules.size(), 0U);
+    // Non-module export declaration.
+    ASSERT_EQ(lexical_scan("export int f();\n").modules.size(), 0U);
+    // An exported private fragment is not a thing.
+    ASSERT_EQ(lexical_scan("export module :private;\n").modules.size(), 0U);
+}
+
+};  // TEST_SUITE(LexicalScanModules)
+
+}  // namespace
+}  // namespace clice::testing

--- a/tests/unit/syntax/lexical_scan_tests.cpp
+++ b/tests/unit/syntax/lexical_scan_tests.cpp
@@ -153,6 +153,12 @@ TEST_CASE(IncompleteDeclaration) {
     ASSERT_EQ(lexical_scan("export module ").modules.size(), 0U);
 }
 
+TEST_CASE(EmptyContent) {
+    auto info = lexical_scan("");
+    ASSERT_EQ(info.comments.size(), 0U);
+    ASSERT_EQ(info.modules.size(), 0U);
+}
+
 TEST_CASE(NegativeControls) {
     // `module` as an ordinary identifier.
     ASSERT_EQ(lexical_scan("int module = 1;\nmodule = 2;\n").modules.size(), 0U);

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -394,6 +394,17 @@ TEST_CASE(ExportModuleMissingSemicolon) {
     EXPECT_FALSE(is_preamble_complete(content, 18));
 }
 
+TEST_CASE(SplicedIncompleteInclude) {
+    // The unterminated filename token's spelling begins with the splice.
+    llvm::StringRef content = "#include \\\n<foo\nint x;";
+    EXPECT_FALSE(is_preamble_complete(content, 16));
+}
+
+TEST_CASE(SplicedCompleteInclude) {
+    llvm::StringRef content = "#include \\\n<foo.h>\nint x;";
+    EXPECT_TRUE(is_preamble_complete(content, 19));
+}
+
 TEST_CASE(AngledHashImport) {
     llvm::StringRef content = "#import <foo.h>\nint x;";
     EXPECT_TRUE(is_preamble_complete(content, 16));

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -394,6 +394,11 @@ TEST_CASE(ExportModuleMissingSemicolon) {
     EXPECT_FALSE(is_preamble_complete(content, 18));
 }
 
+TEST_CASE(AngledHashImport) {
+    llvm::StringRef content = "#import <foo.h>\nint x;";
+    EXPECT_TRUE(is_preamble_complete(content, 16));
+}
+
 TEST_CASE(TrailingCommentAfterSemicolon) {
     // A trailing comment must not hide the terminating semicolon.
     llvm::StringRef content = "import std; // done\nint x;";

--- a/tests/unit/syntax/scan_tests.cpp
+++ b/tests/unit/syntax/scan_tests.cpp
@@ -394,6 +394,18 @@ TEST_CASE(ExportModuleMissingSemicolon) {
     EXPECT_FALSE(is_preamble_complete(content, 18));
 }
 
+TEST_CASE(TrailingCommentAfterSemicolon) {
+    // A trailing comment must not hide the terminating semicolon.
+    llvm::StringRef content = "import std; // done\nint x;";
+    EXPECT_TRUE(is_preamble_complete(content, 20));
+}
+
+TEST_CASE(TrailingCommentNoSemicolon) {
+    llvm::StringRef content = "import std // ;\nint x;";
+    // The semicolon inside the comment does not terminate the statement.
+    EXPECT_FALSE(is_preamble_complete(content, 16));
+}
+
 TEST_CASE(CompleteExportImport) {
     llvm::StringRef content = "export import std;\nint x;";
     // Bound covers "export import std;\n".


### PR DESCRIPTION
## Summary

This round refactors the lexing layer and gives the semantics table first-class coverage of everything the AST and preprocessor callbacks fail to record.

### Lexer

- **In-place lexing**: `Lexer::from_line(content, offset)` starts at the line containing `offset`; token ranges stay in file coordinates, so they compose directly with feature offsets. The hand-written `rfind('\n') → substr → rebase` dance at call sites is gone.
- Positional bool parameters replaced by `LexerOptions`; the dead `ignore_end_of_directive` flag and the unused `is_directive_keyword` helper removed.
- **Header-name automation** now covers the `__has_include`/`__has_embed` family (mode switches after the opening paren) and the `#import` directive; the residual "pick the filename argument" grammar moved next to its only consumer (document links).
- Retained comments are **transparent to the directive state machine**: a line-leading comment no longer consumes the start-of-line state or ends the module-declaration context.
- clang's NUL-terminated-buffer contract is documented and asserted: lex full buffers or suffixes, never a prefix slice; bound the lexing logically instead.

### lexical_scan (new)

One pass over the file collects what neither the AST nor PPCallbacks report, as structured data: comments (range + line/block kind) and the three module-declaration forms (`module;`, `[export] module x.y:z;`, `module :private;`) with per-token ranges.

### Semantics table: Module and Comment nodes

New `Module` and `Comment` node kinds are fed by the lexical scan at build time, cross-checked against the compiler before becoming nodes: named-module gate, DefinitionLoc anchor for the declaration form (macro-spelled names survive, disabled-branch duplicates die), spelled-token liveness for the private fragment. Module nodes own their written tokens like other directive nodes.

Consumers then deleted their own scanners:

- **semantic_tokens**: the module-declaration matcher and the per-request whole-file comment scan are gone; comments come precomputed from the table (build-time once instead of per request), module tokens paint from the node like imports do.
- **tu_index**: the module-declaration lexer state machine is gone; the occurrence is emitted from the validated table data, partition span included.

### Fixes along the way

- `#pragma region/endregion` is classified by the first argument token instead of substring matching — a pragma merely *mentioning* "endregion" no longer closes a fold early (pinned by a new folding fixture).
- `is_preamble_complete`: a trailing comment no longer hides a terminating semicolon (or fakes one), and angled `#import <...>` completes.
- `detect_completion_context` rewritten on the lexer: comment-tolerant, exact keyword boundaries, and the cursor-at-line-start case no longer leaks the previous line.
- A wire-only divergence where the global module fragment lost its keyword highlight under a preamble PCH (its spelled token counts as preprocessed-away there) — gates are now per-form and the case is pinned by a PCH unit test.

### Import-channel audit

The preprocessor callback channel and the AST `ImportDecl` channel agree on all three import forms (named, export-import, partition); pinned by a unit test. The preamble-PCH boundary remains the shared, by-design gap handled per feature by PreambleState.

## Tests

- New unit coverage: lexer in-place lexing / header-name automation / incomplete input, lexical_scan with negative controls (identifier named `module`, strings, comments, disabled branches), semantics-table nodes and gates, module painting under a real PCH split, partition and implementation-unit indexing, preamble/completion edge cases including CRLF and cursor-mid-keyword.
- New folding fixture for the pragma classification fix; feature docs regenerated.
- All four suites green on both Debug and RelWithDebInfo; zero snapshot drift outside the new fixture.
