### PR TITLE
ci: upload-based logs in issue forms, fold format into lint workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! Please search existing issues first to avoid duplicates.
+        Thanks for taking the time to report a bug!
 
         If clice **crashed** (server exited, connection lost), please use the **Crash Report** template instead.
 
@@ -114,12 +114,15 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: upload
     id: logs
     attributes:
       label: Logs
-      description: Relevant server log output, if available. Will be automatically formatted as code.
-      render: text
+      description: >-
+        Server logs, if relevant. Zip the session log directory (its path is printed
+        as "Session log directory: ..." on server startup) and upload it here.
+    validations:
+      accept: ".zip,.gz,.tar.gz,.log,.txt"
 
   - type: textarea
     id: config

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Sorry about the crash! The **clice version** and **stack trace** fields below are parsed automatically to symbolize the crash, so please fill them in exactly as requested.
+        Sorry about the crash! The **clice version** and the **uploaded logs** below are parsed automatically to symbolize the crash.
 
   - type: input
     id: version
@@ -81,21 +81,17 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: stack_trace
-    attributes:
-      label: Stack trace
-      description: Paste the stack trace from the crash output or log. Paste it as-is — do not edit or truncate it.
-      render: text
-    validations:
-      required: true
-
-  - type: textarea
+  - type: upload
     id: logs
     attributes:
       label: Logs
-      description: Server log output around the crash, if available.
-      render: text
+      description: >-
+        Zip the whole session log directory and upload it here. clice runs multiple
+        processes and each writes its own log file, including the stack trace of the
+        crashed one, so please include all of them. The directory path is printed as
+        "Session log directory: ..." on server startup.
+    validations:
+      accept: ".zip,.gz,.tar.gz,.log,.txt"
 
   - type: textarea
     id: reproduce

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,5 +1,5 @@
 # Single source of truth for repository labels.
-# Synced to GitHub automatically when this file changes on main (see workflows/repo.yml).
+# Synced to GitHub automatically when this file changes on main (see workflows/lint.yml).
 # To rename a label without losing its issue associations, add `from_name: <old>`.
 # NOTE: when changing `feature:` labels, also update the "Related area" dropdown
 # in ISSUE_TEMPLATE/{bug_report,crash_report,feature_request}.yml.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,12 @@
-name: repo
+name: lint
 
 on:
   workflow_call:
+    inputs:
+      format:
+        description: Run the format check.
+        type: boolean
+        default: false
   workflow_dispatch:
 
 jobs:
@@ -30,6 +35,38 @@ jobs:
             exit 1
           fi
 
+  format:
+    if: ${{ inputs.format }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pixi
+        with:
+          environments: format
+
+      - name: Run formatter
+        run: pixi run format
+        continue-on-error: true
+
+      - name: Auto correct
+        uses: huacnlee/autocorrect-action@v2.5.4
+        with:
+          args: --lint ./docs
+        continue-on-error: true
+
+      - name: Check diff
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Formatting changes detected. Please run 'pixi run format' and commit the result."
+            git --no-pager diff --stat
+            git --no-pager diff
+            exit 1
+          fi
+
   sync-labels:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
@@ -42,6 +79,7 @@ jobs:
           persist-credentials: false
 
       - uses: dorny/paths-filter@v4
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: filter
         with:
           filters: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,45 +59,15 @@ jobs:
               - '.github/workflows/cross-pair.yml'
               - '.github/workflows/editor-test.yml'
 
-  repo:
+  lint:
+    needs: changes
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: read
       issues: write
-    uses: ./.github/workflows/repo.yml
-
-  format:
-    needs: changes
-    if: ${{ needs.changes.outputs.format == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - uses: ./.github/actions/setup-pixi
-        with:
-          environments: format
-
-      - name: Run formatter
-        run: pixi run format
-        continue-on-error: true
-
-      - name: Auto correct
-        uses: huacnlee/autocorrect-action@v2.5.4
-        with:
-          args: --lint ./docs
-        continue-on-error: true
-
-      - name: Check diff
-        run: |
-          if ! git diff --quiet; then
-            echo "::error::Formatting changes detected. Please run 'pixi run format' and commit the result."
-            git --no-pager diff --stat
-            git --no-pager diff
-            exit 1
-          fi
+    uses: ./.github/workflows/lint.yml
+    with:
+      format: ${{ needs.changes.outputs.format == 'true' }}
 
   deploy:
     needs: changes
@@ -181,8 +151,8 @@ jobs:
   checks-passed:
     if: ${{ always() && !startsWith(github.ref, 'refs/tags/') }}
     needs:
-      - repo
-      - format
+      - changes
+      - lint
       - deploy
       - vscode
       - zed
@@ -197,6 +167,6 @@ jobs:
         uses: re-actors/alls-green@v1.2.2
         with:
           allowed-skips: >-
-            repo,format,deploy,vscode,zed,
+            lint,deploy,vscode,zed,
             native-test,cross-test,editor-test,instant-vscode
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## What changed

**Issue forms**
- The `Logs` fields in the bug and crash report forms now use the `upload` element type instead of a textarea: reporters zip the whole session log directory and upload it (clice runs multiple processes, one log file per process, so pasting a single log was never enough).
- The crash report's separate required `Stack trace` textarea is removed — the stack trace is written into the crashed process's log file, so the required log upload already carries it. The future symbolization bot will parse the version field and scan the uploaded archive. A fallback note covers crashes that happen before any log directory exists (upload the editor output as `.txt`).
- Dropped the "search existing issues first" note from the bug form — duplicate detection is the triage bot's job, not the reporter's.

**Workflows**
- `repo.yml` is renamed to `lint.yml` and the `format` job moves from `main.yml` into it, so all conformance checks (commit format, code format, label sync) live in one reusable workflow. `main.yml` calls it with a `format` boolean computed from the existing paths filter, preserving the exact skip conditions.
- `checks-passed` now also requires the `changes` job, closing a fail-open gap where a paths-filter failure would skip downstream jobs and still turn the gate green.

## Tests

CI-config and issue-template changes only; workflow YAML validated locally, forms need to be checked once rendered on GitHub.